### PR TITLE
fix(consumer): ensure a description is provided for all interactions

### DIFF
--- a/examples/broker/docker-compose.yml
+++ b/examples/broker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.9'
 
 services:
   # A PostgreSQL database for the Broker to store Pacts and verification results
@@ -32,6 +32,13 @@ services:
       PACT_BROKER_DATABASE_NAME: postgres
       PACT_BROKER_BASIC_AUTH_USERNAME: pactbroker
       PACT_BROKER_BASIC_AUTH_PASSWORD: pactbroker
+    # The Pact Broker provides a healthcheck endpoint which we will use to wait
+    # for it to become available before starting up
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "--tries=1", "--spider", "http://pactbroker:pactbroker@localhost:9292/diagnostic/status/heartbeat" ]
+      interval: 1s
+      timeout: 2s
+      retries: 5
 
   # An NGINX reverse proxy in front of the Broker on port 8443, to be able to
   # terminate with SSL
@@ -44,3 +51,7 @@ services:
       - ./ssl:/etc/nginx/ssl
     ports:
       - "8443:443"
+    restart: always
+    depends_on:
+      broker_app:
+        condition: service_healthy

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -11,6 +11,7 @@ from pact.matchers import Term
 from pact.constants import MOCK_SERVICE_PATH
 from pact.pact import Pact, FromTerms, Request, Response
 from pact import pact as pact
+from pact.verify_wrapper import PactException
 
 
 class PactTestCase(TestCase):
@@ -557,6 +558,25 @@ class PactContextManagerTestCase(PactTestCase):
 
         self.mock_setup.assert_called_once_with(pact)
         self.assertFalse(self.mock_verify.called)
+
+
+class PactContextManagerSetupTestCase(PactTestCase):
+    def test_definition_without_description(self):
+        # Description (populated from "given") is listed in the MANDATORY_FIELDS.
+        # Make sure if it isn't there that an exception is raised
+        pact = Pact(self.consumer, self.provider)
+        (pact.given("A request without a description")
+            .with_request('GET', '/path')
+            .will_respond_with(200, body='success'))
+
+        self.assertEqual(len(pact._interactions), 1)
+
+        self.assertTrue('description' not in pact._interactions[0])
+
+        # By using "with", __enter__ will call the setup method that will verify if this is present
+        with self.assertRaises(PactException):
+            with pact:
+                pact.verify()
 
 
 class FromTermsTestCase(TestCase):


### PR DESCRIPTION
Relating to this issue: https://github.com/pact-foundation/pact-provider-verifier/issues/74

Minor change and shouldn't happen if following examples etc but it doesn't help explain the problem currently.

Had some weirdness with docker timing I think, hence adding in the healthcheck which seems to have addressed it.