### PR TITLE
feat(verifier): support --no-enable-pending flag in CLI

### DIFF
--- a/pact/cli/verify.py
+++ b/pact/cli/verify.py
@@ -111,11 +111,12 @@ import click
     'log_level', '--log-level',
     help='The logging level.')
 @click.option(
-    'enable_pending', '--enable-pending',
+    'enable_pending',
+    '--enable-pending/--no-enable-pending',
     default=False,
     help='Allow pacts which are in pending state to be verified without causing the '
-         'overall task to fail. For more information, see https://pact.io/pending',
-    is_flag=True)
+    'overall task to fail. For more information, see https://pact.io/pending',
+)
 def main(pacts, base_url, pact_url, pact_urls, states_url, states_setup_url,
          username, broker_base_url, consumer_version_tag, consumer_version_selector,
          provider_version_tag, password, token, provider, headers, timeout,

--- a/pact/cli/verify.py
+++ b/pact/cli/verify.py
@@ -113,7 +113,7 @@ import click
 @click.option(
     'enable_pending',
     '--enable-pending/--no-enable-pending',
-    default=False,
+    default=None,
     help='Allow pacts which are in pending state to be verified without causing the '
     'overall task to fail. For more information, see https://pact.io/pending',
 )

--- a/pact/verify_wrapper.py
+++ b/pact/verify_wrapper.py
@@ -173,6 +173,8 @@ class VerifyWrapper(object):
             command.extend(['--verbose'])
         if enable_pending:
             command.append('--enable-pending')
+        else:
+            command.append('--no-enable-pending')
 
         headers = kwargs.get('custom_provider_headers', [])
         for header in headers:

--- a/pact/verify_wrapper.py
+++ b/pact/verify_wrapper.py
@@ -121,7 +121,7 @@ class PactException(Exception):
         super().__init__(*args, **kwargs)
         self.message = args[0]
 
-class VerifyWrapper(object):
+class VerifyWrapper:
     """A Pact Verifier Wrapper."""
 
     def _broker_present(self, **kwargs):

--- a/pact/verify_wrapper.py
+++ b/pact/verify_wrapper.py
@@ -171,10 +171,7 @@ class VerifyWrapper(object):
 
         if(kwargs.get('verbose', False) is True):
             command.extend(['--verbose'])
-        if enable_pending:
-            command.append('--enable-pending')
-        else:
-            command.append('--no-enable-pending')
+        command.extend(self._convert_enable_pending_flag(enable_pending))
 
         headers = kwargs.get('custom_provider_headers', [])
         for header in headers:
@@ -195,6 +192,13 @@ class VerifyWrapper(object):
         logs = capture_logs(result, verbose)
 
         return result.returncode, logs
+
+    def _convert_enable_pending_flag(self, value):
+        if value:
+            return ['--enable-pending']
+        elif value is False:
+            return ['--no-enable-pending']
+        return []
 
     def publish_results(self, provider_app_version, command):
         """Publish results to broker."""

--- a/tests/cli/test_verify.py
+++ b/tests/cli/test_verify.py
@@ -345,3 +345,16 @@ class mainTestCase(TestCase):
 
         mock_expand_dirs.assert_called_once()
         mock_path_exists.assert_called_once_with('foo')
+
+    @patch(
+        'pact.verify_wrapper.VerifyWrapper.call_verify', return_value=(0, None)
+    )
+    def test_supports_no_enable_pending_flag(self, call_mock):
+        with patch('pact.cli.verify.path_exists'):
+            result = self.runner.invoke(
+                verify.main, self.simple_pact_opts + ['--no-enable-pending']
+            )
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertTrue(
+            ('enable_pending', False) in call_mock.call_args.kwargs.items()
+        )

--- a/tests/cli/test_verify.py
+++ b/tests/cli/test_verify.py
@@ -358,3 +358,14 @@ class mainTestCase(TestCase):
         self.assertTrue(
             ('enable_pending', False) in call_mock.call_args.kwargs.items()
         )
+
+    @patch(
+        'pact.verify_wrapper.VerifyWrapper.call_verify', return_value=(0, None)
+    )
+    def test_passes_none_when_no_enable_pending_flag(self, call_mock):
+        with patch('pact.cli.verify.path_exists'):
+            result = self.runner.invoke(verify.main, self.simple_pact_opts)
+        self.assertEqual(0, result.exit_code, result.output)
+        self.assertTrue(
+            ('enable_pending', None) in call_mock.call_args.kwargs.items()
+        )

--- a/tests/test_verify_wrapper.py
+++ b/tests/test_verify_wrapper.py
@@ -208,6 +208,19 @@ class VerifyWrapperTestCase(TestCase):
         mock_expand_dirs.assert_called_with(['path/to/pact1',
                                              'path/to/pact2'])
 
+    def test_appends_no_enable_pending_flag_for_false(self):
+        self.mock_Popen.return_value.returncode = 0
+        VerifyWrapper().call_verify(
+            'path/to/pact1',
+            'path/to/pact2',
+            provider_base_url='http://localhost',
+            provider='provider',
+            enable_pending=False,
+        )
+        self.assertTrue(
+            '--no-enable-pending' in self.mock_Popen.call_args.args[0]
+        )
+
 
 class path_existsTestCase(TestCase):
     def test_path_exists(self):

--- a/tests/test_verify_wrapper.py
+++ b/tests/test_verify_wrapper.py
@@ -221,6 +221,21 @@ class VerifyWrapperTestCase(TestCase):
             '--no-enable-pending' in self.mock_Popen.call_args.args[0]
         )
 
+    def test_doesnt_append_enable_pending_flag_by_default(self):
+        self.mock_Popen.return_value.returncode = 0
+        VerifyWrapper().call_verify(
+            'path/to/pact1',
+            'path/to/pact2',
+            provider_base_url='http://localhost',
+            provider='provider',
+        )
+        self.assertTrue(
+            '--no-enable-pending' not in self.mock_Popen.call_args.args[0]
+        )
+        self.assertTrue(
+            '--enable-pending' not in self.mock_Popen.call_args.args[0]
+        )
+
 
 class path_existsTestCase(TestCase):
     def test_path_exists(self):


### PR DESCRIPTION
This pull request implements following behaviour:
* for --enable-pending flag in CLI and enable_pending=True in Python API it adds --enable-pending in underlying CLI,
* for --no-enable-pending flag in CLI and enable_pending=False in Python API it adds --no-enable-pending in underlying CLI,
* for lack of those flags in CLI and enable_pending=None (default for optional keyword argument) it doesn't add any of those flags in underlying CLI.