### PR TITLE
Resolve #17: Deprecate --provider-states-url

### DIFF
--- a/pact/test/test_verify.py
+++ b/pact/test/test_verify.py
@@ -74,17 +74,6 @@ class mainTestCase(TestCase):
         self.assertIn(b'./pacts/consumer-provider.json', result.output_bytes)
         self.assertFalse(self.mock_Popen.called)
 
-    def test_must_provide_both_provide_states_options(self):
-        result = self.runner.invoke(verify.main, [
-            '--provider-base-url=http://localhost',
-            '--pact-urls=./pacts/consumer-provider.json',
-            '--provider-states-url=http://localhost/provider-state'
-        ])
-        self.assertEqual(result.exit_code, 1)
-        self.assertIn(b'--provider-states-url', result.output_bytes)
-        self.assertIn(b'--provider-states-setup-url', result.output_bytes)
-        self.assertFalse(self.mock_Popen.called)
-
     def test_verification_timeout(self):
         self.mock_Popen.return_value.communicate.side_effect = TimeoutExpired(
             [], 30)
@@ -129,7 +118,6 @@ class mainTestCase(TestCase):
             './pacts/consumer-provider2.json',
             '--pact-url=./pacts/consumer-provider3.json',
             '--pact-url=./pacts/consumer-provider4.json',
-            '--provider-states-url=http=//localhost/provider-states',
             '--provider-states-setup-url=http://localhost/provider-states/set',
             '--pact-broker-username=user',
             '--pact-broker-password=pass',
@@ -142,7 +130,6 @@ class mainTestCase(TestCase):
             '--pact-urls=./pacts/consumer-provider3.json,'
             './pacts/consumer-provider4.json,'
             './pacts/consumer-provider.json,./pacts/consumer-provider2.json',
-            '--provider-states-url=http=//localhost/provider-states',
             '--provider-states-setup-url=http://localhost/provider-states/set',
             '--broker-username=user',
             '--broker-password=pass')

--- a/pact/verify.py
+++ b/pact/verify.py
@@ -32,7 +32,8 @@ else:
     multiple=True)  # Remove in major version 1.0.0
 @click.option(
     'states_url', '--provider-states-url',
-    help='URL to fetch the provider states for the given provider API.')
+    help='DEPRECATED: URL to fetch the provider states for'
+         ' the given provider API.')  # Remove in major version 1.0.0
 @click.option(
     'states_setup_url', '--provider-states-setup-url',
     help='URL to send PUT requests to setup a given provider state.')
@@ -61,13 +62,6 @@ def main(base_url, pact_url, pact_urls, states_url, states_setup_url, username,
     """  # NOQA
     error = click.style('Error:', fg='red')
     warning = click.style('Warning:', fg='yellow')
-    if bool(states_url) != bool(states_setup_url):
-        click.echo(
-            error
-            + ' To use provider states you must provide both'
-              ' --provider-states-url and --provider-states-setup-url.')
-        raise click.Abort()
-
     all_pact_urls = list(pact_url)
     for urls in pact_urls:  # Remove in major version 1.0.0
         all_pact_urls.extend(p for p in urls.split(',') if p)
@@ -96,7 +90,6 @@ def main(base_url, pact_url, pact_urls, states_url, states_setup_url, username,
     options = {
         '--provider-base-url': base_url,
         '--pact-urls': ','.join(all_pact_urls),
-        '--provider-states-url': states_url,
         '--provider-states-setup-url': states_setup_url,
         '--broker-username': username,
         '--broker-password': password

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.install import install
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '1.0.0'
+PACT_STANDALONE_VERSION = '1.1.1'
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
The pact-verifier has removed the need for passing `--provider-states-url` so we can now skip
passing it to the process. We will leave our option in place until version 1.0.0 to maintain
backwards compatibility for anyone who has scripted calling the Python code

@mefellows @jslvtr @bethesque