### PR TITLE
Move to using the `service` command with pact-mock-service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==6.7
+psutil==5.2.2
 requests==2.12.3
 six==1.10.0


### PR DESCRIPTION
The start/stop commands in pact-mock-service have trouble with Windows because
it does not exactly support SIGTERM. The simplest solution is to shift how pact-python
runs the mock service to:

- Start the mock service using the `service` command
- Keep track of the subprocess during pact execution
- Use the terminate options from Python's subprocess module to stop the mock service

@mefellows @jslvtr @bethesque 