### PR TITLE
feat: Enhance provider states for pact-message

### DIFF
--- a/pact/message_pact.py
+++ b/pact/message_pact.py
@@ -98,22 +98,31 @@ class MessagePact(Broker):
         self._messages = []
         self._message_process = None
 
-    def given(self, provider_states):
+    def given(self, name, params=None):
         """
         Define the provider state for this pact.
 
         When the provider verifies this contract, they will use this field to
         setup pre-defined data that will satisfy the response expectations.
 
-        :param provider_state: The short sentence that is unique to describe
-            the provider state for this contract.
-        :type provider_state: basestring
+        :param name: The short sentence that is unique to describe the provider
+        state for this contract.
+        :type name: basestring
+        :param params: Additional arguments necessary to set the porovider state
+        :type params: dict
         :rtype: Pact
         """
         self._insert_message_if_complete()
 
-        state = [{"name": "{}".format(provider_states)}]
-        self._messages[0]['providerStates'] = state
+        provider_state = {'name': "{}".format(name)}
+        if params:
+            provider_state['params'] = from_term(params)
+
+        if 'providerStates' not in self._messages[0]:
+            self._messages[0]['providerStates'] = [provider_state]
+        else:
+            self._messages[0]['providerStates'].append(provider_state)
+
         return self
 
     def with_metadata(self, metadata):

--- a/pact/message_pact.py
+++ b/pact/message_pact.py
@@ -108,7 +108,7 @@ class MessagePact(Broker):
         :param name: The short sentence that is unique to describe the provider
         state for this contract.
         :type name: basestring
-        :param params: Additional arguments necessary to set the porovider state
+        :param params: Additional arguments necessary to set the provider state
         :type params: dict
         :rtype: Pact
         """
@@ -116,7 +116,7 @@ class MessagePact(Broker):
 
         provider_state = {'name': "{}".format(name)}
         if params:
-            provider_state['params'] = from_term(params)
+            provider_state['params'] = params
 
         if 'providerStates' not in self._messages[0]:
             self._messages[0]['providerStates'] = [provider_state]

--- a/tests/test_message_pact.py
+++ b/tests/test_message_pact.py
@@ -82,6 +82,60 @@ class MessagePactTestCase(TestCase):
 
         self.assertTrue(target._messages[0]['metaData']['some-header'], 'Pact::Term')
 
+    def test_definition_multiple_provider_states(self):
+        target = MessagePact(self.consumer, self.provider)
+        (
+            target
+            .given('there is an alligator named John',
+                params={'color':'green', 'weight_kg': 130, 'lenght_m': 1.95}
+            )
+            .given('there is an spider named Jack',
+                params={'color':'mostly black', 'weight_kg': 0.009, 'lenght_m': 0.05}
+            )
+            .expects_to_receive('an alligator message')
+            .with_content({'name': 'John', 'document_name': 'sample_document.doc'})
+            .with_metadata({'contentType': 'application/json',
+                            'source': 'legacy_api',
+                            'some-header': Term('\\d+-\\d+-\\d+T\\d+:\\d+:\\d+', '2022-02-15T20:16:01')})
+        )
+
+        self.assertEqual(len(target._messages), 1)
+
+        self.assertEqual(
+            target._messages[0]['providerStates'],
+            [
+                {
+                    'name': 'there is an alligator named John',
+                    'params': {
+                        'color':'green',
+                        'weight_kg': 130,
+                        'lenght_m': 1.95
+                    }
+                },
+                {
+                    'name': 'there is an spider named Jack',
+                    'params': {
+                        'color':'mostly black',
+                        'weight_kg': 0.009,
+                        'lenght_m': 0.05
+                    }
+                }
+            ]
+        )
+
+        self.assertEqual(
+            target._messages[0]['description'],
+            'an alligator message')
+
+        self.assertEqual(
+            target._messages[0]['contents'],
+            {'name': 'John', 'document_name': 'sample_document.doc'})
+
+        self.assertTrue({'contentType': 'application/json', 'source': 'legacy_api'}.items()
+                        <= target._messages[0]['metaData'].items())
+
+        self.assertTrue(target._messages[0]['metaData']['some-header'], 'Pact::Term')
+
     def test_insert_new_message_once_required_attributes_provided(self):
         target = MessagePact(self.consumer, self.provider)
         (

--- a/tests/test_message_pact.py
+++ b/tests/test_message_pact.py
@@ -87,11 +87,9 @@ class MessagePactTestCase(TestCase):
         (
             target
             .given('there is an alligator named John',
-                params={'color':'green', 'weight_kg': 130, 'lenght_m': 1.95}
-            )
+                   params={'color': 'green', 'weight_kg': 130, 'length_m': 1.95})
             .given('there is an spider named Jack',
-                params={'color':'mostly black', 'weight_kg': 0.009, 'lenght_m': 0.05}
-            )
+                   params={'color': 'mostly black', 'weight_kg': 0.009, 'length_m': 0.05})
             .expects_to_receive('an alligator message')
             .with_content({'name': 'John', 'document_name': 'sample_document.doc'})
             .with_metadata({'contentType': 'application/json',
@@ -107,17 +105,17 @@ class MessagePactTestCase(TestCase):
                 {
                     'name': 'there is an alligator named John',
                     'params': {
-                        'color':'green',
+                        'color': 'green',
                         'weight_kg': 130,
-                        'lenght_m': 1.95
+                        'length_m': 1.95
                     }
                 },
                 {
                     'name': 'there is an spider named Jack',
                     'params': {
-                        'color':'mostly black',
+                        'color': 'mostly black',
                         'weight_kg': 0.009,
-                        'lenght_m': 0.05
+                        'length_m': 0.05
                     }
                 }
             ]


### PR DESCRIPTION
* feat: allow multiple provider states to be defined in a pact

* feat: allow additional parameters to be passed in the provider state

Signed-off-by: Nuno Frias <nsfrias@gmail.com>