### PR TITLE
Chore/upgrade to pact ruby standalone 2.0.3

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -21,10 +21,11 @@ pact/pact.py
 pact/provider.py
 pact/verifier.py
 pact/verify_wrapper.py
-pact/bin/pact-3.1.2.2-alpha-linux-arm64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-linux-x86_64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-osx-arm64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-osx-x86_64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-windows-x86_64.zip
+pact/bin/pact-2.0.2-linux-arm64.tar.gz
+pact/bin/pact-2.0.2-linux-x86_64.tar.gz
+pact/bin/pact-2.0.2-osx-arm64.tar.gz
+pact/bin/pact-2.0.2-osx-x86_64.tar.gz
+pact/bin/pact-2.0.2-windows-x86.zip
+pact/bin/pact-2.0.2-windows-x86_64.zip
 pact/cli/__init__.py
 pact/cli/verify.py

--- a/MANIFEST
+++ b/MANIFEST
@@ -21,11 +21,11 @@ pact/pact.py
 pact/provider.py
 pact/verifier.py
 pact/verify_wrapper.py
-pact/bin/pact-2.0.2-linux-arm64.tar.gz
-pact/bin/pact-2.0.2-linux-x86_64.tar.gz
-pact/bin/pact-2.0.2-osx-arm64.tar.gz
-pact/bin/pact-2.0.2-osx-x86_64.tar.gz
-pact/bin/pact-2.0.2-windows-x86.zip
-pact/bin/pact-2.0.2-windows-x86_64.zip
+pact/bin/pact-2.0.3-linux-arm64.tar.gz
+pact/bin/pact-2.0.3-linux-x86_64.tar.gz
+pact/bin/pact-2.0.3-osx-arm64.tar.gz
+pact/bin/pact-2.0.3-osx-x86_64.tar.gz
+pact/bin/pact-2.0.3-windows-x86.zip
+pact/bin/pact-2.0.3-windows-x86_64.zip
 pact/cli/__init__.py
 pact/cli/verify.py

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.command.sdist import sdist as sdist_orig
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '2.0.2'
+PACT_STANDALONE_VERSION = '2.0.3'
 PACT_STANDALONE_SUFFIXES = ['osx-x86_64.tar.gz',
                             'osx-arm64.tar.gz',
                             'linux-x86_64.tar.gz',


### PR DESCRIPTION
https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md#features

Which links to

https://github.com/pact-foundation/pact_broker-client/releases/tag/v1.68.0

#### Features

* support Cirrus CI environment

#### Bug Fixes

* pact-broker --help command failed with Could not find command "__broker_base_url"
