### PR TITLE
Enable possibility to use Matchers in path property of Request class

### DIFF
--- a/e2e/app.py
+++ b/e2e/app.py
@@ -61,4 +61,4 @@ def catch_all(path):
 
 
 if __name__ == '__main__':
-    app.run(port='5000')
+    app.run(port=5000)

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -297,9 +297,9 @@ class Request(FromTerms):
         Create a new instance of Request.
 
         :param method: The HTTP method that is expected.
-        :type method: str, Matcher
+        :type method: str
         :param path: The URI path that is expected on this request.
-        :type path: str
+        :type path: str, Matcher
         :param body: The contents of the body of the expected request.
         :type body: str, dict, list
         :param headers: The headers of the expected request.

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -297,7 +297,7 @@ class Request(FromTerms):
         Create a new instance of Request.
 
         :param method: The HTTP method that is expected.
-        :type method: str
+        :type method: str, Matcher
         :param path: The URI path that is expected on this request.
         :type path: str
         :param body: The contents of the body of the expected request.

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -308,7 +308,7 @@ class Request(FromTerms):
         :type query: str or dict
         """
         self.method = method
-        self.path = path
+        self.path = from_term(path)
         self.body = from_term(body)
         self.headers = from_term(headers)
         self.query = from_term(query)

--- a/pact/test/test_pact.py
+++ b/pact/test/test_pact.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from mock import patch, call, Mock
 from psutil import Process
 
-from .. import Consumer, Provider, pact
+from .. import Consumer, Provider, Term, pact
 from ..constants import MOCK_SERVICE_PATH
 from ..pact import Pact, FromTerms, Request, Response
 
@@ -475,6 +475,11 @@ class RequestTestCase(TestCase):
             'method': 'GET',
             'path': '/path',
             'body': []})
+
+    def test_matcher_in_path_gets_converted(self):
+        target = Request('GET', Term('\/.+', '/test-path'))
+        result = target.json()
+        self.assertTrue(isinstance(result['path'], dict))
 
 
 class ResponseTestCase(TestCase):


### PR DESCRIPTION
Added from_term processing of path property in the constructor of Request