### PR TITLE
feat(matcher): Allow bytes type in from_term function

### DIFF
--- a/pact/matchers.py
+++ b/pact/matchers.py
@@ -184,7 +184,7 @@ def from_term(term):
     Parse the provided term into the JSON for the mock service.
 
     :param term: The term to be parsed.
-    :type term: None, list, dict, int, float, str, unicode, Matcher
+    :type term: None, list, dict, int, float, str, bytes, unicode, Matcher
     :return: The JSON representation for this term.
     :rtype: dict, list, str
     """

--- a/pact/matchers.py
+++ b/pact/matchers.py
@@ -190,7 +190,7 @@ def from_term(term):
     """
     if term is None:
         return term
-    elif isinstance(term, (six.string_types, int, float)):
+    elif isinstance(term, (six.string_types, six.binary_type, int, float)):
         return term
     elif isinstance(term, dict):
         return {k: from_term(v) for k, v in term.items()}

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -135,6 +135,9 @@ class FromTermTestCase(TestCase):
     def test_float(self):
         self.assertEqual(from_term(3.14), 3.14)
 
+    def test_bytes(self):
+        self.assertEqual(from_term(b'testing'), b'testing')
+
     def test_list(self):
         term = [1, 123, 'sample']
         self.assertEqual(from_term(term), term)


### PR DESCRIPTION
Closes https://github.com/pact-foundation/pact-python/issues/241, wherein using bytes is not a valid option for either request or response content.