### PR TITLE
feat: provide ability to verify with a specific pact

### DIFF
--- a/pact/message_provider.py
+++ b/pact/message_provider.py
@@ -115,22 +115,37 @@ class MessageProvider(object):
         return_code, _ = verifier.verify_pacts(pact_files, verbose=False)
         assert (return_code == 0), f'Expected returned_code = 0, actual = {return_code}'
 
-    def verify_with_broker(self, enable_pending=False, include_wip_pacts_since=None, **kwargs):
+    def verify_with_broker(
+            self,
+            *pacts,
+            enable_pending=False,
+            include_wip_pacts_since=None,
+            **kwargs
+    ):
         """Use Broker to verify.
 
-        Args:
-            broker_username ([String]): broker username
-            broker_password ([String]): broker password
-            broker_url ([String]): url of broker
-            enable_pending ([Boolean])
-            include_wip_pacts_since ([String])
-            publish_version ([String])
-
+        :param pacts: List of pact to verify. Every pact in that list can be
+            an HTTP URI or a local file.
+        :type pacts: str
+        :param enable_pending: Allow pacts which are in pending state to be
+            verified without causing the overall task to fail.
+        :type enable_pending: bool
+        :param include_wip_pacts_since: Allow pacts that don't match given
+            consumer selectors (or tags) to  be verified, without causing the
+            overall task to fail
+        :type include_wip_pacts_since: str or None
         """
-        verifier = Verifier(provider=self.provider,
-                            provider_base_url=self._proxy_url())
+        verifier = Verifier(
+            provider=self.provider,
+            provider_base_url=self._proxy_url()
+        )
 
-        return_code, _ = verifier.verify_with_broker(enable_pending, include_wip_pacts_since, **kwargs)
+        return_code, _ = verifier.verify_with_broker(
+            *pacts,
+            enable_pending=enable_pending,
+            include_wip_pacts_since=include_wip_pacts_since,
+            **kwargs
+        )
 
         assert (return_code == 0), f'Expected returned_code = 0, actual = {return_code}'
 
@@ -147,7 +162,7 @@ class MessageProvider(object):
         Exit a Python context.
 
         Return False to cascade the exception in context manager's body.
-        Otherwise it will be supressed and the test will always pass.
+        Otherwise, it will be suppressed and the test will always pass.
         """
         if (exc_type, exc_val, exc_tb) != (None, None, None):
             if exc_type is not None:

--- a/pact/message_provider.py
+++ b/pact/message_provider.py
@@ -125,7 +125,7 @@ class MessageProvider(object):
         """Use Broker to verify.
 
         :param pacts: List of pact to verify. Every pact in that list can be
-            an HTTP URI or a local file.
+            an HTTP URI.
         :type pacts: str
         :param enable_pending: Allow pacts which are in pending state to be
             verified without causing the overall task to fail.

--- a/pact/verifier.py
+++ b/pact/verifier.py
@@ -28,10 +28,17 @@ class Verifier(object):
         return 'Verifier for {} with url {}'.format(self.provider, self.provider_base_url)
 
     def validate_publish(self, **kwargs):
