### PR TITLE
fix: replace yanked version of wheel with a more recent one

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,6 +13,6 @@ pytest-cov==2.11.1
 requests>=2.28.0
 urllib3>=1.26.12
 uvicorn>=0.19.0
-wheel==0.38.0
+wheel==0.38.4
 markupsafe==2.1.1
 httpx==0.23.1


### PR DESCRIPTION
Reason for being yanked: Circular dependency with setuptools on --no-binary=:all: