### PR TITLE
Resolve #56: Fix incorrect indent on test_incorrect_number_of_arguments on test_e2e

### DIFF
--- a/e2e/contracts/test_e2e.py
+++ b/e2e/contracts/test_e2e.py
@@ -157,5 +157,7 @@ class SyntaxErrors(BaseTestCase):
             with pact:
                 two('one')
 
-        self.assertEqual(
-            e.exception.message, 'two() takes exactly 2 arguments (1 given)')
+            self.assertEqual(
+                e.exception.message,
+                'two() takes exactly 2 arguments (1 given)'
+            )


### PR DESCRIPTION
For https://github.com/pact-foundation/pact-python/issues/56