### PR TITLE
make setup-url name format match above reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ states to communicate from the consumer what data should exist on the provider.
 
 When setting up the testing of a provider you will also need to setup the management of
 these provider states. The Pact verifier does this by making additional HTTP requests to
-the `provider_states_setup_url` you provide. This URL could be
+the `--provider-states-setup-url` you provide. This URL could be
 on the provider application or a separate one. Some strategies for managing state include:
 
 - Having endpoints in your application that are not active in production that create and delete your datastore state


### PR DESCRIPTION
fix-setup-url-name isn't referenced anywhere in the code, the format provider-states-setup-url is used else where in the README.md.

This PR assumes that provider-states-setup-url is the correct name and makes usage the same throughout the doc.