### PR TITLE
Docker support for builds

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,28 +1,37 @@
 # Introduction
+
 This is for contributors who want to make changes and test for all different versions of python currently supported. If you don't want to set up and install all the different python versions locally (and there are some difficulties with that) you can just run them in docker using containers.
 
 # Setup
+
 To build a container say for python 3.6 change to the root directory of the project and run
 
 ```bash
-docker build -t pact:python36 -f docker/py36.Dockerfile .
+docker build -t pactfoundation:python36 -f docker/py36.Dockerfile .
 ```
 
 And then to run you will need:
 
 ```bash
-docker run  -it -v `pwd`:/home pact:python36
+docker run  -it -v `pwd`:/home pactfoundation:python36
 ```
 
 If you need to debug you can change the command to:
 
 ```bash
-docker run  -it -v `pwd`:/home pact:python36 sh
+docker run  -it -v `pwd`:/home pactfoundation:python36 sh
 ```
 
 This will open a container with a prompt. From the /home location in the container you can run
-```
+
+```bash
 tox -e py36
 ```
 
-In all the above if you need to run a different version change py36/python36 where appropriate.
+In all the above if you need to run a different version change py36/python36 where appropriate. Or you can run the convenience script to build:
+
+```bash
+docker/build.sh 38
+```
+
+where 38 is the python environment version (3.8 in this case)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Introduction
+This is for contributors who want to make changes and test for all different versions of python currently supported. If you don't want to set up and install all the different python versions locally (and there are some difficulties with that) you can just run them in docker using containers.
+
+# Setup
+To build a container say for python 3.6 change to the root directory of the project and run
+
+```bash
+docker build -t pact:python36 -f docker/py36.Dockerfile .
+```
+
+And then to run you will need:
+
+```bash
+docker run  -it -v `pwd`:/home pact:python36
+```
+
+If you need to debug you can change the command to:
+
+```bash
+docker run  -it -v `pwd`:/home pact:python36 sh
+```
+
+This will open a container with a prompt. From the /home location in the container you can run
+```
+tox -e py36
+```
+
+In all the above if you need to run a different version change py36/python36 where appropriate.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "$0: usage: build.sh 27|36|37|38"
+    exit 1
+fi
+DOCKER_ENV=$1
+echo "Building env ${DOCKER_ENV}"
+
+DOCKER_IMAGE="pactfoundation:python${DOCKER_ENV}"
+DOCKER_FILE="docker/py${DOCKER_ENV}.Dockerfile"
+
+docker build -t $DOCKER_IMAGE -f $DOCKER_FILE .

--- a/docker/py27.Dockerfile
+++ b/docker/py27.Dockerfile
@@ -17,3 +17,5 @@ RUN apk --no-cache add ca-certificates wget && \
 
 
 RUN ln -sf /usr/glibc-compat/bin/locale /usr/local/bin/locale
+
+CMD tox -e py27

--- a/docker/py27.Dockerfile
+++ b/docker/py27.Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /home
 
 COPY requirements_dev.txt .
 
-RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+RUN apk update
+RUN apk upgrade
+
+RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev bash make
 
 RUN python -m pip install psutil subprocess32
 RUN pip install -r requirements_dev.txt

--- a/docker/py36.Dockerfile
+++ b/docker/py36.Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6.10-alpine3.11
+
+WORKDIR /home
+
+COPY requirements_dev.txt .
+
+RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+
+RUN python -m pip install psutil subprocess32
+RUN pip install -r requirements_dev.txt
+
+CMD tox -e py36

--- a/docker/py36.Dockerfile
+++ b/docker/py36.Dockerfile
@@ -6,7 +6,7 @@ COPY requirements_dev.txt .
 
 RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
 
-RUN python -m pip install psutil subprocess32
+RUN python -m pip install psutil
 RUN pip install -r requirements_dev.txt
 
 CMD tox -e py36

--- a/docker/py36.Dockerfile
+++ b/docker/py36.Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /home
 
 COPY requirements_dev.txt .
 
-RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+RUN apk update
+RUN apk upgrade
+
+RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev bash make
 
 RUN python -m pip install psutil
 RUN pip install -r requirements_dev.txt

--- a/docker/py37.Dockerfile
+++ b/docker/py37.Dockerfile
@@ -6,7 +6,7 @@ COPY requirements_dev.txt .
 
 RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
 
-RUN python -m pip install psutil subprocess32
+RUN python -m pip install psutil
 RUN pip install -r requirements_dev.txt
 
 CMD tox -e py37

--- a/docker/py37.Dockerfile
+++ b/docker/py37.Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.7.7-alpine3.11
+
+WORKDIR /home
+
+COPY requirements_dev.txt .
+
+RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+
+RUN python -m pip install psutil subprocess32
+RUN pip install -r requirements_dev.txt
+
+CMD tox -e py37

--- a/docker/py37.Dockerfile
+++ b/docker/py37.Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /home
 
 COPY requirements_dev.txt .
 
-RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+RUN apk update
+RUN apk upgrade
+
+RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev bash make
 
 RUN python -m pip install psutil
 RUN pip install -r requirements_dev.txt

--- a/docker/py38.Dockerfile
+++ b/docker/py38.Dockerfile
@@ -6,7 +6,7 @@ COPY requirements_dev.txt .
 
 RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
 
-RUN python -m pip install psutil subprocess32
+RUN python -m pip install psutil
 RUN pip install -r requirements_dev.txt
 
 CMD tox -e py38

--- a/docker/py38.Dockerfile
+++ b/docker/py38.Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /home
 
 COPY requirements_dev.txt .
 
-RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+RUN apk update
+RUN apk upgrade
+
+RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev bash make
 
 RUN python -m pip install psutil
 RUN pip install -r requirements_dev.txt

--- a/docker/py38.Dockerfile
+++ b/docker/py38.Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.8.2-alpine3.11
+
+WORKDIR /home
+
+COPY requirements_dev.txt .
+
+RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+
+RUN python -m pip install psutil subprocess32
+RUN pip install -r requirements_dev.txt
+
+CMD tox -e py38


### PR DESCRIPTION
Created some simple docker files and script to help create envs where not all python versions are available. Needs a bit of work but allows debugging of version issues. I could tweak this to publish containers with pact-python installed and published to pact-foundation?