### PR TITLE
Fix the use of broker credentials

### DIFF
--- a/pact/test/test_verify.py
+++ b/pact/test/test_verify.py
@@ -113,7 +113,7 @@ class mainTestCase(TestCase):
         self.mock_Popen.return_value.returncode = 0
         result = self.runner.invoke(verify.main, self.default_opts)
         self.assertEqual(result.exit_code, 0)
-        self.assertProcess(*self.default_call + ['--pact-broker-password=pwd'])
+        self.assertProcess(*self.default_call + ['--broker-password=pwd'])
         self.mock_Popen.return_value.communicate.assert_called_once_with(
             timeout=30)
 
@@ -135,8 +135,8 @@ class mainTestCase(TestCase):
             '--pact-urls=./pacts/consumer-provider.json',
             '--provider-states-url=http=//localhost/provider-states',
             '--provider-states-setup-url=http://localhost/provider-states/set',
-            '--pact-broker-username=user',
-            '--pact-broker-password=pass')
+            '--broker-username=user',
+            '--broker-password=pass')
         self.mock_Popen.return_value.communicate.assert_called_once_with(
             timeout=60)
 

--- a/pact/verify.py
+++ b/pact/verify.py
@@ -74,8 +74,8 @@ def main(base_url, pact_urls, states_url, states_setup_url, username,
         '--pact-urls': ','.join(pact_urls),
         '--provider-states-url': states_url,
         '--provider-states-setup-url': states_setup_url,
-        '--pact-broker-username': username,
-        '--pact-broker-password': password
+        '--broker-username': username,
+        '--broker-password': password
     }
 
     command = [VERIFIER_PATH] + [


### PR DESCRIPTION
The broker credential command line arguments of the Ruby verifier
do not expect the arguments to be prefixed with `pact`.

resolves #24 

@mefellows @jslvtr 