### PR TITLE
Reduce timeout in _wait_for_server_start to 25s

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -256,7 +256,7 @@ class Pact(object):
         :raises RuntimeError: If there is a problem starting the mock service.
         """
         s = requests.Session()
-        retries = Retry(total=15, backoff_factor=0.1)
+        retries = Retry(total=9, backoff_factor=0.1)
         s.mount('http://', HTTPAdapter(max_retries=retries))
         resp = s.get(self.uri, headers=self.HEADERS)
         if resp.status_code != 200:

--- a/pact/test/test_pact.py
+++ b/pact/test/test_pact.py
@@ -334,7 +334,7 @@ class PactWaitForServerStartTestCase(TestCase):
             'http://localhost:1234', headers={'X-Pact-Mock-Service': 'true'})
         self.mock_HTTPAdapter.assert_called_once_with(
             max_retries=self.mock_Retry.return_value)
-        self.mock_Retry.assert_called_once_with(total=15, backoff_factor=0.1)
+        self.mock_Retry.assert_called_once_with(total=9, backoff_factor=0.1)
         self.assertFalse(pact._process.communicate.called)
         self.assertFalse(pact._process.terminate.called)
 
@@ -352,7 +352,7 @@ class PactWaitForServerStartTestCase(TestCase):
             'http://localhost:1234', headers={'X-Pact-Mock-Service': 'true'})
         self.mock_HTTPAdapter.assert_called_once_with(
             max_retries=self.mock_Retry.return_value)
-        self.mock_Retry.assert_called_once_with(total=15, backoff_factor=0.1)
+        self.mock_Retry.assert_called_once_with(total=9, backoff_factor=0.1)
         pact._process.communicate.assert_called_once_with()
         pact._process.terminate.assert_called_once_with()
 


### PR DESCRIPTION
Modify Retry.total in Pact._wait_for_server_start to reduce the total
wait time from 54 minutes to about 25 seconds.

With a Retry.backoff_factor of 0.1 and 15 retries, the total wait time
before an error is `sum([0.1 * (2**(i - 1)) for i in range(16)])` which
is 3276 seconds or 54 minutes.