### PR TITLE
Move tests to standard tests dir

### DIFF
--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from mock import patch
 
-from .. import constants
+from pact import constants as constants
 
 
 class broker_client_exeTestCase(TestCase):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -2,8 +2,9 @@ from unittest import TestCase
 
 from mock import Mock
 
-from .. import Consumer, Provider
-from ..pact import Pact
+from pact.consumer import Consumer
+from pact.provider import Provider
+from pact.pact import Pact
 
 
 class ConsumerTestCase(TestCase):

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from ..matchers import EachLike, Like, Matcher, SomethingLike, \
+from pact.matchers import EachLike, Like, Matcher, SomethingLike, \
     Term, from_term, get_generated_values
 
 

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -5,9 +5,11 @@ from unittest import TestCase
 from mock import patch, call, Mock
 from psutil import Process
 
-from .. import Consumer, Provider, Term, pact
-from ..constants import MOCK_SERVICE_PATH, BROKER_CLIENT_PATH
-from ..pact import Pact, FromTerms, Request, Response
+from pact.consumer import Consumer, Provider
+from pact.matchers import Term
+from pact.constants import MOCK_SERVICE_PATH, BROKER_CLIENT_PATH
+from pact.pact import Pact, FromTerms, Request, Response
+from pact import pact as pact
 
 
 class PactTestCase(TestCase):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from .. import Provider
+from pact.provider import Provider
 
 
 class ProviderTestCase(TestCase):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -5,8 +5,8 @@ from unittest import TestCase
 from click.testing import CliRunner
 from mock import patch, Mock, call
 
-from .. import verify
-from ..constants import VERIFIER_PATH
+from pact import verify as verify
+from pact.constants import VERIFIER_PATH
 
 if sys.version_info.major == 2:
     from subprocess32 import PIPE, Popen


### PR DESCRIPTION
Moving the `test` dir that was previously part of the `pact` package into it's own module `tests`. This follows standard practice in python projects.