### PR TITLE
chore: add workflow to trigger pact docs update when markdown files c…

### DIFF
--- a/.github/workflows/trigger_pact_docs_update.yml
+++ b/.github/workflows/trigger_pact_docs_update.yml
@@ -1,0 +1,21 @@
+name: Trigger update to docs.pact.io
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.md'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs.pact.io update workflow
+        run: |
+          curl -X POST https://api.github.com/repos/pact-foundation/docs.pact.io/dispatches \
+                -H 'Accept: application/vnd.github.everest-preview+json' \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -d '{"event_type": "pact-python-docs-updated"}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHTOKENFORTRIGGERINGPACTDOCSUPDATE }}


### PR DESCRIPTION
…hange

The readme and changelog are now synced to docs.pact.io 🎉 This will make them much more prominent and searchable.

This workflow triggers a workflow in the docs.pact.io repository here that pulls in any changes to any relevant markdown files. 

You can see the docs.pact.io workflow here: https://github.com/pact-foundation/docs.pact.io/blob/master/.github/workflows/sync-docs.yml

And the sync script that it runs here: https://github.com/pact-foundation/docs.pact.io/blob/master/scripts/sync/pact_python.rb

I've created a token in the secrets section for the API calls.

Keep in mind that any URLs in the README now need to be absolute so that they work on both docs.pact.io and github.

It would make the changelog a log cleaner if semantic commits could be used. There are probably python tools that can generate changelogs automatically from semantic commits. I use some in both JS and Ruby world. Totally worth doing. It's the only way I've managed to keep releasing 10+ repos every few weeks for the last 5 years.