### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+sudo: false
+
+install: pip install -r requirements_dev.txt
+
+script: make test

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,6 +11,7 @@ pycodestyle==2.2.0
 pydocstyle==1.1.1
 pyflakes==1.3.0
 tox==2.5.0
+tox-travis==0.8
 wheel==0.24.0
 
 -r requirements.txt


### PR DESCRIPTION
- Setup a Travis CI configuration to perform a "build" of pact-python
- Run the tests using tox in Python versions 2.7, 3.3, 3.4, 3.5, and 3.6.

@jslvtr I threw this together so I don't accidentally commit broken things. We should be able to expand it into a full build process as we go.