### PR TITLE
Pass file_write_mode to Pact

### DIFF
--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -81,11 +81,11 @@ class Consumer(object):
         :param version: The Pact Specification version to use, defaults to
             '2.0.0'.
         :type version: str
-        :param file_write_mode: How the mock service should apply multiple calls
-            to .verify(). Pass 'overwrite' to overwrite the generated JSON
-            file on every call to .verify() or pass 'merge' to merge all
+        :param file_write_mode: How the mock service should apply multiple
+            calls to .verify(). Pass 'overwrite' to overwrite the generated
+            JSON file on every call to .verify() or pass 'merge' to merge all
             interactions into the same JSON file. When using 'merge', make
-            sure to delete any existing JSON file before calling .verify() 
+            sure to delete any existing JSON file before calling .verify()
             for the first time. Defaults to 'overwrite'.
         :type version: str
         :return: A Pact object which you can use to define the specific

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -81,6 +81,13 @@ class Consumer(object):
         :param version: The Pact Specification version to use, defaults to
             '2.0.0'.
         :type version: str
+        :param file_write_mode: How the mock service should apply multiple calls
+            to .verify(). Pass 'overwrite' to overwrite the generated JSON
+            file on every call to .verify() or pass 'merge' to merge all
+            interactions into the same JSON file. When using 'merge', make
+            sure to delete any existing JSON file before calling .verify() 
+            for the first time. Defaults to 'overwrite'.
+        :type version: str
         :return: A Pact object which you can use to define the specific
             interactions your code will have with the provider.
         :rtype: pact.Pact

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -33,7 +33,8 @@ class Consumer(object):
 
     def has_pact_with(self, provider, host_name='localhost', port=1234,
                       log_dir=None, ssl=False, sslcert=None, sslkey=None,
-                      cors=False, pact_dir=None, version='2.0.0'):
+                      cors=False, pact_dir=None, version='2.0.0',
+                      file_write_mode='overwrite'):
         """
         Create a contract between the `provider` and this consumer.
 
@@ -99,4 +100,5 @@ class Consumer(object):
             sslkey=sslkey,
             cors=cors,
             pact_dir=pact_dir,
-            version=version)
+            version=version,
+            file_write_mode=file_write_mode)

--- a/pact/test/test_consumer.py
+++ b/pact/test/test_consumer.py
@@ -25,20 +25,23 @@ class ConsumerTestCase(TestCase):
             consumer=self.consumer, provider=self.provider,
             host_name='localhost', port=1234,
             log_dir=None, ssl=False, sslcert=None, sslkey=None,
-            cors=False, pact_dir=None, version='2.0.0')
+            cors=False, pact_dir=None, version='2.0.0',
+            file_write_mode='overwrite')
 
     def test_has_pact_with_customer_all_options(self):
         result = self.consumer.has_pact_with(
             self.provider, host_name='example.com', port=1111,
             log_dir='/logs', ssl=True,  sslcert='/ssl.cert', sslkey='ssl.pem',
-            cors=True, pact_dir='/pacts', version='3.0.0')
+            cors=True, pact_dir='/pacts', version='3.0.0',
+            file_write_mode='merge')
 
         self.assertIs(result, self.mock_service.return_value)
         self.mock_service.assert_called_once_with(
             consumer=self.consumer, provider=self.provider,
             host_name='example.com', port=1111,
             log_dir='/logs', ssl=True, sslcert='/ssl.cert', sslkey='ssl.pem',
-            cors=True, pact_dir='/pacts', version='3.0.0')
+            cors=True, pact_dir='/pacts', version='3.0.0',
+            file_write_mode='merge')
 
     def test_has_pact_with_not_a_provider(self):
         with self.assertRaises(ValueError):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+Click>=2.0.0,<=6.7
 Flask==0.11.1
 configparser==3.5.0
 codecov==2.0.5

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def read(filename):
 
 
 dependencies = [
-    'click>=2.0.0',
+    'click>=2.0.0,<=6.7',
     'psutil>=2.0.0',
     'requests>=2.5.0',
     'six>=1.9.0',


### PR DESCRIPTION
`Pact` accepts a `file_write_mode`, but `Consumer().has_pact_with` does not currently pass it to `Pact`