### PR TITLE
feat: adds matchers to content

### DIFF
--- a/pact/message_pact.py
+++ b/pact/message_pact.py
@@ -7,7 +7,7 @@ from subprocess import Popen
 
 from .broker import Broker
 from .constants import MESSAGE_PATH
-from .matchers import from_term
+from .matchers import Term, from_term, get_generated_values
 
 
 class MessagePact(Broker):
@@ -137,7 +137,10 @@ class MessagePact(Broker):
         :rtype: Pact
         """
         self._insert_message_if_complete()
-        self._messages[0]['contents'] = from_term(contents)
+        if any(isinstance(value, Term) for value in contents.values()):
+            self._messages[0]['contents'] = get_generated_values(contents)
+        else:
+            self._messages[0]['contents'] = from_term(contents)
         return self
 
     def expects_to_receive(self, description):

--- a/tests/test_message_pact.py
+++ b/tests/test_message_pact.py
@@ -82,6 +82,37 @@ class MessagePactTestCase(TestCase):
 
         self.assertTrue(target._messages[0]['metaData']['some-header'], 'Pact::Term')
 
+    def test_definition_with_matchers_in_content(self):
+        target = MessagePact(self.consumer, self.provider)
+        (
+            target
+            .given('there is an alligator named John')
+            .expects_to_receive('an alligator message')
+            .with_content({'name': 'John', 'document_name': 'sample_document.doc', 'document_style': Term('prose|docs', 'prose')})
+            .with_metadata({'contentType': 'application/json',
+                            'source': 'legacy_api',
+                            'some-header': Term('\\d+-\\d+-\\d+T\\d+:\\d+:\\d+', '2022-02-15T20:16:01')})
+        )
+
+        self.assertEqual(len(target._messages), 1)
+
+        self.assertEqual(
+            target._messages[0]['providerStates'],
+            [{'name': 'there is an alligator named John'}])
+
+        self.assertEqual(
+            target._messages[0]['description'],
+            'an alligator message')
+
+        self.assertEqual(
+            target._messages[0]['contents'],
+            {'name': 'John', 'document_name': 'sample_document.doc', 'document_style': 'prose'})
+
+        self.assertTrue({'contentType': 'application/json', 'source': 'legacy_api'}.items()
+                        <= target._messages[0]['metaData'].items())
+
+        self.assertTrue(target._messages[0]['metaData']['some-header'], 'Pact::Term')
+
     def test_insert_new_message_once_required_attributes_provided(self):
         target = MessagePact(self.consumer, self.provider)
         (


### PR DESCRIPTION
Hello,
Upon testing out pact I discovered that Message Pact does not support Matchers. 
See: https://github.com/pact-foundation/pact-python/issues/308 

This commit fixes this issue by checking whether the content contains any matchers and if it does, it converts the content