### PR TITLE
test: v2.0.1 (pact-2.0.1) - pact-ruby-standalone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.command.sdist import sdist as sdist_orig
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '2.0.0'
+PACT_STANDALONE_VERSION = '2.0.1'
 PACT_STANDALONE_SUFFIXES = ['osx-x86_64.tar.gz',
                             'osx-arm64.tar.gz',
                             'linux-x86_64.tar.gz',


### PR DESCRIPTION
Following on from #342

Tracking thread [here](https://github.com/pact-foundation/devrel/issues/10)

This updates pact-ruby-standalone to 2.0.1 which resolves the error seeing when writing Pact files.  

https://github.com/pact-foundation/pact-mock_service/pull/143