### PR TITLE
Allow falsy responses (e.g. 0 not as a string).

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -326,7 +326,7 @@ class Response(FromTerms):
     def json(self):
         """Convert the Response to a JSON version for the mock service."""
         response = {'status': self.status}
-        if self.body:
+        if self.body is not None:
             response['body'] = self.body
 
         if self.headers:


### PR DESCRIPTION
In playing with pact-python I found I was unable to generate a pact file with a body of 0 where the 0 wasn't already a string (e.g. it's a json-encoded response of the number 0). I believe this PR rectifies the issue.