### PR TITLE
Fix missing normalization of consumer name while publishing pact

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -149,6 +149,10 @@ class Pact(object):
         self._interactions[0]['provider_state'] = provider_state
         return self
 
+    @staticmethod
+    def _normalize_consumer_name(name):
+        return name.lower().replace(' ', '_')
+
     def publish(self):
         """Publish the generated pact files to the specified pact broker."""
         if self.broker_base_url is None \
@@ -157,8 +161,10 @@ class Pact(object):
                                "Did you expect the PACT_BROKER_BASE_URL " +
                                "environment variable to be set?")
 
-        pact_files = fnmatch.filter(os.listdir(self.pact_dir),
-                                    self.consumer.name + '*.json')
+        pact_files = fnmatch.filter(
+            os.listdir(self.pact_dir),
+            self._normalize_consumer_name(self.consumer.name) + '*.json'
+        )
         command = [
             BROKER_CLIENT_PATH,
             'publish',


### PR DESCRIPTION
We have a name of consumer which is a string formatted as title: "Sample Project". It's contract file is being saved as "sample_project_….json". While publishing pact logic is looking for a name of contract file beginning with not normalized, but original consumer name. Therefore it does not find the file and exits with following message:

    No value provided for required pact_files
    Error in atexit._run_exitfuncs:
    Traceback (most recent call last):
      File "/…/site-packages/pact/pact.py", line 260, in stop_service
        self.publish()
      File "/…/site-packages/pact/pact.py", line 193, in publish
        .format(url))
    RuntimeError: There was an error while publishing to the pact broker at ….

The pull request is a fix for that.