### PR TITLE
feat: Support publish pact with branch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 ignore = E226,E302,E41,W503
 max-line-length = 160
-max-complexity = 10
+max-complexity = 15
 exclude = .git,venv,.venv,.tox,.pytest_cache,.direnv

--- a/pact/broker.py
+++ b/pact/broker.py
@@ -49,7 +49,7 @@ class Broker():
         return name.lower().replace(' ', '_')
 
     def publish(self, consumer_name, version, pact_dir=None,
-                tag_with_git_branch=None, consumer_tags=None):
+                tag_with_git_branch=None, consumer_tags=None, branch=None):
         """Publish the generated pact files to the specified pact broker."""
         if self.broker_base_url is None \
                 and "PACT_BROKER_BASE_URL" not in os.environ:
@@ -84,6 +84,9 @@ class Broker():
         if consumer_tags is not None:
             for tag in consumer_tags:
                 command.extend(['-t', tag])
+
+        if branch:
+            command.extend(['--branch={}'.format(branch)])
 
         log.debug(f"PactBroker publish command: {command}")
 

--- a/pact/broker.py
+++ b/pact/broker.py
@@ -49,7 +49,7 @@ class Broker():
         return name.lower().replace(' ', '_')
 
     def publish(self, consumer_name, version, pact_dir=None,
-                tag_with_git_branch=None, consumer_tags=None, branch=None, build_url=None):
+                tag_with_git_branch=None, consumer_tags=None, branch=None, build_url=None, auto_detect_version_properties=None):
         """Publish the generated pact files to the specified pact broker."""
         if self.broker_base_url is None \
                 and "PACT_BROKER_BASE_URL" not in os.environ:
@@ -90,6 +90,9 @@ class Broker():
 
         if build_url:
             command.extend(['--build-url={}'.format(build_url)])
+
+        if auto_detect_version_properties is True:
+            command.append('--auto-detect-version-properties')
 
         log.debug(f"PactBroker publish command: {command}")
 

--- a/pact/broker.py
+++ b/pact/broker.py
@@ -49,7 +49,7 @@ class Broker():
         return name.lower().replace(' ', '_')
 
     def publish(self, consumer_name, version, pact_dir=None,
-                tag_with_git_branch=None, consumer_tags=None, branch=None):
+                tag_with_git_branch=None, consumer_tags=None, branch=None, build_url=None):
         """Publish the generated pact files to the specified pact broker."""
         if self.broker_base_url is None \
                 and "PACT_BROKER_BASE_URL" not in os.environ:
@@ -87,6 +87,9 @@ class Broker():
 
         if branch:
             command.extend(['--branch={}'.format(branch)])
+
+        if build_url:
+            command.extend(['--build-url={}'.format(build_url)])
 
         log.debug(f"PactBroker publish command: {command}")
 

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -16,7 +16,7 @@ class Consumer(object):
     """
 
     def __init__(self, name, service_cls=Pact, tags=None,
-                 tag_with_git_branch=False, version='0.0.0', branch=None, build_url=None, auto_detect_version_properties=True):
+                 tag_with_git_branch=False, version='0.0.0', branch=None, build_url=None, auto_detect_version_properties=False):
         """
         Create the Consumer class.
 
@@ -44,7 +44,7 @@ class Consumer(object):
         :param auto_detect_version_properties: Automatically detect the repository branch from known CI,
             environment variables or git CLI. Supports Buildkite, Circle CI, Travis CI, GitHub Actions,
             Jenkins, Hudson, AppVeyor, GitLab, CodeShip, Bitbucket and Azure DevOps.'.
-            Defaults to True.
+            Defaults to False.
         :type auto_detect_version_properties: bool
         """
         self.name = name

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -16,7 +16,7 @@ class Consumer(object):
     """
 
     def __init__(self, name, service_cls=Pact, tags=None,
-                 tag_with_git_branch=False, version='0.0.0', branch=None):
+                 tag_with_git_branch=False, version='0.0.0', branch=None, build_url=None):
         """
         Create the Consumer class.
 
@@ -39,6 +39,8 @@ class Consumer(object):
             publishing pacts to a pact broker. Defaults to '0.0.0'
         :param branch: The branch of this Consumer.
         :type name: str
+        :param build_url: The build URL that created the pact.
+        :type name: str
         """
         self.name = name
         self.service_cls = service_cls
