### PR TITLE
pact-python manages the mock service

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,1 +1,2 @@
 v0.1.0, 2017-03-30 -- Basic support for authoring contracts against a separately running mock service
+v0.2.0, 2017-04-22 -- Pact Python manages the Pact mock service

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,6 @@ e2e:
 	sh -c '\
 		cd e2e; \
 		docker-compose pull > /dev/null; \
-		docker-compose up -d pactmockservice; \
-		while ! nc -z localhost 1234; do sleep 0.1; done; \
-		docker-compose logs --follow > ./pacts/mock-service-logs.txt & \
 		nosetests ./contracts; \
 		docker-compose down; \
 		docker-compose up -d app pactverifier; \

--- a/README.md
+++ b/README.md
@@ -40,14 +40,19 @@ def user(user_name):
 Then `Consumer`'s contract test might look something like this:
 
 ```python
+import atexit
 import unittest
 
 from pact import Consumer, Provider
 
 
+pact = Consumer('Consumer').has_pact_with(Provider('Provider'))
+pact.start()
+atexit.register(pact.stop)
+
+
 class GetUserInfoContract(unittest.TestCase):
   def test_get_user(self):
-    pact = Consumer('Consumer').has_pact_with(Provider('Provider'))
     expected = {
       'username': 'UserA',
       'id': 123,
@@ -88,13 +93,12 @@ pact = Consumer('Consumer').has_pact_with(
     Provider('Provider'), host_name='mockservice', port=8080)
 ```
 
-This can be useful if you are running your tests and the mock service inside a Docker
-network, where you want to reference the service by its Docker name, instead of via
-the `localhost` interface. It is important to note that the code you are testing with
-this contract _must_ contact the mock service. So in this example, the `user` method
-could accept an argument to specify the location of the server, or retrieve it from an
-environment variable so you can change its URI during the test. Another option is to
-specify a Docker network alias so the requests that you make will go to the container.
+This can be useful if you need to run to create more than one Pact for your test
+because your code interacts with two different services. It is important to note
+that the code you are testing with this contract _must_ contact the mock service.
+So in this example, the `user` method could accept an argument to specify the
+location of the server, or retrieve it from an environment variable so you can
+change its URI during the test.
 
 The mock service offers you several important features when building your contracts:
 - It provides a real HTTP server that your code can contact during the test and provides the responses you defined.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ from pact import Consumer, Provider
 
 
 pact = Consumer('Consumer').has_pact_with(Provider('Provider'))
-pact.start()
-atexit.register(pact.stop)
+pact.start_service()
+atexit.register(pact.stop_service)
 
 
 class GetUserInfoContract(unittest.TestCase):
@@ -82,7 +82,22 @@ This does a few important things:
 Using the Pact object as a [context manager], we call our method under test
 which will then communicate with the Pact mock service. The mock service will respond with
 the items we defined, allowing us to assert that the method processed the response and
