### PR TITLE
docs: typo in pact-verifier help string: PUT -> POST

### DIFF
--- a/pact/cli/verify.py
+++ b/pact/cli/verify.py
@@ -33,7 +33,7 @@ import click
          ' the given provider API.')  # Remove in major version 1.0.0
 @click.option(
     'states_setup_url', '--provider-states-setup-url',
-    help='URL to send PUT requests to setup a given provider state.')
+    help='URL to send POST requests to setup a given provider state.')
 @click.option(
     'username', '--pact-broker-username',
     envvar='PACT_BROKER_USERNAME',


### PR DESCRIPTION
`pact-verifier` sends POST requests when setting up the provider states.