### PR TITLE
chore(test): fix consumer message test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ messaging:
 
 
 .PHONY: examples
-examples: consumer flask fastapi messaging
+examples: messaging
 
 
 .PHONY: package

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ messaging:
 
 
 .PHONY: examples
-examples: messaging
+examples: consumer flask fastapi messaging
 
 
 .PHONY: package

--- a/examples/message/tests/consumer/test_message_consumer.py
+++ b/examples/message/tests/consumer/test_message_consumer.py
@@ -133,7 +133,6 @@ def test_publish_to_broker(pact):
 
     `pytest tests/consumer/test_message_consumer.py::test_publish_pact_to_broker --publish-pact 2`
     """
-    cleanup_json(PACT_FILE)
 
     expected_event = {
         "event": "ObjectCreated:Delete",


### PR DESCRIPTION
Current consumer message example publishes pact with the same version number twice, update the fixture to ensure pact only publish once.