### PR TITLE
fix: call kill instead of terminate in message_provider

### DIFF
--- a/pact/message_provider.py
+++ b/pact/message_provider.py
@@ -86,7 +86,7 @@ class MessageProvider(object):
         """Wait for server to finish, or raise exception after timeout."""
         retry = 20
         while True:
-            self._process.terminate()
+            self._process.kill()
             time.sleep(0.1)
             try:
                 assert not self._process.is_alive()


### PR DESCRIPTION
Closes #294 

When run pact tests inside fresh docker container `_wait_for_server_stop` function throwing an `AssertionError` because process is not stopped. Looks like `SIGTERM` signal is captured by another process. `process.kill()` which sends `SIGKILL` works.