### PR TITLE
feat(test): add docker images for Python 3.9-3.11 for testing purposes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ docker run -it --rm -v "$(pwd)":/home pactfoundation:python311 sh
 ```
 
 This will open a container with a prompt. From the `/home` location in the
-container you can run:
+container you can run the same tests manually:
 
 ```bash
 tox -e py311-{test,install}

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ project and run:
 docker build -t pactfoundation:python311 -f docker/py311.Dockerfile .
 ```
 
-And then to run you will need:
+To then run the tests and exit, you will need:
 
 ```bash
 docker run -it --rm -v "$(pwd)":/home pactfoundation:python311

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ To build a container say for Python 3.11 change to the root directory of the
 project and run:
 
 ```bash
-docker build -t pactfoundation:python311 -f docker/py310.Dockerfile .
+docker build -t pactfoundation:python311 -f docker/py311.Dockerfile .
 ```
 
 And then to run you will need:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,37 +1,44 @@
 # Introduction
 
-This is for contributors who want to make changes and test for all different versions of python currently supported. If you don't want to set up and install all the different python versions locally (and there are some difficulties with that) you can just run them in docker using containers.
+This is for contributors who want to make changes and test for all different
+versions of python currently supported. If you don't want to set up and install
+all the different python versions locally (and there are some difficulties with
+that) you can just run them in docker using containers.
 
 # Setup
 
-To build a container say for python 3.6 change to the root directory of the project and run
+To build a container say for Python 3.11 change to the root directory of the
+project and run:
 
 ```bash
-docker build -t pactfoundation:python36 -f docker/py36.Dockerfile .
+docker build -t pactfoundation:python311 -f docker/py310.Dockerfile .
 ```
 
 And then to run you will need:
 
 ```bash
-docker run  -it -v `pwd`:/home pactfoundation:python36
+docker run -it --rm -v "$(pwd)":/home pactfoundation:python311
 ```
 
 If you need to debug you can change the command to:
 
 ```bash
-docker run  -it -v `pwd`:/home pactfoundation:python36 sh
+docker run -it --rm -v "$(pwd)":/home pactfoundation:python311 sh
 ```
 
-This will open a container with a prompt. From the /home location in the container you can run
+This will open a container with a prompt. From the `/home` location in the
+container you can run:
 
 ```bash
-tox -e py36
+tox -e py311-{test,install}
 ```
 
-In all the above if you need to run a different version change py36/python36 where appropriate. Or you can run the convenience script to build:
+In all the above if you need to run a different version change
+`py311`/`python311` where appropriate.  Or you can run the convenience script
+to build:
 
 ```bash
-docker/build.sh 38
+docker/build.sh 311
 ```
 
-where 38 is the python environment version (3.8 in this case)
+where `311` is the python environment version (3.11 in this case).

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
+
 set -eo pipefail
 
 if [ $# -ne 1 ]; then
-    echo "$0: usage: build.sh 27|36|37|38"
+    echo "$0: usage: build.sh 37|38|39|310|311"
     exit 1
 fi
 DOCKER_ENV=$1
@@ -11,4 +12,4 @@ echo "Building env ${DOCKER_ENV}"
 DOCKER_IMAGE="pactfoundation:python${DOCKER_ENV}"
 DOCKER_FILE="docker/py${DOCKER_ENV}.Dockerfile"
 
-docker build -t $DOCKER_IMAGE -f $DOCKER_FILE .
+docker build -t "$DOCKER_IMAGE" -f "$DOCKER_FILE" .

--- a/docker/py310.Dockerfile
+++ b/docker/py310.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.17
+FROM python:3.10-alpine3.17
 
 ENV PIP_ROOT_USER_ACTION=ignore
 
@@ -13,4 +13,4 @@ RUN apk update \
     && pip install --progress-bar=off --upgrade psutil \
     && pip install --progress-bar=off --use-pep517 -r requirements_dev.txt
 
-CMD ["tox", "-e", "py38-{test,install}"]
+CMD ["tox", "-e", "py310-{test,install}"]

--- a/docker/py311.Dockerfile
+++ b/docker/py311.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.17
+FROM python:3.11-alpine3.17
 
 ENV PIP_ROOT_USER_ACTION=ignore
 
@@ -13,4 +13,4 @@ RUN apk update \
     && pip install --progress-bar=off --upgrade psutil \
     && pip install --progress-bar=off --use-pep517 -r requirements_dev.txt
 
-CMD ["tox", "-e", "py38-{test,install}"]
+CMD ["tox", "-e", "py311-{test,install}"]

--- a/docker/py37.Dockerfile
+++ b/docker/py37.Dockerfile
@@ -1,15 +1,16 @@
-FROM python:3.7.9-alpine3.11
+FROM python:3.7-alpine3.17
+
+ENV PIP_ROOT_USER_ACTION=ignore
 
 WORKDIR /home
 
 COPY requirements_dev.txt .
 
-RUN apk update
-RUN apk upgrade
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache --update gcc build-base linux-headers musl-locales \
+    && pip install --progress-bar=off --upgrade pip \
+    && pip install --progress-bar=off --upgrade psutil \
+    && pip install --progress-bar=off --use-pep517 -r requirements_dev.txt
 
-RUN apk add gcc py-pip python-dev libffi-dev openssl-dev gcc libc-dev bash make
-
-RUN python -m pip install psutil
-RUN pip install -r requirements_dev.txt
-
-CMD tox -e py37
+CMD ["tox", "-e", "py37-{test,install}"]

--- a/docker/py39.Dockerfile
+++ b/docker/py39.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.17
+FROM python:3.9-alpine3.17
 
 ENV PIP_ROOT_USER_ACTION=ignore
 
@@ -13,4 +13,4 @@ RUN apk update \
     && pip install --progress-bar=off --upgrade psutil \
     && pip install --progress-bar=off --use-pep517 -r requirements_dev.txt
 
-CMD ["tox", "-e", "py38-{test,install}"]
+CMD ["tox", "-e", "py39-{test,install}"]


### PR DESCRIPTION
This pull request introduces the ability to build Docker images for Python versions 3.9, 3.10, and 3.11. Additionally, it unifies the existing images to ensure consistency and maintainability. The documentation has been proofread for clarity and accuracy, and the build instructions have been updated to reflect these new changes.