### PR TITLE
Resolves #58: Update to pact-ruby-standalone 1.9.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ define E2E
 	done
 	pact-verifier \
 		--provider-base-url=http://localhost:5000 \
-		--pact-urls=./pacts/consumer-provider.json \
 		--provider-states-url=http://localhost:5000/_pact/provider-states \
-		--provider-states-setup-url=http://localhost:5000/_pact/provider-states/active
+		--provider-states-setup-url=http://localhost:5000/_pact/provider-states/active \
+		./pacts/consumer-provider.json
 endef
 
 

--- a/e2e/contracts/test_e2e.py
+++ b/e2e/contracts/test_e2e.py
@@ -93,7 +93,7 @@ class InexactMatches(BaseTestCase):
         (pact
          .given('the user `bob` exists')
          .upon_receiving('a request for the user object of `bob`')
-         .with_request('get', '/users/bob')
+         .with_request('get', Term('/users/[a-z]+', '/users/bob'))
          .will_respond_with(200, body={
              'username': SomethingLike('bob'),
              'id': Term('\d+', '123')}))

--- a/pact/test/test_pact.py
+++ b/pact/test/test_pact.py
@@ -35,7 +35,8 @@ class PactTestCase(TestCase):
         target = Pact(
             self.consumer, self.provider, host_name='192.168.1.1', port=8000,
             log_dir='/logs', ssl=True, sslcert='/ssl.cert', sslkey='/ssl.pem',
-            cors=True, pact_dir='/pacts', version='3.0.0')
+            cors=True, pact_dir='/pacts', version='3.0.0',
+            file_write_mode='merge')
 
         self.assertIs(target.consumer, self.consumer)
         self.assertIs(target.cors, True)
@@ -49,6 +50,7 @@ class PactTestCase(TestCase):
         self.assertEqual(target.sslkey, '/ssl.pem')
         self.assertEqual(target.uri, 'https://192.168.1.1:8000')
         self.assertEqual(target.version, '3.0.0')
+        self.assertEqual(target.file_write_mode, 'merge')
         self.assertEqual(len(target._interactions), 0)
 
     def test_definition_sparse(self):
@@ -232,6 +234,7 @@ class PactStartShutdownServerTestCase(TestCase):
             '--port=1234',
             '--log', '/logs/pact-mock-service.log',
             '--pact-dir', '/pacts',
+            '--pact-file-write-mode', 'overwrite',
             '--pact-specification-version=2.0.0',
             '--consumer', 'consumer',
             '--provider', 'provider'])
@@ -247,6 +250,7 @@ class PactStartShutdownServerTestCase(TestCase):
             '--port=1234',
             '--log', '/logs/pact-mock-service.log',
             '--pact-dir', '/pacts',
+            '--pact-file-write-mode', 'overwrite',
             '--pact-specification-version=2.0.0',
             '--consumer', 'consumer',
             '--provider', 'provider'])
@@ -263,6 +267,7 @@ class PactStartShutdownServerTestCase(TestCase):
             '--port=1234',
             '--log', '/logs/pact-mock-service.log',
             '--pact-dir', '/pacts',
+            '--pact-file-write-mode', 'overwrite',
             '--pact-specification-version=2.0.0',
             '--consumer', 'consumer',
             '--provider', 'provider',
@@ -373,9 +378,7 @@ class PactVerifyTestCase(PactTestCase):
             'post', 'http://localhost:1234/pact',
             data=None,
             headers={'X-Pact-Mock-Service': 'true'},
-            json={'pact_dir': os.getcwd(),
-                  'consumer': {'name': 'TestConsumer'},
-                  'provider': {'name': 'TestProvider'}})
+            json=None)
 
     def test_success(self):
         self.mock_requests.side_effect = iter([Mock(status_code=200)] * 2)

--- a/pact/test/test_verify.py
+++ b/pact/test/test_verify.py
@@ -42,9 +42,10 @@ class mainTestCase(TestCase):
 
         self.runner = CliRunner()
         self.default_call = [
-            '--provider-base-url=http://localhost',
-            '--pact-urls=./pacts/consumer-provider.json,'
-            './pacts/consumer-provider2.json,./pacts/consumer-provider3.json']
+            './pacts/consumer-provider.json',
+            './pacts/consumer-provider2.json',
+            './pacts/consumer-provider3.json',
+            '--provider-base-url=http://localhost']
 
         self.default_opts = [
             '--provider-base-url=http://localhost',
@@ -74,7 +75,7 @@ class mainTestCase(TestCase):
             verify.main, ['--provider-base-url=http://localhost'])
 
         self.assertEqual(result.exit_code, 1)
-        self.assertIn(b'--pact-url or --pact-urls', result.output_bytes)
+        self.assertIn(b'at least one', result.output_bytes)
         self.assertFalse(self.mock_Popen.called)
 
     def test_local_pact_urls_must_exist(self):
@@ -123,6 +124,7 @@ class mainTestCase(TestCase):
     def test_all_options(self):
         self.mock_Popen.return_value.returncode = 0
         result = self.runner.invoke(verify.main, [
+            './pacts/consumer-provider5.json',
             '--provider-base-url=http://localhost',
             '--pact-urls=./pacts/consumer-provider.json,'
             './pacts/consumer-provider2.json',
@@ -135,13 +137,15 @@ class mainTestCase(TestCase):
             '--provider-app-version=1.2.3',
             '--timeout=60'
         ])
-        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.exit_code, 0, result.output)
         self.assertEqual(self.mock_Popen.call_count, 1)
         self.assertProcess(
+            './pacts/consumer-provider5.json',
+            './pacts/consumer-provider3.json',
+            './pacts/consumer-provider4.json',
+            './pacts/consumer-provider.json',
+            './pacts/consumer-provider2.json',
             '--provider-base-url=http://localhost',
-            '--pact-urls=./pacts/consumer-provider3.json,'
-            './pacts/consumer-provider4.json,'
-            './pacts/consumer-provider.json,./pacts/consumer-provider2.json',
             '--provider-states-setup-url=http://localhost/provider-states/set',
             '--broker-username=user',
             '--broker-password=pass',
@@ -163,9 +167,9 @@ class mainTestCase(TestCase):
             result.output_bytes)
         self.assertEqual(self.mock_Popen.call_count, 1)
         self.assertProcess(
-            '--provider-base-url=http://localhost',
-            '--pact-urls=./pacts/consumer-provider.json,'
-            './pacts/consumer-provider2.json')
+            './pacts/consumer-provider.json',
+            './pacts/consumer-provider2.json',
+            '--provider-base-url=http://localhost')
         self.mock_Popen.return_value.communicate.assert_called_once_with(
             timeout=30)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.install import install
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '1.8.0'
+PACT_STANDALONE_VERSION = '1.9.0'
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Resolves #58 

- Pinned to pact-ruby-standalone 1.9.0
- Removed the payload to `/pact` of the pact-mock-service as its no longer required
- Added the option to specify pact URIs as arguments to be consistent with the Ruby verifier
- Added deprecation notices to `--pact-url` and `--pact-urls`
- Added `file_write_mode` to the Pact class to control how the mock service
  writes files when tests are run in parallel