### PR TITLE
add support for Python 3.11

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
 
     steps:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 Click>=2.0.0
-coverage==5.4
+coverage==6.0.2
 Flask==1.1.4
 configparser==3.5.0
 flake8==3.8.3
@@ -9,7 +9,7 @@ pycodestyle==2.6.0
 pydocstyle==4.0.1
 tox==3.14.0
 pytest==7.1.3
-pytest-cov==2.11.1
+pytest-cov==3.0.0
 requests>=2.26.0
 tox-travis==0.8
 urllib3>=1.26.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{36,37,38,39,310}-{test,install}
+envlist=py{36,37,38,39,310,311}-{test,install}
 [testenv]
 deps=
     test: -rrequirements_dev.txt


### PR DESCRIPTION
there was one deprecation warning when I ran `tox -e py311` it was related to an old `coverage` version, so updated it to a newer one, where it was fixed 🙂 