### PR TITLE
chore: update PACT_STANDALONE_VERSION to 1.88.83

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.command.sdist import sdist as sdist_orig
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '1.88.77'
+PACT_STANDALONE_VERSION = '1.88.83'
 PACT_STANDALONE_SUFFIXES = ['osx.tar.gz',
                             'linux-x86_64.tar.gz',
                             'linux-x86.tar.gz',


### PR DESCRIPTION
See changelog [here](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md)

> [](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features)v1.88.83 (2022-03-15)
Features
gems
update to pact_broker-client (1.59.0) ([142fdd6](https://github.com/pact-foundation/pact-ruby-standalone/commit/142fdd6)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#v18882-2022-02-21)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features-1))

> v1.88.82 (2022-02-21)
Features
gems
update to pact (1.62.0) ([eb8ae0f](https://github.com/pact-foundation/pact-ruby-standalone/commit/eb8ae0f)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#v18881-2021-12-16)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features-2))

> v1.88.81 (2021-12-16)
Features
gems
update to pact (1.61.0) ([f43f171](https://github.com/pact-foundation/pact-ruby-standalone/commit/f43f171)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#v18880-2021-11-13)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features-3))

> v1.88.80 (2021-11-13)
Features
gems
update to pact_broker-client (1.58.0) ([93cfe93](https://github.com/pact-foundation/pact-ruby-standalone/commit/93cfe93)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#v18879-2021-11-05)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features-4))

> v1.88.79 (2021-11-05)
Features
gems
update to pact_broker-client (1.57.0) ([280b93e](https://github.com/pact-foundation/pact-ruby-standalone/commit/280b93e)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#v18878-2021-10-27)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features-5))

> v1.88.78 (2021-10-27)
Features
gems
update to pact-provider-verifier (1.36.1) ([e4fafbc](https://github.com/pact-foundation/pact-ruby-standalone/commit/e4fafbc)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#v18877-2021-10-08)[](https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features-6))

> v1.88.77 (2021-10-08)
Features
gems
update to pact_broker-client (1.56.0) ([8f7f1b7](https://github.com/pact-foundation/pact-ruby-standalone/commit/8f7f1b7))