### PR TITLE
feat: update to pact-ruby-standalone-1.79.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools.command.install import install
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '1.74.0'
+PACT_STANDALONE_VERSION = '1.79.0'
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This is required so that SSL_CERT_FILE is respected when fetching pacts from a pact broker with a self signed certificate.