-        """Validate publish has a version."""
-        if (kwargs.get('publish') is not None) and (kwargs.get('publish_version') is None):
-            # do something
-            raise Exception()
+        """Ensure the participant version is provided.
+
+        :raises Exception: When `publish_verification_results` is set,
+            but `publish_version` is not provided.
+        """
+        if not kwargs.get('publish_verification_results'):
+            return
+
+        if not kwargs.get('publish_version'):
+            raise Exception('To publish the results of verification to the '
+                            'broker version of the participant is mandatory')
 
     def verify_pacts(
             self,
@@ -70,6 +77,8 @@ class Verifier(object):
             consumer selectors (or tags) to  be verified, without causing the
             overall task to fail
         :type include_wip_pacts_since: str or None
+        :raises Exception: When `publish_verification_results` is set,
+            but `publish_version` is not provided.
         :return: Returns a tuple of two elements. The first indicates the
             status of the operation, so that 0 means success, and the second
             contains the logs of the operation.
@@ -142,7 +151,8 @@ class Verifier(object):
         :keyword str broker_token: Pact Broker bearer token.
         :keyword str broker_url: Base URL of the Pact Broker from which to
             retrieve the pacts.
-        :raises Exception: [ErrorDescription]
+        :raises Exception: When `publish_verification_results` is set,
+            but `publish_version` is not provided.
         :return: Returns a tuple of two elements. The first indicates the
             status of the operation, so that 0 means success, and the second
             contains the logs of the operation.

--- a/pact/verifier.py
+++ b/pact/verifier.py
@@ -42,7 +42,7 @@ class Verifier(object):
     ):
         """Verify pacts from the provider.
 
-        Example:
+        Usage:
 
         >>> from pact import Verifier
         >>>
@@ -106,7 +106,7 @@ class Verifier(object):
     ):
         """Use Broker to verify.
 
-        Example:
+        Usage:
 
         >>> from pact import Verifier
         >>>

