### PR TITLE
Chore/docker non linux os

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -21,10 +21,11 @@ pact/pact.py
 pact/provider.py
 pact/verifier.py
 pact/verify_wrapper.py
-pact/bin/pact-3.1.2.2-alpha-linux-arm64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-linux-x86_64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-osx-arm64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-osx-x86_64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-windows-x86_64.zip
+pact/bin/pact-2.0.2-linux-arm64.tar.gz
+pact/bin/pact-2.0.2-linux-x86_64.tar.gz
+pact/bin/pact-2.0.2-osx-arm64.tar.gz
+pact/bin/pact-2.0.2-osx-x86_64.tar.gz
+pact/bin/pact-2.0.2-windows-x86.zip
+pact/bin/pact-2.0.2-windows-x86_64.zip
 pact/cli/__init__.py
 pact/cli/verify.py

--- a/MANIFEST
+++ b/MANIFEST
@@ -21,11 +21,11 @@ pact/pact.py
 pact/provider.py
 pact/verifier.py
 pact/verify_wrapper.py
-pact/bin/pact-2.0.2-linux-arm64.tar.gz
-pact/bin/pact-2.0.2-linux-x86_64.tar.gz
-pact/bin/pact-2.0.2-osx-arm64.tar.gz
-pact/bin/pact-2.0.2-osx-x86_64.tar.gz
-pact/bin/pact-2.0.2-windows-x86.zip
-pact/bin/pact-2.0.2-windows-x86_64.zip
+pact/bin/pact-2.0.3-linux-arm64.tar.gz
+pact/bin/pact-2.0.3-linux-x86_64.tar.gz
+pact/bin/pact-2.0.3-osx-arm64.tar.gz
+pact/bin/pact-2.0.3-osx-x86_64.tar.gz
+pact/bin/pact-2.0.3-windows-x86.zip
+pact/bin/pact-2.0.3-windows-x86_64.zip
 pact/cli/__init__.py
 pact/cli/verify.py

--- a/examples/broker/docker-compose.yml
+++ b/examples/broker/docker-compose.yml
@@ -20,9 +20,11 @@ services:
     #
     # As well as changing the image, the destination port will need to be changed
     # from 9292 below, and in the nginx.conf proxy_pass section
-    image: pactfoundation/pact-broker
+    image: pactfoundation/pact-broker:latest-multi
     ports:
       - "80:9292"
+    depends_on:
+      - postgres
     links:
       - postgres
     environment:
@@ -32,6 +34,7 @@ services:
       PACT_BROKER_DATABASE_NAME: postgres
       PACT_BROKER_BASIC_AUTH_USERNAME: pactbroker
       PACT_BROKER_BASIC_AUTH_PASSWORD: pactbroker
+      PACT_BROKER_DATABASE_CONNECT_MAX_RETRIES: "5"
     # The Pact Broker provides a healthcheck endpoint which we will use to wait
     # for it to become available before starting up
     healthcheck:
@@ -55,3 +58,4 @@ services:
     depends_on:
       broker_app:
         condition: service_healthy
+        

--- a/examples/common/sharedfixtures.py
+++ b/examples/common/sharedfixtures.py
@@ -1,3 +1,4 @@
+import platform
 import pathlib
 
 import docker
@@ -65,6 +66,11 @@ def publish_existing_pact(broker):
         "PACT_BROKER_PASSWORD": "pactbroker",
     }
 
+    target_platform = platform.platform().lower()
+
+    if 'macos' in target_platform or 'windows' in target_platform:
+        envs["PACT_BROKER_BASE_URL"] = "http://host.docker.internal:80"
+
     client = docker.from_env()
 
     print("Publishing existing Pact")
@@ -72,7 +78,7 @@ def publish_existing_pact(broker):
         remove=True,
         network="broker_default",
         volumes=pacts,
-        image="pactfoundation/pact-cli:latest",
+        image="pactfoundation/pact-cli:latest-multi",
         environment=envs,
         command="publish /pacts --consumer-app-version 1",
     )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.command.sdist import sdist as sdist_orig
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '2.0.2'
+PACT_STANDALONE_VERSION = '2.0.3'
 PACT_STANDALONE_SUFFIXES = ['osx-x86_64.tar.gz',
                             'osx-arm64.tar.gz',
                             'linux-x86_64.tar.gz',


### PR DESCRIPTION
If you run `make examples` on a windows or macos machine, they fail to connect, as the pact ruby cli cannot communicate with the pact broker via `broker_app` and needs to use `host.docker.internal`

https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66

If you run on an arm64 machine, without defaulting to machine to use DOCKER_DEFAULT_HOST of linux/amd64 you cannot pull either image, as they are not multi-platform

https://github.com/pact-foundation/pact-broker-docker#platforms
https://github.com/pact-foundation/pact-ruby-cli