### PR TITLE
Remove typo from examples/e2e requirements.txt

### DIFF
--- a/examples/e2e/requirements.txt
+++ b/examples/e2e/requirements.txt
@@ -14,7 +14,7 @@ packaging==20.3
 pluggy==0.13.1
 psutil==5.7.0
 py==1.8.1
-pyparsing==2.4.6f
+pyparsing==2.4.6
 pytest==5.4.1
 requests==2.23.0
 six==1.14.0


### PR DESCRIPTION
A stray f was in examples/e2e/requirements.txt causing pip install to break