### PR TITLE
feat(verifier): Allow setting consumer_version_selectors on Verifier

### DIFF
--- a/pact/verifier.py
+++ b/pact/verifier.py
@@ -1,4 +1,6 @@
 """Classes and methods to verify Contracts."""
+import json
+
 from pact.verify_wrapper import VerifyWrapper, path_exists, expand_directories
 
 class Verifier(object):
@@ -103,6 +105,9 @@ class Verifier(object):
         verbose = kwargs.get('verbose', False)
         publish_version = kwargs.get('publish_version', None)
 
+        raw_consumer_selectors = kwargs.get('consumer_version_selectors', [])
+        consumer_selectors = self._build_consumer_selectors(raw_consumer_selectors)
+
         options = {
             'log_dir': log_dir,
             'log_level': log_level,
@@ -114,8 +119,16 @@ class Verifier(object):
             'provider_states_setup_url': states_setup_url,
             'verbose': verbose,
             'publish_version': publish_version,
+            'consumer_selectors': consumer_selectors
         }
         return self.filter_empty_options(**options)
+
+    def _build_consumer_selectors(self, consumer_selectors):
+        """
+        Turns each dict in the consumer_selectors list into a string with a
+        json object, as expected by VerifyWrapper.
+        """
+        return [json.dumps(selector) for selector in consumer_selectors]
 
     def filter_empty_options(self, **kwargs):
         """Filter out empty options."""

--- a/pact/verifier.py
+++ b/pact/verifier.py
@@ -125,7 +125,9 @@ class Verifier(object):
 
     def _build_consumer_selectors(self, consumer_selectors):
         """
-        Turns each dict in the consumer_selectors list into a string with a
+        Build the consumer_selectors list.
+
+        Turn each dict in the consumer_selectors list into a string with a
         json object, as expected by VerifyWrapper.
         """
         return [json.dumps(selector) for selector in consumer_selectors]

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -178,7 +178,7 @@ class VerifierBrokerTestCase(TestCase):
                 {"tag": "main", "latest": True},
                 {"tag": "test", "latest": False},
             ],
-            **self.default_opts,
+            **self.default_opts
         )
 
         self.assertTrue(output)

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -174,11 +174,11 @@ class VerifierBrokerTestCase(TestCase):
         mock_wrapper.return_value = (True, 'some value')
 
         output, _ = self.verifier.verify_with_broker(
-            **self.default_opts,
             consumer_version_selectors=[
                 {"tag": "main", "latest": True},
                 {"tag": "test", "latest": False},
-            ]
+            ],
+            **self.default_opts,
         )
 
         self.assertTrue(output)

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from unittest import TestCase
 import unittest
 from mock import patch
@@ -52,8 +54,9 @@ class VerifierPactsTestCase(TestCase):
             'path/to/pact2',
             headers=['header1', 'header2'],
             consumer_version_selectors=[
-                {"tag": "main", "latest": True},
-                {"tag": "test", "latest": False},
+                # Using OrderedDict for the sake of testing
+                OrderedDict([("tag", "main"), ("latest", True)]),
+                OrderedDict([("tag", "test"), ("latest", False)]),
             ]
         )
 
@@ -175,8 +178,9 @@ class VerifierBrokerTestCase(TestCase):
 
         output, _ = self.verifier.verify_with_broker(
             consumer_version_selectors=[
-                {"tag": "main", "latest": True},
-                {"tag": "test", "latest": False},
+                # Using OrderedDict for the sake of testing
+                OrderedDict([("tag", "main"), ("latest", True)]),
+                OrderedDict([("tag", "test"), ("latest", False)]),
             ],
             **self.default_opts
         )


### PR DESCRIPTION
Complimenting https://github.com/pact-foundation/pact-python/pull/170, this PR allows to set `consumer_version_selectors` (as a list of python dicts) when instantiating a `Verifier` object, e.g:
```python
verifier = Verifier(
    # ...
    consumer_version_selectors=[{"tag": "main", "latest": True}],
    # ...
)
```
