### PR TITLE
ci: add python 3.11 to test matrix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,29 +4,50 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
     strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+      # When set to true, GitHub cancels
+      # all in-progress jobs if any matrix job fails.
       fail-fast: false
 
+      matrix:
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+        os: [ ubuntu-latest ]
+
+        # These versions are no longer supported by Python team, and may
+        # eventually be dropped from GitHub Actions.
+        include:
+          - python-version: '3.6'
+            os: ubuntu-20.04
+
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements_dev.txt
+          python -m pip install -r requirements_dev.txt
+
       - name: Lint with flake8, pydocstyle
         run: |
           flake8
           pydocstyle pact
+
       - name: Test with pytest
-        run: |
-          tox -e test
+        run: tox -e test
+
       - name: Test examples
-        run: |
-          make examples
+        run: make examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,16 +56,17 @@ There is a pypi package that does similar [commitizen](https://pypi.org/project/
 
 You can run the tests locally with `make test`, this will run the tests with `tox`
 
-You will need `pyenv` to test on different versions `3.6`, `3.7`, `3.8`, `3.9`, `3.10`
+You will need `pyenv` to test on different versions `3.6`, `3.7`, `3.8`, `3.9`,
+`3.10`, `3.11`.
 
 Download and install python versions:
 ```
-pyenv install 3.6.15 3.7.16 3.8.16 3.9.16 3.10.10
+pyenv install 3.6.15 3.7.16 3.8.16 3.9.16 3.10.10 3.11.2
 ```
 
 Set these versions locally for the project:
 ```
-pyenv local 3.6.15 3.7.16 3.8.16 3.9.16 3.10.10
+pyenv local 3.6.15 3.7.16 3.8.16 3.9.16 3.10.10 3.11.2
 ```
 
 Run the tests:

--- a/examples/consumer/requirements.txt
+++ b/examples/consumer/requirements.txt
@@ -1,3 +1,6 @@
-pytest==7.1.3
-requests>=2.26.0
-testcontainers==3.3.0
+pytest==7.0.1; python_version < '3.7'
+pytest==7.1.3; python_version >= '3.7'
+requests==2.27.1; python_version < '3.7'
+requests>=2.28.0; python_version >= '3.7'
+testcontainers==3.7.0; python_version < '3.7'
+testcontainers==3.7.1; python_version >= '3.7'

--- a/examples/fastapi_provider/requirements.txt
+++ b/examples/fastapi_provider/requirements.txt
@@ -1,5 +1,9 @@
 fastapi==0.67.0
-pytest==7.1.3
-requests>=2.26.0
-uvicorn>=0.14.0
-testcontainers==3.3.0
+pytest==7.0.1; python_version < '3.7'
+pytest==7.1.3; python_version >= '3.7'
+requests==2.27.1; python_version < '3.7'
+requests>=2.28.0; python_version >= '3.7'
+uvicorn==0.16.0; python_version < '3.7'
+uvicorn>=0.19.0; python_version >= '3.7'
+testcontainers==3.7.0; python_version < '3.7'
+testcontainers==3.7.1; python_version >= '3.7'

--- a/examples/flask_provider/requirements.txt
+++ b/examples/flask_provider/requirements.txt
@@ -1,5 +1,10 @@
-Flask==1.1.4
-pytest==7.1.3
-requests>=2.26.0
-testcontainers==3.3.0
-markupsafe==2.0.1
+Flask==2.0.3; python_version < '3.7'
+Flask==2.2.2; python_version >= '3.7'
+pytest==7.0.1; python_version < '3.7'
+pytest==7.1.3; python_version >= '3.7'
+requests==2.27.1; python_version < '3.7'
+requests>=2.28.0; python_version >= '3.7'
+testcontainers==3.7.0; python_version < '3.7'
+testcontainers==3.7.1; python_version >= '3.7'
+markupsafe==2.0.1; python_version < '3.7'
+markupsafe==2.1.2; python_version >= '3.7'

--- a/examples/message/requirements.txt
+++ b/examples/message/requirements.txt
@@ -1,3 +1,6 @@
-Flask==1.1.1
-pytest==7.1.3
-requests>=2.26.0
+Flask==2.0.3; python_version < '3.7'
+Flask==2.2.2; python_version >= '3.7'
+pytest==7.0.1; python_version < '3.7'
+pytest==7.1.3; python_version >= '3.7'
+requests==2.27.1; python_version < '3.7'
+requests>=2.28.0; python_version >= '3.7'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,8 @@
-Click>=8.1.3
+Click<=8.0.4; python_version < '3.7'
+Click>=8.1.3; python_version >= '3.7'
 coverage==5.4
-Flask==2.2.2
+Flask==2.0.3; python_version < '3.7'
+Flask==2.2.2; python_version >= '3.7'
 configparser==3.5.0
 flake8==5.0.4
 mock==3.0.5
@@ -8,11 +10,17 @@ psutil==5.9.4
 pycodestyle==2.9.0
 pydocstyle==4.0.1
 tox==3.27.1
-pytest==7.1.3
+pytest==7.0.1; python_version < '3.7'
+pytest==7.1.3; python_version >= '3.7'
 pytest-cov==2.11.1
-requests>=2.28.0
+requests==2.27.1; python_version < '3.7'
+requests>=2.28.0; python_version >= '3.7'
 urllib3>=1.26.12
-uvicorn>=0.19.0
-wheel==0.38.0
-markupsafe==2.1.1
-httpx==0.23.1
+uvicorn==0.16.0; python_version < '3.7'
+uvicorn>=0.19.0; python_version >= '3.7'
+wheel==0.37.1; python_version < '3.7'
+wheel==0.40.0; python_version >= '3.7'
+markupsafe==2.0.1; python_version < '3.7'
+markupsafe==2.1.2; python_version >= '3.7'
+httpx==0.22.0; python_version < '3.7'
+httpx==0.23.3; python_version >= '3.7'

--- a/setup.py
+++ b/setup.py
@@ -218,15 +218,26 @@ def read(filename):
 
 
 dependencies = [
-    'click>=8.1.3',
     'psutil>=5.9.4',
-    'requests>=2.28.0',
     'six>=1.16.0',
     'fastapi>=0.67.0',
     'urllib3>=1.26.12',
-    'uvicorn>=0.19.0',
-    'httpx==0.23.1'
 ]
+
+if sys.version_info < (3, 7):
+    dependencies += [
+        'click<=8.0.4',
+        'httpx==0.22.0',
+        'requests==2.27.1',
+        'uvicorn==0.16.0',
+    ]
+else:
+    dependencies += [
+        'click>=8.1.3',
+        'httpx==0.23.3',
+        'requests>=2.28.0',
+        'uvicorn>=0.19.0',
+    ]
 
 # Classifiers: available ones listed at https://pypi.org/classifiers
 CLASSIFIERS = [

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ def install_ruby_app(package_bin_path: str, download_bin_path=None):
             download_ruby_app_binary(package_bin_path, binary['filename'], binary['suffix'])
             extract_ruby_app_binary(package_bin_path, package_bin_path, binary['filename'])
 
+
 def ruby_app_binary():
     """
     Determine the ruby app binary required for this OS.
@@ -208,6 +209,7 @@ def extract_ruby_app_binary(source, destination, binary):
 
             safe_extract(f, destination)
 
+
 def read(filename):
     """Read file contents."""
     path = os.path.realpath(os.path.join(os.path.dirname(__file__), filename))
@@ -224,6 +226,26 @@ dependencies = [
     'urllib3>=1.26.12',
     'uvicorn>=0.19.0',
     'httpx==0.23.1'
+]
+
+# Classifiers: available ones listed at https://pypi.org/classifiers
+CLASSIFIERS = [
+    'Development Status :: 5 - Production/Stable',
+
+    'Operating System :: OS Independent',
+
+    'Intended Audience :: Developers',
+
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+
+    'License :: OSI Approved :: MIT License',
 ]
 
 if __name__ == '__main__':
@@ -246,6 +268,8 @@ if __name__ == '__main__':
             [console_scripts]
             pact-verifier=pact.cli.verify:main
         ''',
+        classifiers=CLASSIFIERS,
+        python_requires='>=3.6,<4',
         install_requires=dependencies,
         packages=['pact', 'pact.cli'],
         package_data={'pact': ['bin/*']},

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{36,37,38,39,310}-{test,install}
+envlist=py{36,37,38,39,310,311}-{test,install}
 [testenv]
 deps=
     test: -rrequirements_dev.txt


### PR DESCRIPTION
- add python 3.11 to test matrix and setup.py
- describe classifiers and python version for pypi package
- replace yanked version of wheel with a more recent one
- use compatible dependency versions for Python 3.6

closes #311
closes #329