### PR TITLE
fix: fix datetime serialization issues in Format

### DIFF
--- a/pact/matchers.py
+++ b/pact/matchers.py
@@ -331,7 +331,7 @@ class Format:
         return Term(
             self.Regexes.timestamp.value, datetime.datetime(
                 2000, 2, 1, 12, 30, 0, 0
-            )
+            ).isoformat()
         )
 
     def date(self):
@@ -344,7 +344,7 @@ class Format:
         return Term(
             self.Regexes.date.value, datetime.datetime(
                 2000, 2, 1, 12, 30, 0, 0
-            ).date()
+            ).date().isoformat()
         )
 
     def time(self):
@@ -357,7 +357,7 @@ class Format:
         return Term(
             self.Regexes.time_regex.value, datetime.datetime(
                 2000, 2, 1, 12, 30, 0, 0
-            ).time()
+            ).time().isoformat()
         )
 
     class Regexes(Enum):

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -362,7 +362,7 @@ class FormatTestCase(TestCase):
                         "s": self.formatter.Regexes.timestamp.value,
                         "o": 0,
                     },
-                    "generate": datetime.datetime(2000, 2, 1, 12, 30, 0, 0),
+                    "generate": datetime.datetime(2000, 2, 1, 12, 30, 0, 0).isoformat(),
                 },
             },
         )
@@ -381,7 +381,7 @@ class FormatTestCase(TestCase):
                         "o": 0,
                     },
                     "generate": datetime.datetime(
-                        2000, 2, 1, 12, 30, 0, 0).date(),
+                        2000, 2, 1, 12, 30, 0, 0).date().isoformat(),
                 },
             },
         )
@@ -400,7 +400,7 @@ class FormatTestCase(TestCase):
                         "o": 0,
                     },
                     "generate": datetime.datetime(
-                        2000, 2, 1, 12, 30, 0, 0).time(),
+                        2000, 2, 1, 12, 30, 0, 0).time().isoformat(),
                 },
             },
         )


### PR DESCRIPTION
### Description

This PR fixes the usage of `Format().timestamp`, `Format().date`, and `Format().time` by converting the datetime objects into string isoformat. See https://github.com/pact-foundation/pact-python/issues/228