### PR TITLE
Updates to integrated pact broker client

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -158,7 +158,7 @@ class Pact(object):
 
         if self.broker_username is not None:
             command.append('--broker-username={}'.format(self.broker_username))
-        if self.broker_username is not None:
+        if self.broker_password is not None:
             command.append('--broker-password={}'.format(self.broker_password))
         if self.broker_token is not None:
             command.append('--broker-token={}'.format(self.broker_token))

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -78,16 +78,22 @@ class Pact(object):
             pacts to a pact broker. Defaults to False.
         :type publish_to_broker: bool
         :param broker_base_url: URL of the pact broker that pacts will be
-            published to. Defaults to None.
+            published to. Can also be supplied through the PACT_BROKER_BASE_URL
+            environment variable. Defaults to None.
         :type broker_base_url: str
         :param broker_username: Username to use when connecting to the pact
-            broker if authentication is required. Defaults to None.
+            broker if authentication is required. Can also be supplied through
+            the PACT_BROKER_USERNAME environment variable. Defaults to None.
         :type broker_username: str
         :param broker_password: Password to use when connecting to the pact
-            broker if authentication is required. Defaults to None.
+            broker if authentication is required. Strongly recommend supplying
+            this value through the PACT_BROKER_PASSWORD environment variable
+            instead. Defaults to None.
         :type broker_password: str
         :param broker_token: Authentication token to use when connecting to
-            the pact broker. Defaults to None.
+            the pact broker. Strongly recommend supplying this value through
+            the PACT_BROKER_TOKEN environment variable instead.
+            Defaults to None.
         :type broker_token: str
         :param pact_dir: Directory where the resulting pact files will be
             written. Defaults to the current directory.

--- a/pact/test/test_pact.py
+++ b/pact/test/test_pact.py
@@ -251,6 +251,13 @@ class PactPublishTestCase(PactTestCase):
         with self.assertRaises(RuntimeError):
             pact.publish()
 
+    def text_publish_with_broker_url_environment_variable(self):
+        pact = Pact(self.consumer, self.provider, publish_to_broker=True)
+        os.environ["PACT_BROKER_BASE_URL"] = "http://localhost"
+
+        pact.publish()
+        del os.environ["PACT_BROKER_BASE_URL"]
+
     def test_default_publish(self):
         pact = Pact(self.consumer, self.provider,
                     publish_to_broker=True,


### PR DESCRIPTION
Minor fixes that didn't get pushed before #106 got merged.
* `publish()` method was looking to see if `self.broker_username` was set instead of `self.broker_password` when adding the `--broker-password` argument
* Documentation updated to reflect environment variables picked up by pact broker client
* Allow `publish()` to proceed if no pact broker base URL is provided, but `PACT_BROKER_BASE_URL` environment variable is set
* Add test regarding above code change