@@ -46,6 +48,7 @@ class Consumer(object):
         self.tag_with_git_branch = tag_with_git_branch
         self.version = version
         self.branch = branch
+        self.build_url = build_url
 
     def has_pact_with(self, provider, host_name='localhost', port=1234,
                       log_dir=None, ssl=False, sslcert=None, sslkey=None,

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -16,7 +16,7 @@ class Consumer(object):
     """
 
     def __init__(self, name, service_cls=Pact, tags=None,
-                 tag_with_git_branch=False, version='0.0.0', branch=None, build_url=None):
+                 tag_with_git_branch=False, version='0.0.0', branch=None, build_url=None, auto_detect_version_properties=True):
         """
         Create the Consumer class.
 
@@ -41,6 +41,11 @@ class Consumer(object):
         :type name: str
         :param build_url: The build URL that created the pact.
         :type name: str
+        :param auto_detect_version_properties: Automatically detect the repository branch from known CI,
+            environment variables or git CLI. Supports Buildkite, Circle CI, Travis CI, GitHub Actions,
+            Jenkins, Hudson, AppVeyor, GitLab, CodeShip, Bitbucket and Azure DevOps.'.
+            Defaults to False.
+        :type auto_detect_version_properties: bool
         """
         self.name = name
         self.service_cls = service_cls
@@ -49,6 +54,7 @@ class Consumer(object):
         self.version = version
         self.branch = branch
         self.build_url = build_url
+        self.auto_detect_version_properties = auto_detect_version_properties
 
     def has_pact_with(self, provider, host_name='localhost', port=1234,
                       log_dir=None, ssl=False, sslcert=None, sslkey=None,

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -16,7 +16,7 @@ class Consumer(object):
     """
 
     def __init__(self, name, service_cls=Pact, tags=None,
-                 tag_with_git_branch=False, version='0.0.0'):
+                 tag_with_git_branch=False, version='0.0.0', branch=None):
         """
         Create the Consumer class.
 
@@ -37,12 +37,15 @@ class Consumer(object):
         :type tag_with_git_branch: bool
         :param version: The version of this Consumer. This will be used when
             publishing pacts to a pact broker. Defaults to '0.0.0'
+        :param branch: The branch of this Consumer.
+        :type name: str
         """
         self.name = name
         self.service_cls = service_cls
         self.tags = tags
         self.tag_with_git_branch = tag_with_git_branch
         self.version = version