-returned the expected value.
+returned the expected value. If you want more control over when the mock service is 
+configured and the interactions verified, use the `setup` and `verify` methods, respectively:
+
+```python
+   (pact
+     .given('UserA exists and is not an administrator')
+     .upon_receiving('a request for UserA')
+     .with_request('get', '/users/UserA')
+     .will_respond_with(200, body=expected))
+
+    pact.setup()
+    # Some additional steps before running the code under test
+    result = user('UserA')
+    # Some additional steps before verifying all interactions have occurred
+    pact.verify()
+````
 
 The default hostname and port for the Pact mock service will be
 `localhost:1234` but you can adjust this during Pact creation:

--- a/e2e/contracts/test_e2e.py
+++ b/e2e/contracts/test_e2e.py
@@ -9,8 +9,8 @@ from pact.provider import Provider
 
 
 pact = Consumer('consumer').has_pact_with(Provider('provider'))
-pact.start()
-atexit.register(pact.stop)
+pact.start_service()
+atexit.register(pact.stop_service)
 
 
 class BaseTestCase(unittest.TestCase):

--- a/e2e/contracts/test_e2e.py
+++ b/e2e/contracts/test_e2e.py
@@ -1,3 +1,5 @@
+import atexit
+
 import requests
 import unittest
 
@@ -7,6 +9,8 @@ from pact.provider import Provider
 
 
 pact = Consumer('consumer').has_pact_with(Provider('provider'))
+pact.start()
+atexit.register(pact.stop)
 
 
 class BaseTestCase(unittest.TestCase):

--- a/e2e/contracts/test_e2e.py
+++ b/e2e/contracts/test_e2e.py
@@ -6,29 +6,30 @@ from pact.consumer import Consumer
 from pact.provider import Provider
 
 
+pact = Consumer('consumer').has_pact_with(Provider('provider'))
+
+
 class BaseTestCase(unittest.TestCase):
-    def setUp(self):
-        self.pact = Consumer('consumer').has_pact_with(
-            Provider('provider'))
+    pass
 
 
 class ExactMatches(BaseTestCase):
     def test_get_user_sparse(self):
         expected = {'name': 'Jonas'}
-        (self.pact
+        (pact
             .given('a simple json blob exists')
             .upon_receiving('a request for a user')
             .with_request('get', '/users/Jonas')
             .will_respond_with(200, body=expected))
 
-        with self.pact:
+        with pact:
             result = requests.get('http://localhost:1234/users/Jonas')
 
         self.assertEqual(result.json(), expected)
 
     def test_post_user_complex(self):
         expected = {'name': 'Jonas'}
-        (self.pact
+        (pact
          .given('a simple json blob exists')
          .upon_receiving('a query for the user Jonas')
          .with_request(
@@ -42,7 +43,7 @@ class ExactMatches(BaseTestCase):
             body=expected,
             headers={'Content-Type': 'application/json'}))
 
-        with self.pact:
+        with pact:
             result = requests.post(
                 'http://localhost:1234/users/?Jonas',
                 headers={'Accept': 'application/json'},
@@ -53,7 +54,7 @@ class ExactMatches(BaseTestCase):
 
 class InexactMatches(BaseTestCase):
     def test_sparse(self):
-        (self.pact
+        (pact
          .given('the user `bob` exists')
          .upon_receiving('a request for the user object of `bob`')
          .with_request('get', '/users/bob')
@@ -61,13 +62,13 @@ class InexactMatches(BaseTestCase):
              'username': SomethingLike('bob'),
              'id': Term('\d+', '123')}))
 
-        with self.pact:
+        with pact:
             result = requests.get('http://localhost:1234/users/bob')
 
         self.assertEqual(result.json(), {'username': 'bob', 'id': '123'})
 
     def test_nested(self):
-        (self.pact
+        (pact
          .given('a list of users exists')
          .upon_receiving('a query of all users')
          .with_request('get', '/users/', query={'limit': Term('\d+', '5')})
@@ -77,7 +78,7 @@ class InexactMatches(BaseTestCase):
             'groups': EachLike(123),
          }, minimum=2)}))
 
-        with self.pact:
+        with pact:
             results = requests.get(
                 'http://localhost:1234/users/?limit=4')
 
@@ -89,7 +90,7 @@ class InexactMatches(BaseTestCase):
 
 class SyntaxErrors(BaseTestCase):
     def test_incorrect_number_of_arguments(self):
-        (self.pact
+        (pact
          .given('a list of users exists')
          .upon_receiving('a request for a user')
          .with_request('get', '/users/')
@@ -99,7 +100,7 @@ class SyntaxErrors(BaseTestCase):
             print('Requires two arguments')
 
         with self.assertRaises(TypeError) as e:
-            with self.pact:
+            with pact:
                 two('one')
 
         self.assertEqual(

--- a/pact/__init__.py
+++ b/pact/__init__.py
@@ -6,4 +6,4 @@ from .provider import Provider
 
 
 __all__ = ('Consumer', 'EachLike', 'Pact', 'Provider', 'SomethingLike', 'Term')
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/pact/constants.py
+++ b/pact/constants.py
@@ -1,0 +1,15 @@
+"""Constant values for the pact-python package."""
+import os
+from os.path import join, dirname, normpath
+
+
+def mock_service_exe():
+    """Get the appropriate executable name for this platform."""
+    if os.name == 'nt':
+        return 'pact-mock-service.bat'
+    else:
+        return 'pact-mock-service'
+
+
+MOCK_SERVICE_PATH = normpath(join(
+    dirname(__file__), 'bin', 'mock-service', 'bin', mock_service_exe()))

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -31,7 +31,9 @@ class Consumer(object):
         self.name = name
         self.service_cls = service_cls
 
-    def has_pact_with(self, provider, host_name='localhost', port=1234):
+    def has_pact_with(self, provider, host_name='localhost', port=1234,
+                      log_dir=None, ssl=False, sslcert=None, sslkey=None,
+                      cors=False, pact_dir=None, version='2.0.0'):
         """
         Create a contract between the `provider` and this consumer.
 
@@ -56,6 +58,28 @@ class Consumer(object):
             This will need to tbe the same port used by your code under test
             to contact the mock service. It defaults to: 1234
         :type port: int
+        :param log_dir: The directory where logs should be written. Defaults to
+            the current directory.
+        :type log_dir: str
+        :param ssl: Flag to control the use of a self-signed SSL cert to run
+            the server over HTTPS , defaults to False.
+        :type ssl: bool
+        :param sslcert: Path to a custom self-signed SSL cert file, 'ssl'
+            option must be set to True to use this option. Defaults to None.
+        :type sslcert: str
+        :param sslkey: Path to a custom key and self-signed SSL cert key file,
+            'ssl' option must be set to True to use this option.
+            Defaults to None.
+        :type sslkey: str
+        :param cors: Allow CORS OPTION requests to be accepted,
+            defaults to False.
+        :type cors: bool
+        :param pact_dir: Directory where the resulting pact files will be
+            written. Defaults to the current directory.
+        :type pact_dir: str
+        :param version: The Pact Specification version to use, defaults to
+            '2.0.0'.
+        :type version: str
         :return: A Pact object which you can use to define the specific
             interactions your code will have with the provider.
         :rtype: pact.Pact
@@ -68,4 +92,11 @@ class Consumer(object):
             consumer=self,
             provider=provider,
             host_name=host_name,
-            port=port)
+            port=port,
+            log_dir=log_dir,
+            ssl=ssl,
+            sslcert=sslcert,
+            sslkey=sslkey,
+            cors=cors,
+            pact_dir=pact_dir,
+            version=version)

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -198,7 +198,6 @@ class Pact(object):
 
         Sets up the mock service to expect the client requests.
         """
-        self.start()
         try:
             payload = {
                 'description': self._description,
@@ -217,7 +216,6 @@ class Pact(object):
 
             assert resp.status_code == 200, resp.content
         except AssertionError:
-            self.stop()
             raise
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -228,24 +226,20 @@ class Pact(object):
         expected, and has it write out the contracts to disk.
         """
         if (exc_type, exc_val, exc_tb) != (None, None, None):
-            self.stop()
             return
 
-        try:
-            resp = requests.get(
-                self.uri + '/interactions/verification',
-                headers=self.HEADERS)
-            assert resp.status_code == 200, resp.content
-            payload = {
-                'consumer': {'name': self.consumer.name},
-                'provider': {'name': self.provider.name},
-                'pact_dir': self.pact_dir
-            }
-            resp = requests.post(
-                self.uri + '/pact', headers=self.HEADERS, json=payload)
-            assert resp.status_code == 200, resp.content
-        finally:
-            self.stop()
+        resp = requests.get(
+            self.uri + '/interactions/verification',
+            headers=self.HEADERS)
+        assert resp.status_code == 200, resp.content
+        payload = {
+            'consumer': {'name': self.consumer.name},
+            'provider': {'name': self.provider.name},
+            'pact_dir': self.pact_dir
+        }
+        resp = requests.post(
+            self.uri + '/pact', headers=self.HEADERS, json=payload)
+        assert resp.status_code == 200, resp.content
 
 
 class FromTerms(object):

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -1,6 +1,11 @@
 """API for creating a contract and configuring the mock service."""
+from __future__ import unicode_literals
+import os
+from subprocess import Popen
+
 import requests
 
+from .constants import MOCK_SERVICE_PATH
 from .matchers import from_term
 
 
@@ -18,7 +23,7 @@ class Pact(object):
     ...  .with_request('get', '/echo', query={'text': 'Hello!'})
     ...  .will_respond_with(200, body='Hello!'))
     >>> with pact:
-    ...   requests.get('http://localhost:1234/echo?text=Hello!')
+    ...   requests.get(pact.uri + '/echo?text=Hello!')
 
     The GET request is made to the mock service, which will verify that it
     was a GET to /echo with a query string with a key named `text` and its
@@ -28,7 +33,9 @@ class Pact(object):
 
     HEADERS = {'X-Pact-Mock-Service': 'true'}
 
-    def __init__(self, consumer, provider, host_name='localhost', port=1234):
+    def __init__(self, consumer, provider, host_name='localhost', port=1234,
+                 log_dir=None, ssl=False, sslcert=None, sslkey=None,
+                 cors=False, pact_dir=None, version='2.0.0'):
         """
         Constructor for Pact.
 
@@ -40,12 +47,44 @@ class Pact(object):
         :type host_name: str
         :param port: The port number where the mock service is running.
         :type port: int
+        :param log_dir: The directory where logs should be written. Defaults to
+            the current directory.
+        :type log_dir: str
+        :param ssl: Flag to control the use of a self-signed SSL cert to run
+            the server over HTTPS , defaults to False.
+        :type ssl: bool
+        :param sslcert: Path to a custom self-signed SSL cert file, 'ssl'
+            option must be set to True to use this option. Defaults to None.
+        :type sslcert: str
+        :param sslkey: Path to a custom key and self-signed SSL cert key file,
+            'ssl' option must be set to True to use this option.
+            Defaults to None.
+        :type sslkey: str
+        :param cors: Allow CORS OPTION requests to be accepted,
+            defaults to False.
+        :type cors: bool
+        :param pact_dir: Directory where the resulting pact files will be
+            written. Defaults to the current directory.
+        :type pact_dir: str
+        :param version: The Pact Specification version to use, defaults to
+            '2.0.0'.
+        :type version: str
         """
-        self.BASE_URI = 'http://{host_name}:{port}'.format(
-            host_name=host_name, port=port)
+        scheme = 'https' if ssl else 'http'
+        self.uri = '{scheme}://{host_name}:{port}'.format(
+            host_name=host_name, port=port, scheme=scheme)
 
         self.consumer = consumer
+        self.cors = cors
+        self.host_name = host_name
+        self.log_dir = log_dir or os.getcwd()
+        self.pact_dir = pact_dir or os.getcwd()
+        self.port = port
         self.provider = provider
+        self.ssl = ssl
+        self.sslcert = sslcert
+        self.sslkey = sslkey
+        self.version = version
         self._description = None
         self._provider_state = None
         self._request = None
@@ -66,6 +105,40 @@ class Pact(object):
         """
         self._provider_state = provider_state
         return self
+
+    def start(self):
+        """Start the external Mock Service."""
+        command = [
+            MOCK_SERVICE_PATH,
+            'start',
+            '--host={}'.format(self.host_name),
+            '--port={}'.format(self.port),
+            '--log', '{}/pact-mock-service.log'.format(self.log_dir),
+            '--pact-dir', self.pact_dir,
+            '--pact-specification-version={}'.format(self.version),
+            '--consumer', self.consumer.name,
+            '--provider', self.provider.name]
+
+        if self.ssl:
+            command.append('--ssl')
+        if self.sslcert:
+            command.extend(['--sslcert', self.sslcert])
+        if self.sslkey:
+            command.extend(['--sslkey', self.sslkey])
+
+        process = Popen(command)
+        process.communicate()
+        if process.returncode != 0:
+            raise RuntimeError('The Pact mock service failed to start.')
+
+    def stop(self):
+        """Stop the external Mock Service."""
+        command = [MOCK_SERVICE_PATH, 'stop', '--port={}'.format(self.port)]
+        popen = Popen(command)
+        popen.communicate()
+        if popen.returncode != 0:
+            raise RuntimeError(
+                'There was an error when stopping the Pact mock service.')
 
     def upon_receiving(self, scenario):
         """
@@ -125,22 +198,27 @@ class Pact(object):
 
         Sets up the mock service to expect the client requests.
         """
-        payload = {
-            'description': self._description,
-            'provider_state': self._provider_state,
-            'request': self._request,
-            'response': self._response
-        }
+        self.start()
+        try:
+            payload = {
+                'description': self._description,
+                'provider_state': self._provider_state,
+                'request': self._request,
+                'response': self._response
+            }
 
-        resp = requests.delete(
-            self.BASE_URI + '/interactions', headers=self.HEADERS)
+            resp = requests.delete(
+                self.uri + '/interactions', headers=self.HEADERS)
 
-        assert resp.status_code == 200, resp.content
-        resp = requests.post(
-            self.BASE_URI + '/interactions',
-            headers=self.HEADERS, json=payload)
+            assert resp.status_code == 200, resp.content
+            resp = requests.post(
+                self.uri + '/interactions',
+                headers=self.HEADERS, json=payload)
 
-        assert resp.status_code == 200, resp.content
+            assert resp.status_code == 200, resp.content
+        except AssertionError:
+            self.stop()
+            raise
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
@@ -150,19 +228,24 @@ class Pact(object):
         expected, and has it write out the contracts to disk.
         """
         if (exc_type, exc_val, exc_tb) != (None, None, None):
+            self.stop()
             return
 
-        resp = requests.get(
-            self.BASE_URI + '/interactions/verification', headers=self.HEADERS)
-        assert resp.status_code == 200, resp.content
-        payload = {
-            'consumer': {'name': self.consumer.name},
-            'provider': {'name': self.provider.name},
-            'pact_dir': '/opt/contracts'
-        }
-        resp = requests.post(
-            self.BASE_URI + '/pact', headers=self.HEADERS, json=payload)
-        assert resp.status_code == 200, resp.content
+        try:
+            resp = requests.get(
+                self.uri + '/interactions/verification',
+                headers=self.HEADERS)
+            assert resp.status_code == 200, resp.content
+            payload = {
+                'consumer': {'name': self.consumer.name},
+                'provider': {'name': self.provider.name},
+                'pact_dir': self.pact_dir
+            }
+            resp = requests.post(
+                self.uri + '/pact', headers=self.HEADERS, json=payload)
+            assert resp.status_code == 200, resp.content
+        finally:
+            self.stop()
 
 
 class FromTerms(object):

--- a/pact/test/test_constants.py
+++ b/pact/test/test_constants.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from mock import patch
+
+from .. import constants
+
+
+class mock_service_exeTestCase(TestCase):
+    def setUp(self):
+        super(mock_service_exeTestCase, self).setUp()
+        self.addCleanup(patch.stopall)
+        self.mock_os = patch.object(constants, 'os', autospec=True).start()
+
+    def test_other(self):
+        self.mock_os.name = 'posix'
+        self.assertEqual(constants.mock_service_exe(), 'pact-mock-service')
+
+    def test_windows(self):
+        self.mock_os.name = 'nt'
+        self.assertEqual(constants.mock_service_exe(), 'pact-mock-service.bat')

--- a/pact/test/test_consumer.py
+++ b/pact/test/test_consumer.py
@@ -23,16 +23,22 @@ class ConsumerTestCase(TestCase):
         self.assertIs(result, self.mock_service.return_value)
         self.mock_service.assert_called_once_with(
             consumer=self.consumer, provider=self.provider,
-            host_name='localhost', port=1234)
+            host_name='localhost', port=1234,
+            log_dir=None, ssl=False, sslcert=None, sslkey=None,
+            cors=False, pact_dir=None, version='2.0.0')
 
-    def test_has_pact_with_customer_host_name_and_port(self):
+    def test_has_pact_with_customer_all_options(self):
         result = self.consumer.has_pact_with(
-            self.provider, host_name='example.com', port=1111)
+            self.provider, host_name='example.com', port=1111,
+            log_dir='/logs', ssl=True,  sslcert='/ssl.cert', sslkey='ssl.pem',
+            cors=True, pact_dir='/pacts', version='3.0.0')
 
         self.assertIs(result, self.mock_service.return_value)
         self.mock_service.assert_called_once_with(
             consumer=self.consumer, provider=self.provider,
-            host_name='example.com', port=1111)
+            host_name='example.com', port=1111,
+            log_dir='/logs', ssl=True, sslcert='/ssl.cert', sslkey='ssl.pem',
+            cors=True, pact_dir='/pacts', version='3.0.0')
 
     def test_has_pact_with_not_a_provider(self):
         with self.assertRaises(ValueError):

--- a/pact/test/test_pact.py
+++ b/pact/test/test_pact.py
@@ -126,11 +126,11 @@ class PactStartStopTestCase(TestCase):
             MOCK_SERVICE_PATH, 'start',
             '--host=localhost',
             '--port=1234',
-            '--log="/logs/pact-mock-service.log"',
-            '--pact-dir="/pacts"',
-            '--pact-specification-version="2.0.0"',
-            '--consumer="consumer"',
-            '--provider="provider"'])
+            '--log', '/logs/pact-mock-service.log',
+            '--pact-dir', '/pacts',
+            '--pact-specification-version=2.0.0',
+            '--consumer', 'consumer',
+            '--provider', 'provider'])
 
         self.mock_Popen.return_value.communicate.assert_called_once_with()
 
@@ -143,11 +143,11 @@ class PactStartStopTestCase(TestCase):
             MOCK_SERVICE_PATH, 'start',
             '--host=localhost',
             '--port=1234',
-            '--log="/logs/pact-mock-service.log"',
-            '--pact-dir="/pacts"',
-            '--pact-specification-version="2.0.0"',
-            '--consumer="consumer"',
-            '--provider="provider"'])
+            '--log', '/logs/pact-mock-service.log',
+            '--pact-dir', '/pacts',
+            '--pact-specification-version=2.0.0',
+            '--consumer', 'consumer',
+            '--provider', 'provider'])
 
         self.mock_Popen.return_value.communicate.assert_called_once_with()
 
@@ -161,14 +161,14 @@ class PactStartStopTestCase(TestCase):
             MOCK_SERVICE_PATH, 'start',
             '--host=localhost',
             '--port=1234',
-            '--log="/logs/pact-mock-service.log"',
-            '--pact-dir="/pacts"',
-            '--pact-specification-version="2.0.0"',
-            '--consumer="consumer"',
-            '--provider="provider"',
+            '--log', '/logs/pact-mock-service.log',
+            '--pact-dir', '/pacts',
+            '--pact-specification-version=2.0.0',
+            '--consumer', 'consumer',
+            '--provider', 'provider',
             '--ssl',
-            '--sslcert="/ssl.cert"',
-            '--sslkey="/ssl.key"'])
+            '--sslcert', '/ssl.cert',
+            '--sslkey', '/ssl.key'])
 
         self.mock_Popen.return_value.communicate.assert_called_once_with()
 
@@ -196,8 +196,6 @@ class PactContextManagerTestCase(TestCase):
         super(PactContextManagerTestCase, self).setUp()
         self.addCleanup(patch.stopall)
         self.mock_requests = patch('requests.api.request').start()
-        self.mock_start = patch.object(Pact, 'start', autospec=True).start()
-        self.mock_stop = patch.object(Pact, 'stop', autospec=True).start()
         self.consumer = Consumer('TestConsumer')
         self.provider = Provider('TestProvider')
         self.target = Pact(self.consumer, self.provider)
@@ -245,8 +243,6 @@ class PactContextManagerTestCase(TestCase):
         self.mock_requests.assert_has_calls([
             self.delete_call, self.post_interactions_call,
             self.get_verification_call, self.post_publish_pacts_call])
-        self.mock_start.assert_called_once_with(self.target)
-        self.mock_stop.assert_called_once_with(self.target)
 
     def test_error_deleting_interactions(self):
         self.mock_requests.side_effect = iter([
@@ -258,8 +254,6 @@ class PactContextManagerTestCase(TestCase):
         self.assertEqual(str(e.exception), 'deletion error')
         self.assertEqual(self.mock_requests.call_count, 1)
         self.mock_requests.assert_has_calls([self.delete_call])
-        self.mock_start.assert_called_once_with(self.target)
-        self.mock_stop.assert_called_once_with(self.target)
 
     def test_error_posting_interactions(self):
         self.mock_requests.side_effect = iter([
@@ -273,14 +267,11 @@ class PactContextManagerTestCase(TestCase):
         self.assertEqual(self.mock_requests.call_count, 2)
         self.mock_requests.assert_has_calls(
             [self.delete_call, self.post_interactions_call])
-        self.mock_start.assert_called_once_with(self.target)
-        self.mock_stop.assert_called_once_with(self.target)
 
     def test_error_raised(self):
         self.mock_requests.side_effect = TypeError('type error')
         self.target.__exit__(TypeError, 'type error', Mock())
         self.assertFalse(self.mock_requests.called)
-        self.mock_stop.assert_called_once_with(self.target)
 
     def test_error_verifying_interactions(self):
         self.mock_requests.side_effect = iter([
@@ -293,7 +284,6 @@ class PactContextManagerTestCase(TestCase):
         self.assertEqual(self.mock_requests.call_count, 1)
         self.mock_requests.assert_has_calls([
             self.get_verification_call])
-        self.mock_stop.assert_called_once_with(self.target)
 
     def test_error_writing_pacts_to_file(self):
         self.mock_requests.side_effect = iter([
@@ -307,7 +297,6 @@ class PactContextManagerTestCase(TestCase):
         self.assertEqual(self.mock_requests.call_count, 2)
         self.mock_requests.assert_has_calls([
             self.get_verification_call, self.post_publish_pacts_call])
-        self.mock_stop.assert_called_once_with(self.target)
 
 
 class FromTermsTestCase(TestCase):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 Flask==0.11.1
 configparser==3.5.0
 codecov==2.0.5
-coverage==4.0.3
+coverage==4.3.4
 enum34==1.1.6
 flake8==3.2.1
 mccabe==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import platform
 import sys
 import tarfile
 
-from setuptools import find_packages, setup
+from setuptools import setup
 from setuptools.command.install import install
 
 
@@ -94,7 +94,7 @@ setup_args = dict(
     author_email='matthew.balvanz@workiva.com',
     url='https://github.com/pact-foundation/pact-python',
     install_requires=dependencies,
-    packages=find_packages(exclude=['*.test', '*.test.*', 'test.*', 'test']),
+    packages=['pact'],
     package_data={'pact': ['bin/*']},
     package_dir={'pact': 'pact'},
     license=read('LICENSE'))


### PR DESCRIPTION
- pact-python now manages the mock service process
- Moved the project to version v0.2.0

resolves #5 and possibly #7 

@mefellows @jslvtr 