### PR TITLE
Expose —broker-token option

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,11 @@ The username to use when contacting the Pact Broker.
 The password to use when contacting the Pact Broker. You can also specify this value
 as the environment variable `PACT_BROKER_PASSWORD`.
 
+###### --pact-broker-token
+
+The bearer token to use when contacting the Pact Broker. You can also specify this value
+as the environment variable `PACT_BROKER_TOKEN`.
+
 ### Provider States
 In many cases, your contracts will need very specific data to exist on the provider
 to pass successfully. If you are fetching a user profile, that user needs to exist,

--- a/pact/test/test_verify.py
+++ b/pact/test/test_verify.py
@@ -118,6 +118,7 @@ class mainTestCase(TestCase):
             '--provider-states-setup-url=http://localhost/provider-states/set',
             '--pact-broker-username=user',
             '--pact-broker-password=pass',
+            '--pact-broker-token=token',
             '--publish-verification-results',
             '--provider-app-version=1.2.3',
             '--timeout=60',
@@ -136,6 +137,7 @@ class mainTestCase(TestCase):
             '--provider-states-setup-url=http://localhost/provider-states/set',
             '--broker-username=user',
             '--broker-password=pass',
+            '--broker-token=token',
             '--publish-verification-results',
             '--provider-app-version', '1.2.3',
             '--verbose')

--- a/pact/verify.py
+++ b/pact/verify.py
@@ -52,6 +52,11 @@ else:
     help='Password for Pact Broker basic authentication. Can also be specified'
          ' via the environment variable PACT_BROKER_PASSWORD')
 @click.option(
+    'token', '--pact-broker-token',
+    envvar='PACT_BROKER_TOKEN',
+    help='Bearer token for Pact Broker authentication. Can also be specified'
+         ' via the environment variable PACT_BROKER_TOKEN')
+@click.option(
     'header', '--custom-provider-header',
     envvar='CUSTOM_PROVIDER_HEADER',
     help='Header to add to provider state set up and '
@@ -79,7 +84,7 @@ else:
     default=False,
     help='Toggle verbose logging, defaults to False.')
 def main(pacts, base_url, pact_url, pact_urls, states_url,
-         states_setup_url, username, password, header, timeout,
+         states_setup_url, username, password, token, header, timeout,
          provider_app_version, publish_verification_results, verbose):
     """
     Verify one or more contracts against a provider service.
@@ -121,6 +126,7 @@ def main(pacts, base_url, pact_url, pact_urls, states_url,
         '--provider-states-setup-url': states_setup_url,
         '--broker-username': username,
         '--broker-password': password,
+        '--broker-token': token,
         '--custom-provider-header': header,
     }
     command = [VERIFIER_PATH]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.install import install
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '1.54.4'
+PACT_STANDALONE_VERSION = '1.74.0'
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Closes #113.

This PR updates `pact-ruby-standalone` and expose the `—broker-token` option. 