### PR TITLE
Added windows specific code to check if mock service is stopped.

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -169,13 +169,18 @@ class Pact(object):
             p = psutil.Process(self._process.pid)
             for child in p.children(recursive=True):
                 child.terminate()
+            p.wait()
+            if psutil.pid_exists(self._process.pid):
+                raise RuntimeError(
+                    'There was an error when stopping the Pact mock service.')
+
         else:
             self._process.terminate()
 
-        self._process.communicate()
-        if self._process.returncode != 0:
-            raise RuntimeError(
-                'There was an error when stopping the Pact mock service.')
+            self._process.communicate()
+            if self._process.returncode != 0:
+                raise RuntimeError(
+                    'There was an error when stopping the Pact mock service.')
 
     def upon_receiving(self, scenario):
         """


### PR DESCRIPTION
I was getting error while using pact-python in windows 10 'There was an error when stopping the Pact mock service.' Same code was running without any error in Ubuntu.
While digging a bit found out that checking  self._process.returncode != 0 does not work with windows as in my case windows was returning return code as 15.
So now for windows I am checking if process still exists using psutil.pid_exists to determine if mock service is stopped or not.