### PR TITLE
Resolve #43: Rename SomethingLike to Like

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,24 +156,25 @@ as `generate`, in this case `2016-12-15T20:16:01`. When the contract is verified
 provider, the regex will be used to search the response from the real provider service
 and the test will be considered successful if the regex finds a match in the response.
 
-### SomethingLike(matcher)
+### Like(matcher)
 Asserts the element's type matches the matcher. For example:
 
 ```python
-from pact import SomethingLike
-SomethingLike(123)  # Matches if the value is an integer
-SomethingLike('hello world')  # Matches if the value is a string
-SomethingLike(3.14)  # Matches if the value is a float
+from pact import Like
+Like(123)  # Matches if the value is an integer
+Like('hello world')  # Matches if the value is a string
+Like(3.14)  # Matches if the value is a float
 ```
-The argument supplied to `SomethingLike` will be what the mock service responds with.
+The argument supplied to `Like` will be what the mock service responds with.
 
-When a dictionary is used as an argument for SomethingLike, all the child objects (and their child objects etc.) will be matched according to their types, unless you use a more specific matcher like a Term.
+When a dictionary is used as an argument for Like, all the child objects (and their child objects etc.) will be matched according to their types, unless you use a more specific matcher like a Term.
 
 ```python
-SomethingLike({
+from pact import Like, Term
+Like({
     'username': Term('[a-zA-Z]+', 'username'),
     'id': 123, # integer
-    'confirmed': false, # boolean
+    'confirmed': False, # boolean
     'address': { # dictionary
         'street': '200 Bourke St' # string
     }
@@ -194,7 +195,7 @@ EachLike('hello')  # All items are strings
 Or other matchers can be nested inside to assert more complex objects:
 
 ```python
-from pact import EachLike, SomethingLike, Term
+from pact import EachLike, Term
 EachLike({
     'username': Term('[a-zA-Z]+', 'username'),
     'id': 123,

--- a/pact/__init__.py
+++ b/pact/__init__.py
@@ -1,8 +1,9 @@
 """Python methods for interactive with a Pact Mock Service."""
 from .consumer import Consumer
-from .matchers import EachLike, SomethingLike, Term
+from .matchers import EachLike, Like, SomethingLike, Term
 from .pact import Pact
 from .provider import Provider
 from .__version__ import __version__  # noqa: F401
 
-__all__ = ('Consumer', 'EachLike', 'Pact', 'Provider', 'SomethingLike', 'Term')
+__all__ = ('Consumer', 'EachLike', 'Like', 'Pact', 'Provider', 'SomethingLike',
+           'Term')

--- a/pact/matchers.py
+++ b/pact/matchers.py
@@ -66,7 +66,7 @@ class EachLike(Matcher):
             'min': self.minimum}
 
 
-class SomethingLike(Matcher):
+class Like(Matcher):
     """
     Expect the type of the value to be the same as matcher.
 
@@ -79,7 +79,7 @@ class SomethingLike(Matcher):
     ...  .upon_receiving('a request for a random number')
     ...  .with_request('get', '/generate-number')
     ...  .will_respond_with(200, body={
-    ...    'number': SomethingLike(1111222233334444)
+    ...    'number': Like(1111222233334444)
     ...  }))
 
     Would expect the response body to be a JSON object, containing the key
@@ -118,6 +118,10 @@ class SomethingLike(Matcher):
         return {
             'json_class': 'Pact::SomethingLike',
             'contents': from_term(self.matcher)}
+
+
+# Remove SomethingLike in major version 1.0.0
+SomethingLike = Like
 
 
 class Term(Matcher):

--- a/pact/test/test_matchers.py
+++ b/pact/test/test_matchers.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from ..matchers import EachLike, Matcher, SomethingLike, Term, from_term
+from ..matchers import EachLike, Like, Matcher, SomethingLike, Term, from_term
 
 
 class MatcherTestCase(TestCase):
@@ -54,6 +54,11 @@ class EachLikeTestCase(TestCase):
                      'json_class': 'Pact::SomethingLike',
                      'contents': 123}},
              'min': 1})
+
+
+class LikeTestCase(TestCase):
+    def test_is_something_like(self):
+        self.assertIs(SomethingLike, Like)
 
 
 class SomethingLikeTestCase(TestCase):


### PR DESCRIPTION
- This is step 1 of the rename, adding Like as a alias for SomethingLike
- SomethingLike will be removed in version 1.0.0

@jslvtr @mefellows @bethesque 