### PR TITLE
Resolves #59 Hide Ruby stack traces by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,4 @@ test: deps
 	pydocstyle pact
 	coverage erase
 	tox
-	coverage report --fail-under=100
+	coverage report -m --fail-under=100


### PR DESCRIPTION
- When running the verifier Ruby stacks are hidden by default
- They can be shown again by passing `--verbose` on the command line

Resolves #59 