### PR TITLE
Feat: ARM64 Support for OSX / Linux + Windows 32 bit support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
 linux_arm64_task: 
   env:
     matrix:
-      - IMAGE: python:3.6-slim
+      # - IMAGE: python:3.6-slim  # This works locally, with cirrus run, but fails in CI
       - IMAGE: python:3.7-slim
       - IMAGE: python:3.8-slim
       - IMAGE: python:3.9-slim
@@ -31,7 +31,7 @@ macosx_arm64_task:
   env:
     PATH: ${HOME}/.pyenv/shims:${PATH}
     matrix:
-      # - PYTHON: 3.6 # This works locally, with cirrus run, but fails in CI
+      - PYTHON: 3.6
       - PYTHON: 3.7
       - PYTHON: 3.8
       - PYTHON: 3.9

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,55 @@
+BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
+  arch_check_script:
+    - uname -am
+  test_script:
+    - python --version
+    - python -m pip install --upgrade pip
+    - python -m pip install -r requirements_dev.txt
+    - python -m flake8
+    - python -m pydocstyle pact
+    - python -m tox -e test
+    # - make examples
+
+linux_arm64_task: 
+  env:
+    matrix:
+      - IMAGE: python:3.6-slim
+      - IMAGE: python:3.7-slim
+      - IMAGE: python:3.8-slim
+      - IMAGE: python:3.9-slim
+      - IMAGE: python:3.10-slim
+  arm_container:
+    image: $IMAGE
+  install_script:
+    - apt update --yes && apt install --yes gcc make
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+
+macosx_arm64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  env:
+    PATH: ${HOME}/.pyenv/shims:${PATH}
+    matrix:
+      - PYTHON: 3.6
+      - PYTHON: 3.7
+      - PYTHON: 3.8
+      - PYTHON: 3.9
+      - PYTHON: 3.10
+  install_script:
+    # Per the pyenv homebrew recommendations.
+    # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+    # - xcode-select --install  # Unnecessary on Cirrus
+    - brew update    
+    # - brew install openssl readline sqlite3 xz zlib 
+    - brew install pyenv
+    - pyenv install ${PYTHON}
+    - pyenv global ${PYTHON}
+    - pyenv rehash
+  ## To install rosetta
+    # - softwareupdate --install-rosetta --agree-to-license
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+
+
+

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ macosx_arm64_task:
   env:
     PATH: ${HOME}/.pyenv/shims:${PATH}
     matrix:
-      - PYTHON: 3.6
+      # - PYTHON: 3.6 # This works locally, with cirrus run, but fails in CI
       - PYTHON: 3.7
       - PYTHON: 3.8
       - PYTHON: 3.9

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
         # These versions are no longer supported by Python team, and may
         # eventually be dropped from GitHub Actions.
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -50,4 +50,5 @@ jobs:
         run: tox -e test
 
       - name: Test examples
+        if: runner.os == 'Linux'
         run: make examples

--- a/.github/workflows/package_and_push_to_pypi.yml
+++ b/.github/workflows/package_and_push_to_pypi.yml
@@ -9,9 +9,9 @@ jobs:
     environment: "Upload Python Package"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+ARG PYTHON_VERSION=3.6