+        self.branch = branch
 
     def has_pact_with(self, provider, host_name='localhost', port=1234,
                       log_dir=None, ssl=False, sslcert=None, sslkey=None,

--- a/pact/consumer.py
+++ b/pact/consumer.py
@@ -38,13 +38,13 @@ class Consumer(object):
         :param version: The version of this Consumer. This will be used when
             publishing pacts to a pact broker. Defaults to '0.0.0'
         :param branch: The branch of this Consumer.
-        :type name: str
+        :type branch: str
         :param build_url: The build URL that created the pact.
-        :type name: str
+        :type build_url: str
         :param auto_detect_version_properties: Automatically detect the repository branch from known CI,
             environment variables or git CLI. Supports Buildkite, Circle CI, Travis CI, GitHub Actions,
             Jenkins, Hudson, AppVeyor, GitLab, CodeShip, Bitbucket and Azure DevOps.'.
-            Defaults to False.
+            Defaults to True.
         :type auto_detect_version_properties: bool
         """
         self.name = name

--- a/pact/message_consumer.py
+++ b/pact/message_consumer.py
@@ -22,6 +22,9 @@ class MessageConsumer(object):
         tags=None,
         tag_with_git_branch=False,
         version="0.0.0",
+        branch=None,
+        build_url=None,
+        auto_detect_version_properties=False
     ):
         """
         Create the Message Consumer class.
@@ -43,12 +46,24 @@ class MessageConsumer(object):
         :type tag_with_git_branch: bool
         :param version: The version of this Consumer. This will be used when
             publishing pacts to a pact broker. Defaults to '0.0.0'
+        :param branch: The branch of this Consumer.
+        :type branch: str
+        :param build_url: The build URL that created the pact.
+        :type build_url: str
+        :param auto_detect_version_properties: Automatically detect the repository branch from known CI,
+            environment variables or git CLI. Supports Buildkite, Circle CI, Travis CI, GitHub Actions,
+            Jenkins, Hudson, AppVeyor, GitLab, CodeShip, Bitbucket and Azure DevOps.'.
+            Defaults to False.
+        :type auto_detect_version_properties: bool
         """
         self.name = name
         self.service_cls = service_cls
         self.tags = tags
         self.tag_with_git_branch = tag_with_git_branch
         self.version = version
+        self.branch = branch
+        self.build_url = build_url
+        self.auto_detect_version_properties = auto_detect_version_properties
 
     def has_pact_with(
         self,

--- a/pact/message_pact.py
+++ b/pact/message_pact.py
@@ -208,4 +208,7 @@ class MessagePact(Broker):
                 pact_dir=self.pact_dir,
                 tag_with_git_branch=self.consumer.tag_with_git_branch,
                 consumer_tags=self.consumer.tags,
+                branch=self.consumer.branch,
+                build_url=self.consumer.build_url,
+                auto_detect_version_properties=self.consumer.auto_detect_version_properties
             )

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -246,7 +246,8 @@ class Pact(Broker):
                 tag_with_git_branch=self.consumer.tag_with_git_branch,
                 consumer_tags=self.consumer.tags,
                 branch=self.consumer.branch,
-                pact_dir=self.pact_dir
+                pact_dir=self.pact_dir,
+                build_url=self.consumer.build_url
             )
 
     def upon_receiving(self, scenario):

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -247,7 +247,8 @@ class Pact(Broker):
                 consumer_tags=self.consumer.tags,
                 branch=self.consumer.branch,
                 pact_dir=self.pact_dir,
-                build_url=self.consumer.build_url
+                build_url=self.consumer.build_url,
+                auto_detect_version_properties=self.consumer.auto_detect_version_properties
             )
 
     def upon_receiving(self, scenario):

--- a/pact/pact.py
+++ b/pact/pact.py
@@ -245,6 +245,7 @@ class Pact(Broker):
                 self.consumer.version,
                 tag_with_git_branch=self.consumer.tag_with_git_branch,
                 consumer_tags=self.consumer.tags,
+                branch=self.consumer.branch,
                 pact_dir=self.pact_dir
             )
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -152,3 +152,18 @@ class BrokerTestCase(TestCase):
             '--broker-base-url=http://localhost',
             './TestConsumer-TestProvider.json',
             '--branch=consumer-branch'])
+
+    def test_buildUrl_publish(self):
+        broker = Broker(broker_base_url="http://localhost")
+
+        broker.publish("TestConsumer",
+                       "2.0.1",
+                       build_url='http://ci',
+                       pact_dir='.')
+
+        self.mock_Popen.assert_called_once_with([
+            BROKER_CLIENT_PATH, 'publish',
+            '--consumer-app-version=2.0.1',
+            '--broker-base-url=http://localhost',
+            './TestConsumer-TestProvider.json',
+            '--build-url=http://ci'])

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -153,7 +153,7 @@ class BrokerTestCase(TestCase):
             './TestConsumer-TestProvider.json',
             '--branch=consumer-branch'])
 
-    def test_buildUrl_publish(self):
+    def test_build_url_publish(self):
         broker = Broker(broker_base_url="http://localhost")
 
         broker.publish("TestConsumer",

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -137,3 +137,18 @@ class BrokerTestCase(TestCase):
             './TestConsumer-TestProvider.json',
             '-t', 'tag1',
             '-t', 'tag2'])
+
+    def test_branch_publish(self):
+        broker = Broker(broker_base_url="http://localhost")
+
+        broker.publish("TestConsumer",
+                       "2.0.1",
+                       branch='consumer-branch',
+                       pact_dir='.')
+
+        self.mock_Popen.assert_called_once_with([
+            BROKER_CLIENT_PATH, 'publish',
+            '--consumer-app-version=2.0.1',
+            '--broker-base-url=http://localhost',
+            './TestConsumer-TestProvider.json',
+            '--branch=consumer-branch'])

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -167,3 +167,18 @@ class BrokerTestCase(TestCase):
             '--broker-base-url=http://localhost',
             './TestConsumer-TestProvider.json',
             '--build-url=http://ci'])
+
+    def test_auto_detect_version_properties_publish(self):
+        broker = Broker(broker_base_url="http://localhost")
+
+        broker.publish("TestConsumer",
+                       "2.0.1",
+                       auto_detect_version_properties=True,
+                       pact_dir='.')
+
+        self.mock_Popen.assert_called_once_with([
+            BROKER_CLIENT_PATH, 'publish',
+            '--consumer-app-version=2.0.1',
+            '--broker-base-url=http://localhost',
+            './TestConsumer-TestProvider.json',
+            '--auto-detect-version-properties'])

--- a/tests/test_message_pact.py
+++ b/tests/test_message_pact.py
@@ -146,13 +146,24 @@ class MessagePactContextManagerTestCase(MessagePactTestCase):
     def test_successful(self):
         pact = MessagePact(
             self.consumer, self.provider, publish_to_broker=True,
-            broker_base_url='http://localhost', broker_username='username', broker_password='password')
+            broker_base_url='http://localhost', broker_username='username', broker_password='password',
+            pact_dir='some_dir')
 
         with pact:
             pass
 
         self.write_to_pact_file.assert_called_once()
-        self.mock_publish.assert_called_once()
+        self.mock_publish.assert_called_once_with(
+            pact,
+            'TestConsumer',
+            '0.0.0',
+            auto_detect_version_properties=False,
+            branch=None,
+            build_url=None,
+            consumer_tags=None,
+            pact_dir='some_dir',
+            tag_with_git_branch=False
+        )
 
     def test_context_raises_error(self):
         pact = MessagePact(

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -392,7 +392,8 @@ class PactStartShutdownServerTestCase(TestCase):
             tag_with_git_branch=False,
             pact_dir='some_dir',
             branch=None,
-            build_url=None)
+            build_url=None,
+            auto_detect_version_properties=True)
 
     def test_stop_fails_posix(self):
         self.mock_platform.return_value = 'Linux'

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -393,7 +393,7 @@ class PactStartShutdownServerTestCase(TestCase):
             pact_dir='some_dir',
             branch=None,
             build_url=None,
-            auto_detect_version_properties=True)
+            auto_detect_version_properties=False)
 
     def test_stop_fails_posix(self):
         self.mock_platform.return_value = 'Linux'

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -390,7 +390,8 @@ class PactStartShutdownServerTestCase(TestCase):
             'abc',
             consumer_tags=None,
             tag_with_git_branch=False,
-            pact_dir='some_dir')
+            pact_dir='some_dir',
+            branch=None)
 
     def test_stop_fails_posix(self):
         self.mock_platform.return_value = 'Linux'

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -391,7 +391,8 @@ class PactStartShutdownServerTestCase(TestCase):
             consumer_tags=None,
             tag_with_git_branch=False,
             pact_dir='some_dir',
-            branch=None)
+            branch=None,
+            build_url=None)
 
     def test_stop_fails_posix(self):
         self.mock_platform.return_value = 'Linux'


### PR DESCRIPTION
## Feature description:
https://github.com/pact-foundation/pact-python/issues/268

## Details:
- Support publishing pacts with branch and a build_url. 
- Use auto_detect_version_properties flag to read branch information from CI. ~~Enable it by default~~

## Actual pacts published with branch:
[broker url](https://bethtest.test.pactflow.io/overview/provider/User%20Service/consumer/UserServiceClient)