### PR TITLE
Relax version requirements in setup.py (vs requirements.txt)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,12 @@ def read(filename):
         return f.read().decode('utf-8')
 
 
-dependencies = read('requirements.txt').split()
+dependencies = [
+    'click==6.7',
+    'psutil>=5.2.2,<6.0.0',
+    'requests>=2.5.0,<3.0.0',
+    'six==1.10.0',
+]
 
 if sys.version_info.major == 2:
     dependencies.append('subprocess32')


### PR DESCRIPTION
I'd like to suggest this as a solution to #47, instead of the solution provided in #48.

`requirements.txt` and `setup.py`'s dependencies serve two different purposes for libraries. Ideally `setup.py` dependencies are as relaxed as possible while ensuring the library will work with those dependencies, and `requirements.txt` pins every library to a specific version (e.g. for testing purposes). [This blog post](https://caremad.io/posts/2013/07/setup-vs-requirement/) has a good explanation.

As such I'm recommending a move away from the "copy what's in `requirements.txt` into `setup.py` and use those dependencies.

Let me know what you think.