### PR TITLE
fix: actualize doc on how to make contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ Please provide the following information with your issue to enable us to respond
 - The relevant versions of the packages you are using.
 - The steps to recreate your issue.
 - The full stacktrace if there is an exception.
-- An executable code example where possible. You can fork this repository and use the [e2e] directory to quickly recreate your issue.
+- An executable code example where possible. You can fork this repository and
+  use the [examples] directory to quickly recreate your issue.
 
 # Contributing
 
@@ -24,24 +25,27 @@ might impact other work that is in flight.
 We also appreciate it if you take the time to update and write tests for any changes
 you submit.
 
-[e2e]: https://github.com/pact-foundation/pact-python/tree/master/e2e
+[e2e]: https://github.com/pact-foundation/pact-python/tree/master/examples
 
 ## Commit messages
 
-Pact Python is adopting the Conventional Changelog commit message conventions. Please ensure you follow the guidelines, we don't want to be that person, but the commit messages are very important to the automation of our release process.
+Pact Python is adopting the Conventional Changelog commit message conventions.
+Please ensure you follow the guidelines, we don't want to be that person, but
+the commit messages are very important to the automation of our release process.
 
 Take a look at the git history (git log) to get the gist of it.
 
 If you'd like to get some CLI assistance there is a node npm package. Example usage is:
 
 ```
-npm install commitizen -g
-npm i -g cz-conventional-changelog
+npm install -g commitizen
+npm install -g cz-conventional-changelog
 ```
 
-git cz to commit and commitizen will guide you.
+`git cz` to commit and `commitizen` will guide you.
 
-There is a pypi package that does similar [commitizen]: https://pypi.org/project/commitizen/. This would make a great feature to add! There is a check on the travis build that your commits follow this convention. On creating a PR any commits that don't will instantly fail the build and you will have to rename them.
+There is a pypi package that does similar [commitizen]: https://pypi.org/project/commitizen/.
+This would make a great feature to add!
 
 ## Running the tests
 
@@ -49,16 +53,27 @@ You can run the tests locally with `make test`, this will run the tests with `to
 
 You will need `pyenv` to test on different versions `3.6`, `3.7`, `3.8`, `3.9`, `3.10`
 
-`pyenv install 3.6.15 3.7.13 3.8.13 3.9.14 3.10.6` - Download and install python versions
-`pyenv local 3.6.15 3.8.13 3.7.13 3.9.14 3.10.6` - Set these versions locally for the project
-`make test` - Run the tests
+Download and install python versions:
+```
+pyenv install 3.6.15 3.7.16 3.8.16 3.9.16 3.10.10
+```
 
-### MacOS Setup Guide
+Set these versions locally for the project:
+```
+pyenv local 3.6.15 3.7.16 3.8.16 3.9.16 3.10.10
+```
 
-See the following guides to setup `Python` and configure `pyenv` on your Mac.
+Run the tests:
+```
+make test
+```
 
-- https://yellowdesert.consulting/2018/02/04/python-on-mac-one-of-the-good-ways/
-- https://yellowdesert.consulting/2020/10/24/tox-testing-multiple-python-versions-with-pyenv/
+### macOS Setup Guide
+
+See the following guides to setup Python and configure `pyenv` on your Mac.
+
+- [How to Install Python on macOS](https://realpython.com/installing-python/#how-to-install-python-on-macos)
+- [Managing Multiple Python Versions With pyenv](https://realpython.com/intro-to-pyenv/)
 
 ## Running the examples
 


### PR DESCRIPTION
Hi,

It's is an attempt to update information on how to make contributions. This patch makes the following changes:

- Replace the reference to the **`e2e`** directory with **`examples`**. The **`e2e`** directory has been deleted here https://github.com/pact-foundation/pact-python/pull/144
- Reformatted the file a bit to get rid of the horizontal scrolling
- Removed mention of Travis, which apparently has not been used by project for a very long time
- Replaced the broken links to the guides with others that will probably last longer
- Updated the Python versions of the pyenv examples