+FROM python:$PYTHON_VERSION-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update --yes && apt install --yes gcc make
+
+WORKDIR /app
+COPY . /app
+
+RUN python -m pip install --upgrade pip
+RUN python -m pip install -r requirements_dev.txt
+RUN python -m flake8
+RUN python -m pydocstyle pact
+RUN python -m tox -e test
+
+CMD ["sh","-c","python -m tox -e test"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,30 @@
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION 3.9
+
+#Set of all dependencies needed for pyenv to work on Ubuntu
+RUN apt-get update \ 
+        && apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget ca-certificates curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev mecab-ipadic-utf8 git
+
+# Set-up necessary Env vars for PyEnv
+ENV PYENV_ROOT /root/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+
+# Install pyenv
+RUN set -ex \
+    && curl https://pyenv.run | bash \
+    && pyenv update \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
+    && pyenv rehash
+
+WORKDIR /app
+COPY . /app
+
+RUN python -m pip install --upgrade pip
+RUN python -m pip install -r requirements_dev.txt
+RUN python -m flake8
+RUN python -m pydocstyle pact
+RUN python -m tox -e test
+
+CMD ["sh","-c","python -m tox -e test"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -21,9 +21,10 @@ pact/pact.py
 pact/provider.py
 pact/verifier.py
 pact/verify_wrapper.py
-pact/bin/pact-1.88.83-linux-x86.tar.gz
-pact/bin/pact-1.88.83-linux-x86_64.tar.gz
-pact/bin/pact-1.88.83-osx.tar.gz
-pact/bin/pact-1.88.83-win32.zip
+pact/bin/pact-3.1.2.2-alpha-linux-arm64.tar.gz
+pact/bin/pact-3.1.2.2-alpha-linux-x86_64.tar.gz
+pact/bin/pact-3.1.2.2-alpha-osx-arm64.tar.gz
+pact/bin/pact-3.1.2.2-alpha-osx-x86_64.tar.gz
+pact/bin/pact-3.1.2.2-alpha-windows-x86_64.zip
 pact/cli/__init__.py
 pact/cli/verify.py

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for arch in arm64 amd64; do
+    # for version in 3.6; do 
+    for version in 3.7 3.8 3.9 3.10 3.11; do
+        docker build -t python-$arch-$version --build-arg PYTHON_VERSION=$version --platform=linux/$arch .
+        docker run -it --rm python-$arch-$version
+    done
+done

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,12 @@ from distutils.command.sdist import sdist as sdist_orig
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '1.88.83'
-PACT_STANDALONE_SUFFIXES = ['osx.tar.gz',
+PACT_STANDALONE_VERSION = '3.1.2.2-alpha'
+PACT_STANDALONE_SUFFIXES = ['osx-x86_64.tar.gz',
+                            'osx-arm64.tar.gz',
                             'linux-x86_64.tar.gz',
-                            'linux-x86.tar.gz',
-                            'win32.zip']
+                            'linux-arm64.tar.gz',
+                            'windows-x86_64.zip']
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -131,13 +132,14 @@ def ruby_app_binary():
     target_platform = platform.platform().lower()
 
     binary = ('pact-{version}-{suffix}')
-
-    if 'darwin' in target_platform or 'macos' in target_platform:
-        suffix = 'osx.tar.gz'
-    elif 'linux' in target_platform and IS_64:
-        suffix = 'linux-x86_64.tar.gz'
+    if ("darwin" in target_platform or "macos" in target_platform) and ("aarch64" in platform.machine() or "arm64" in platform.machine()):
+        suffix = 'osx-arm64.tar.gz'
+    elif ("darwin" in target_platform or "macos" in target_platform) and IS_64:
+        suffix = 'osx-x86_64.tar.gz'
+    elif 'linux' in target_platform and IS_64 and "aarch64" in platform.machine():
+        suffix = 'linux-arm64.tar.gz'
     elif 'linux' in target_platform:
-        suffix = 'linux-x86.tar.gz'
+        suffix = 'linux-x86_64.tar.gz'
     elif 'windows' in target_platform:
         suffix = 'win32.zip'
     else:
@@ -157,7 +159,7 @@ def download_ruby_app_binary(path_to_download_to, filename, suffix):
     :param filename: The filename that should be installed.
     :param suffix: The suffix of the standalone app to install.
     """
-    uri = ('https://github.com/pact-foundation/pact-ruby-standalone/releases'
+    uri = ('https://github.com/you54f/pact-ruby-standalone/releases'
            '/download/v{version}/pact-{version}-{suffix}')
 
     if sys.version_info.major == 2:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ PACT_STANDALONE_SUFFIXES = ['osx-x86_64.tar.gz',
                             'osx-arm64.tar.gz',
                             'linux-x86_64.tar.gz',
                             'linux-arm64.tar.gz',
-                            'windows-x86_64.zip']
+                            'windows-x86_64.zip',
+                            'windows-x86.zip',
+                            ]
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -140,8 +142,10 @@ def ruby_app_binary():
         suffix = 'linux-arm64.tar.gz'
     elif 'linux' in target_platform:
         suffix = 'linux-x86_64.tar.gz'
+    elif 'windows' in target_platform and IS_64:
+        suffix = 'windows-x86_64.zip'
     elif 'windows' in target_platform:
-        suffix = 'win32.zip'
+        suffix = 'windows-x86.zip'
     else:
         msg = ('Unfortunately, {} is not a supported platform. Only Linux,'
                ' Windows, and OSX are currently supported.').format(


### PR DESCRIPTION
## Testing out changes to traveling ruby to support additional platforms

### Details of changes made to travelling ruby

PR's to Travelling ruby to update the supported archs

- https://github.com/phusion/traveling-ruby/pull/132
- https://github.com/phusion/traveling-ruby/pull/133

| OS     | Ruby      | Architecture | Supported |
| -------| ------- | ------------ | --------- |
| OSX    | 3.2.2     | x86_64       | ✅         |
| OSX    | 3.2.2     | aarch64 (arm)| ✅         |
| Linux  | 3.2.2   | x86_64       | ✅         |
| Linux  | 3.2.2   | aarch64 (arm)| ✅          |
| Windows| 3.2.2 | x86_64       | ✅        |
| Windows| 3.2.2 | x86       | ✅        |
| Windows| 3.2.2 | aarch64 (via x86 emulation) |  ✅        |

Release of traveling ruby from my fork is here https://github.com/YOU54F/traveling-ruby/releases/tag/rel-20230508

### Details of changes made to pact-ruby-standalone

A fork of pact-ruby-standalone is consuming the above release in this packaging task https://github.com/YOU54F/pact-ruby-standalone/blob/win32_x86/tasks/package.rake

And was released from CI here

https://github.com/YOU54F/pact-ruby-standalone/releases/tag/v3.1.2.2-alpha

Test run in pact-ruby-standalone, building and testing the executables

https://github.com/YOU54F/pact-ruby-standalone/actions/runs/4671665215

### Details of changes made to pact-python

These have been consumed in the pact-python project, and tested cross platform

| OS     | Standalone Version     | Architecture | Tested |
| -------| ------- | ------------ | --------- |
| OSX    | v3.1.2.2-alpha     | x86_64       | GitHub Actions            |
| OSX    | v3.1.2.2-alpha     | aarch64 (arm)| Cirrus CI         |
| Linux  | v3.1.2.2-alpha  | x86_64       | GitHub Actions          |
| Linux  | v3.1.2.2-alpha  | aarch64 (arm)| Cirrus-CI       |
| Windows| v3.1.2.2-alpha | x86_64       | GitHub Actions        |
| Windows| v3.1.2.2-alpha | x86       | Untested        |
| Windows| v3.1.2.2-alpha | aarch64 (via x86 emulation) |  Untested       |

### Local testing to validate this change in pact-python

- Ran locally against M1 Mac.
- Ran with [Cirrus CLI](https://github.com/cirruslabs/cirrus-cli) / [Tart.run](https://tart.run/)
- Created a Dockerfile (one for the slim python base `./Dockerfile`) and one for a base ubuntu container (`./Dockerfile.ubuntu`)
- Created a script to loop through, build the examples for multiple python versions and both `arm64` and amd64` platforms

Tested across Python Versions
- 3.6
- 3.7
- 3.8
- 3.9
- 3.10
- 3.11

### Automated testing to validate this change in pact-python

In order to test ARM64 on MacOS, and Linux, I have utilised cirrus-ci, which is free for open-source usage (within reasonable limits)

GitHub Actions Run

https://github.com/YOU54F/pact-python/actions/runs/4766057046

<img width="752" alt="Screenshot 2023-04-21 at 15 54 16" src="https://user-images.githubusercontent.com/19932401/233667692-c01a90fd-72f6-4967-8fc6-e9bab23f011f.png">

Cirrus CI run locally - all passing

<img width="587" alt="Screenshot 2023-04-21 at 15 55 00" src="https://user-images.githubusercontent.com/19932401/233667863-a913790d-e481-44e4-8a9d-5a99cb70b99f.png">

Cirrus CI run remote - 3.6 python failing

https://cirrus-ci.com/build/5183279620423680 

Details from individual 3.6 run https://cirrus-ci.com/task/5786844193882112

the two macos builds were aborted due to kicking off a later commit

<img width="650" alt="Screenshot 2023-04-21 at 15 56 15" src="https://user-images.githubusercontent.com/19932401/233668173-bcd62ab0-1e7c-48db-b086-4f5dc01ed26c.png">
