### PR TITLE
Remove support for x86 linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ IS_64 = sys.maxsize > 2 ** 32
 PACT_STANDALONE_VERSION = '1.88.83'
 PACT_STANDALONE_SUFFIXES = ['osx.tar.gz',
                             'linux-x86_64.tar.gz',
-                            'linux-x86.tar.gz',
                             'win32.zip']
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Fixes failing build here: https://github.com/pact-foundation/pact-python/pull/319

See https://github.com/pact-foundation/pact-ruby-standalone/pull/75

Travelling ruby has deprecated support for linux-x86 (x86_64 is still supported), so that's been removed from the created packages. 

This PR essentially drops support for linux x86. 

This _probably_ ought to be a major version bump, but I'll leave that to the maintainer to decide. I suspect not many people use this architecture.
