### PR TITLE
Fix #73 by adding BUNDLE_FROZEN=1 env to subprocess calls.

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -158,7 +158,7 @@ class Pact(object):
         if self.sslkey:
             command.extend(['--sslkey', self.sslkey])
 
-        self._process = Popen(command)
+        self._process = Popen(command, env={'BUNDLE_FROZEN': '1'})
         self._wait_for_server_start()
 
     def stop_service(self):

--- a/pact/test/test_pact.py
+++ b/pact/test/test_pact.py
@@ -228,32 +228,40 @@ class PactStartShutdownServerTestCase(TestCase):
         with self.assertRaises(RuntimeError):
             pact.start_service()
 
-        self.mock_Popen.assert_called_once_with([
-            MOCK_SERVICE_PATH, 'service',
-            '--host=localhost',
-            '--port=1234',
-            '--log', '/logs/pact-mock-service.log',
-            '--pact-dir', '/pacts',
-            '--pact-file-write-mode', 'overwrite',
-            '--pact-specification-version=2.0.0',
-            '--consumer', 'consumer',
-            '--provider', 'provider'])
+        self.mock_Popen.assert_called_once_with(
+            [
+                MOCK_SERVICE_PATH, 'service',
+                '--host=localhost',
+                '--port=1234',
+                '--log', '/logs/pact-mock-service.log',
+                '--pact-dir', '/pacts',
+                '--pact-file-write-mode', 'overwrite',
+                '--pact-specification-version=2.0.0',
+                '--consumer', 'consumer',
+                '--provider', 'provider'
+            ],
+            env={'BUNDLE_FROZEN', '1'},
+        )
 
     def test_start_no_ssl(self):
         pact = Pact(Consumer('consumer'), Provider('provider'),
                     log_dir='/logs', pact_dir='/pacts')
         pact.start_service()
 
-        self.mock_Popen.assert_called_once_with([
-            MOCK_SERVICE_PATH, 'service',
-            '--host=localhost',
-            '--port=1234',
-            '--log', '/logs/pact-mock-service.log',
-            '--pact-dir', '/pacts',
-            '--pact-file-write-mode', 'overwrite',
-            '--pact-specification-version=2.0.0',
-            '--consumer', 'consumer',
-            '--provider', 'provider'])
+        self.mock_Popen.assert_called_once_with(
+            [
+                MOCK_SERVICE_PATH, 'service',
+                '--host=localhost',
+                '--port=1234',
+                '--log', '/logs/pact-mock-service.log',
+                '--pact-dir', '/pacts',
+                '--pact-file-write-mode', 'overwrite',
+                '--pact-specification-version=2.0.0',
+                '--consumer', 'consumer',
+                '--provider', 'provider'
+            ],
+            env={'BUNDLE_FROZEN', '1'},
+        )
 
     def test_start_with_ssl(self):
         pact = Pact(Consumer('consumer'), Provider('provider'),
@@ -261,19 +269,23 @@ class PactStartShutdownServerTestCase(TestCase):
                     ssl=True, sslcert='/ssl.cert', sslkey='/ssl.key')
         pact.start_service()
 
-        self.mock_Popen.assert_called_once_with([
-            MOCK_SERVICE_PATH, 'service',
-            '--host=localhost',
-            '--port=1234',
-            '--log', '/logs/pact-mock-service.log',
-            '--pact-dir', '/pacts',
-            '--pact-file-write-mode', 'overwrite',
-            '--pact-specification-version=2.0.0',
-            '--consumer', 'consumer',
-            '--provider', 'provider',
-            '--ssl',
-            '--sslcert', '/ssl.cert',
-            '--sslkey', '/ssl.key'])
+        self.mock_Popen.assert_called_once_with(
+            [
+                MOCK_SERVICE_PATH, 'service',
+                '--host=localhost',
+                '--port=1234',
+                '--log', '/logs/pact-mock-service.log',
+                '--pact-dir', '/pacts',
+                '--pact-file-write-mode', 'overwrite',
+                '--pact-specification-version=2.0.0',
+                '--consumer', 'consumer',
+                '--provider', 'provider',
+                '--ssl',
+                '--sslcert', '/ssl.cert',
+                '--sslkey', '/ssl.key'
+            ],
+            env={'BUNDLE_FROZEN', '1'},
+        )
 
     def test_stop_posix(self):
         self.mock_platform.return_value = 'Linux'

--- a/pact/verify.py
+++ b/pact/verify.py
@@ -129,6 +129,7 @@ def main(pacts, base_url, pact_url, pact_urls, states_url,
 
     env = os.environ.copy()
     env['PACT_INTERACTION_RERUN_COMMAND'] = rerun_command()
+    env['BUNDLE_FROZEN'] = '1'
     p = subprocess.Popen(command, env=env)
     p.communicate(timeout=timeout)
     sys.exit(p.returncode)


### PR DESCRIPTION
This keeps the `bundle exec` call from modifying the `Gemfile.lock`,
which does not work if pact-python is installed in the system Python's
site-packages.