### PR TITLE
match platforms like 'macOS-*' to osx suffix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def install_ruby_app(bin_path):
     uri = ('https://github.com/pact-foundation/pact-ruby-standalone/releases'
            '/download/v{version}/pact-{version}-{suffix}')
 
-    if 'darwin' in target_platform:
+    if 'darwin' in target_platform or 'macos' in target_platform:
         suffix = 'osx.tar.gz'
     elif 'linux' in target_platform and IS_64:
         suffix = 'linux-x86_64.tar.gz'


### PR DESCRIPTION
Should address #112 

`platform.platform()` returns a macOS version, rather than a Darwin version as of python 3.8.  Both should match the 'osx.tar.gz' pact build.