### PR TITLE
Fix CORS parameter not doing anything

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -214,6 +214,8 @@ class Pact(Broker):
             command.extend(['--sslcert', self.sslcert])
         if self.sslkey:
             command.extend(['--sslkey', self.sslkey])
+        if self.cors:
+            command.extend(['--cors'])
 
         self._process = Popen(command)
         self._wait_for_server_start()


### PR DESCRIPTION
We found that pact ignores the CORS parameter of the `Consumer.has_pact_with()` function.
If the CORS parameter is set to True `--cors=*` is appended to the list of commands for the external mock service.

The mock service itself already supports this parameter.