### PR TITLE
Updated Versions of Pact Ruby applications

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,3 @@
 v0.1.0, 2017-03-30 -- Basic support for authoring contracts against a separately running mock service
 v0.2.0, 2017-04-22 -- Pact Python manages the Pact mock service
+v0.3.0, 2017-05-13 -- Upgraded Pact mock service to v2.1.0 and Pact provider verifier to v1.0.1

--- a/e2e/contracts/test_e2e.py
+++ b/e2e/contracts/test_e2e.py
@@ -8,7 +8,9 @@ from pact.consumer import Consumer
 from pact.provider import Provider
 
 
-pact = Consumer('consumer').has_pact_with(Provider('provider'))
+pact = Consumer('consumer').has_pact_with(
+    Provider('provider'), pact_dir='./pacts')
+
 pact.start_service()
 atexit.register(pact.stop_service)
 

--- a/pact/__init__.py
+++ b/pact/__init__.py
@@ -6,4 +6,4 @@ from .provider import Provider
 
 
 __all__ = ('Consumer', 'EachLike', 'Pact', 'Provider', 'SomethingLike', 'Term')
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,7 +46,7 @@ package() {
 
 
 echo "Packaging the Mock Service for distribution."
-export GEM_VERSION=0.12.1
+export GEM_VERSION=2.1.0
 export RELEASE_VERSION=1
 export PACKAGE_VERSION=${GEM_VERSION}-${RELEASE_VERSION}
 
@@ -79,7 +79,7 @@ export EXTENSION='tar.gz'
 package
 
 echo "Packaging the Verifier for distribution."
-export GEM_VERSION=0.0.13
+export GEM_VERSION=1.0.1
 export RELEASE_VERSION=1
 export PACKAGE_VERSION=${GEM_VERSION}-${RELEASE_VERSION}
 export PROJECT_NAME='pact-provider-verifier'


### PR DESCRIPTION
- Pact Mock Service is now v2.1.0
- Pact Provider Verifier is now v1.0.1
- Fixed a disconnect in the e2e tests where the consumer wrote to a different
  than the provider tests expected

@mefellows @jslvtr FYI