--- a/pact/verifier.py
+++ b/pact/verifier.py
@@ -38,7 +38,8 @@ class Verifier(object):
 
         if not kwargs.get('publish_version'):
             raise Exception('To publish the results of verification to the '
-                            'broker version of the participant is mandatory')
+                            'broker, attribute publish_version (containing '
+                            'the provider version) must be set')
 
     def verify_pacts(
             self,
@@ -53,11 +54,9 @@ class Verifier(object):
 
         >>> from pact import Verifier
         >>>
-        >>> PROVIDER_URL = f'http://127.0.0.1:5001'
-        >>>
         >>> verifier = Verifier(
-        ...   provider='AcmeAPI',
-        ...   provider_base_url=PROVIDER_URL
+        ...   provider='UserService',
+        ...   provider_base_url='http://localhost:5001'
         ... )
         >>>
         >>> result, _ = verifier.verify_pacts(
@@ -67,8 +66,9 @@ class Verifier(object):
         >>>
         >>> assert result == 0
 
-        :param pacts: List of pact to verify. Every pact in that list can be
-            an HTTP URI or a local file.
+        :param pacts: Pacts to verify, passed as multiple comma-separated
+            paths. Every pact in that list can be an HTTP URI, a local file, or
+            a path to a local directory.
         :type pacts: str
         :param enable_pending: Allow pacts which are in pending state to be
             verified without causing the overall task to fail.
@@ -119,11 +119,9 @@ class Verifier(object):
 
         >>> from pact import Verifier
         >>>
-        >>> PROVIDER_URL = f'http://127.0.0.1:5001'
-        >>>
         >>> verifier = Verifier(
-        ...   provider='AcmeAPI',
-        ...   provider_base_url=PROVIDER_URL
+        ...   provider='UserService',
+        ...   provider_base_url='http://localhost:5001'
         ... )
         >>>
         >>> result, _ = verifier.verify_with_broker(
@@ -136,8 +134,9 @@ class Verifier(object):
         >>>
         >>> assert result == 0
 
-        :param pacts: List of pact to verify. Every pact in that list can be
-            an HTTP URI or a local file.
+        :param pacts: Pacts to verify, passed as multiple comma-separated
+            paths. Every pact in that list can be an HTTP URI, a local file, or
+            a path to a local directory.
         :type pacts: str
         :param enable_pending: Allow pacts which are in pending state to be
             verified without causing the overall task to fail.
@@ -153,9 +152,8 @@ class Verifier(object):
             retrieve the pacts.
         :raises Exception: When `publish_verification_results` is set,
             but `publish_version` is not provided.
-        :return: Returns a tuple of two elements. The first indicates the
-            status of the operation, so that 0 means success, and the second
-            contains the logs of the operation.
+        :return: Returns a tuple of the overall result (where 0 indicates
+            success), and logs produced.
         :rtype: tuple
         """
         self.validate_publish(**kwargs)

--- a/pact/verify_wrapper.py
+++ b/pact/verify_wrapper.py
@@ -36,6 +36,7 @@ def path_exists(path):
 
     return isfile(path)
 
+
 def sanitize_logs(process, verbose):
     """
     Print the logs from a process while removing Ruby stack traces.
@@ -52,6 +53,7 @@ def sanitize_logs(process, verbose):
             continue
         else:
             sys.stdout.write(line)
+
 
 def expand_directories(paths):
     """
@@ -84,7 +86,6 @@ def rerun_command():
     :rtype: str
     """
     is_windows = 'windows' in platform.platform().lower()
-    command = ''
     if is_windows:
         command = (
             'cmd.exe /v /c "'
@@ -101,6 +102,7 @@ def rerun_command():
     env = os.environ.copy()
     env['PACT_INTERACTION_RERUN_COMMAND'] = command
     return env
+
 
 class PactException(Exception):
     """PactException when input isn't valid.
@@ -122,13 +124,12 @@ class PactException(Exception):
         super().__init__(*args, **kwargs)
         self.message = args[0]
 
+
 class VerifyWrapper(object):
     """A Pact Verifier Wrapper."""
 
     def _broker_present(self, **kwargs):
-        if kwargs.get('broker_url') is None:
-            return False
-        return True
+        return kwargs.get('broker_url') is not None
 
     def _validate_input(self, pacts, **kwargs):
         if len(pacts) == 0 and not self._broker_present(**kwargs):
@@ -163,14 +164,14 @@ class VerifyWrapper(object):
         command.extend(all_pact_urls)
         command.extend(['{}={}'.format(k, v) for k, v in options.items() if v])
 
-        if (provider_app_version):
+        if provider_app_version:
             command.extend(["--provider-app-version",
                             provider_app_version])
 
-        if (kwargs.get('publish_verification_results', False) is True):
+        if kwargs.get('publish_verification_results', False) is True:
             command.extend(['--publish-verification-results'])
 
-        if (kwargs.get('verbose', False) is True):
+        if kwargs.get('verbose', False) is True:
             command.extend(['--verbose'])
 
         if enable_pending:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,25 @@ pytest==7.1.3; python_version >= '3.7'
 pytest-cov==2.11.1
 requests==2.27.1; python_version < '3.7'
 requests>=2.28.0; python_version >= '3.7'
-urllib3>=1.26.12
+# TODO: It seems requests-2.30.0 (wich uses urllib3 2.0 by default) broke our
+#       examples. I'll sort out with this a bit later.
+#
+# 1. docker.api.client.APIClient:_retrieve_server_version()
+# 2. docker/api/client.py:version()
+# 3. docker/api/daemon.py:inner()
+# 4. docker/utils/decorators.py:_get()
+# 5. docker/api/client.py:get()
+# 6. requests/sessions.py:request()
+# 7. requests/sessions.py:send()
+# 8. requests/adapters.py:urlopen() <- calls _make_request() with 'chunked' param
+# 9. urllib3/connectionpool.py:_make_request() <- TypeError: request() got an unexpected keyword argument 'chunked'
+#
+# For more see:
+# https://github.com/pact-foundation/pact-python/actions/runs/4874690954/jobs/8696170180?pr=334
+#
+# For the migration guide see:
+# https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
+urllib3>=1.26.12,<2
 uvicorn==0.16.0; python_version < '3.7'
 uvicorn>=0.19.0; python_version >= '3.7'
 wheel==0.37.1; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,10 @@ dependencies = [
     'psutil>=5.9.4',
     'six>=1.16.0',
     'fastapi>=0.67.0',
-    'urllib3>=1.26.12',
+    # TODO: sort out with the broken tests before change urllib3 upper version
+    # For the migration guide see:
+    # https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
+    'urllib3>=1.26.12,<2',
 ]
 
 if sys.version_info < (3, 7):

--- a/tests/test_message_provider.py
+++ b/tests/test_message_provider.py
@@ -63,7 +63,9 @@ class MessageProviderTestCase(TestCase):
         self.provider.verify_with_broker(**self.options)
 
         assert mock_verify_pacts.call_count == 1
-        mock_verify_pacts.assert_called_with(False, None, broker_username="test",
+        mock_verify_pacts.assert_called_with(enable_pending=False,
+                                             include_wip_pacts_since=None,
+                                             broker_username="test",
                                              broker_password="test",
                                              broker_url="http://localhost",
                                              publish_version='3',

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -83,7 +83,8 @@ class VerifierPactsTestCase(TestCase):
             )
 
         message = ('To publish the results of verification to the '
-                   'broker version of the participant is mandatory')
+                   'broker, attribute publish_version (containing '
+                   'the provider version) must be set')
         self.assertTrue(message in str(exc.exception))
 
     @patch("pact.verify_wrapper.VerifyWrapper.call_verify")

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -48,7 +48,7 @@ class VerifierPactsTestCase(TestCase):
 
     @patch("pact.verify_wrapper.VerifyWrapper.call_verify")
     @patch('pact.verifier.path_exists', return_value=True)
-    def test_verifier_with_provider_and_files_passes_consumer_selctors(self, mock_path_exists, mock_wrapper):
+    def test_verifier_with_provider_and_files_passes_consumer_selectors(self, mock_path_exists, mock_wrapper):
         mock_wrapper.return_value = (True, 'some logs')
 
         output, _ = self.verifier.verify_pacts(
@@ -76,7 +76,15 @@ class VerifierPactsTestCase(TestCase):
                                                '{"tag": "test", "latest": false}'])
 
     def test_validate_on_publish_results(self):
-        self.assertRaises(Exception, self.verifier.verify_pacts, 'path/to/pact1', publish=True)
+        with self.assertRaises(Exception) as exc:
+            self.verifier.verify_pacts(
+                'path/to/pact1',
+                publish_verification_results=True,
+            )
+
+        message = ('To publish the results of verification to the '
+                   'broker version of the participant is mandatory')
+        self.assertTrue(message in str(exc.exception))
 
     @patch("pact.verify_wrapper.VerifyWrapper.call_verify")
     @patch('pact.verifier.path_exists', return_value=True)

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -159,10 +159,16 @@ class VerifierBrokerTestCase(TestCase):
 
         mock_wrapper.return_value = (True, 'some value')
 
-        output, _ = self.verifier.verify_with_broker(**self.default_opts)
+        output, _ = self.verifier.verify_with_broker(
+            'http://broker/path/to/pact1',
+            'http://broker/path/to/pact1',
+            **self.default_opts
+        )
 
         self.assertTrue(output)
         assertVerifyCalled(mock_wrapper,
+                           'http://broker/path/to/pact1',
+                           'http://broker/path/to/pact1',
                            provider='test_provider',
                            provider_base_url='http://localhost:8888',
                            broker_password=self.broker_password,
@@ -175,7 +181,7 @@ class VerifierBrokerTestCase(TestCase):
                            include_wip_pacts_since=None)
 
     @patch("pact.verify_wrapper.VerifyWrapper.call_verify")
-    def test_verifier_and_pubish_with_broker(self, mock_wrapper):
+    def test_verifier_and_publish_with_broker(self, mock_wrapper):
 
         mock_wrapper.return_value = (True, 'some value')
 
@@ -198,7 +204,7 @@ class VerifierBrokerTestCase(TestCase):
                            )
 
     @patch("pact.verify_wrapper.VerifyWrapper.call_verify")
-    def test_verifier_with_broker_passes_consumer_selctors(self, mock_wrapper):
+    def test_verifier_with_broker_passes_consumer_selectors(self, mock_wrapper):
 
         mock_wrapper.return_value = (True, 'some value')
 


### PR DESCRIPTION
This change adds the ability to verify pacts by passing their URI to verify. The URI of the every pact can be an HTTP URI or a local file path.

Fixes #332