### PR TITLE
chore(ruby): update ruby standalone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.command.sdist import sdist as sdist_orig
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '1.88.51'
+PACT_STANDALONE_VERSION = '1.88.75'
 PACT_STANDALONE_SUFFIXES = ['osx.tar.gz',
                             'linux-x86_64.tar.gz',
                             'linux-x86.tar.gz',


### PR DESCRIPTION
This should enable PACT_DISABLE_SSL_VERIFICATION=true for Pact broker verification.