### PR TITLE
fix: change option default from empty string to empty list (click 8.0.0 incompatibility)

### DIFF
--- a/pact/cli/verify.py
+++ b/pact/cli/verify.py
@@ -21,7 +21,7 @@ import click
     multiple=True)  # Remove in major version 1.0.0
 @click.option(
     'pact_urls', '--pact-urls',
-    default='',
+    default=[],
     help='DEPRECATED: specify pacts as arguments instead.\n'
          'The URI(s) of the pact to verify.'
          ' Can be an HTTP URI(s) or local file path(s).'
@@ -47,19 +47,19 @@ import click
          ' via the environment variable PACT_BROKER_BASE_URL.')
 @click.option(
     'consumer_version_tag', '--consumer-version-tag',
-    default='',
+    default=[],
     multiple=True,
     help='Retrieve the latest pacts with this consumer version tag. '
          'Used in conjunction with --provider. May be specified multiple times.')
 @click.option(
     'consumer_version_selector', '--consumer-version-selector',
-    default='',
+    default=[],
     multiple=True,
     help='Retrieve the latest pacts with this consumer version selector. '
          'Used in conjunction with --provider. May be specified multiple times.')
 @click.option(
     'provider_version_tag', '--provider-version-tag',
-    default='',
+    default=[],
     multiple=True,
     help='Tag to apply to the provider application version. '
          'May be specified multiple times.')

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-Click>=2.0.0,<=6.7
+Click>=2.0.0
 coverage==5.4
 Flask==1.0
 configparser==3.5.0


### PR DESCRIPTION
Click 8.0 released on 11th of May caused a lot of
> ValueError: 'default' must be a list when 'multiple' is true.

Because setup.py specifies `click>=2.0.0` the new version is installed, so tests will fail. There is also the option to set max click version to 6.8, like in `requirements_dev.txt` but I think the fix is fairly easy: change the optional arguments from empty string to empty list.