### PR TITLE
Feat/veri url

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -21,10 +21,11 @@ pact/pact.py
 pact/provider.py
 pact/verifier.py
 pact/verify_wrapper.py
-pact/bin/pact-3.1.2.2-alpha-linux-arm64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-linux-x86_64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-osx-arm64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-osx-x86_64.tar.gz
-pact/bin/pact-3.1.2.2-alpha-windows-x86_64.zip
+pact/bin/pact-2.0.2-linux-arm64.tar.gz
+pact/bin/pact-2.0.2-linux-x86_64.tar.gz
+pact/bin/pact-2.0.2-osx-arm64.tar.gz
+pact/bin/pact-2.0.2-osx-x86_64.tar.gz
+pact/bin/pact-2.0.2-windows-x86.zip
+pact/bin/pact-2.0.2-windows-x86_64.zip
 pact/cli/__init__.py
 pact/cli/verify.py

--- a/MANIFEST
+++ b/MANIFEST
@@ -21,11 +21,11 @@ pact/pact.py
 pact/provider.py
 pact/verifier.py
 pact/verify_wrapper.py
-pact/bin/pact-2.0.2-linux-arm64.tar.gz
-pact/bin/pact-2.0.2-linux-x86_64.tar.gz
-pact/bin/pact-2.0.2-osx-arm64.tar.gz
-pact/bin/pact-2.0.2-osx-x86_64.tar.gz
-pact/bin/pact-2.0.2-windows-x86.zip
-pact/bin/pact-2.0.2-windows-x86_64.zip
+pact/bin/pact-2.0.3-linux-arm64.tar.gz
+pact/bin/pact-2.0.3-linux-x86_64.tar.gz
+pact/bin/pact-2.0.3-osx-arm64.tar.gz
+pact/bin/pact-2.0.3-osx-x86_64.tar.gz
+pact/bin/pact-2.0.3-windows-x86.zip
+pact/bin/pact-2.0.3-windows-x86_64.zip
 pact/cli/__init__.py
 pact/cli/verify.py

--- a/examples/broker/docker-compose.yml
+++ b/examples/broker/docker-compose.yml
@@ -20,9 +20,11 @@ services:
     #
     # As well as changing the image, the destination port will need to be changed
     # from 9292 below, and in the nginx.conf proxy_pass section
-    image: pactfoundation/pact-broker
+    image: pactfoundation/pact-broker:latest-multi
     ports:
       - "80:9292"
+    depends_on:
+      - postgres
     links:
       - postgres
     environment:
@@ -32,6 +34,7 @@ services:
       PACT_BROKER_DATABASE_NAME: postgres
       PACT_BROKER_BASIC_AUTH_USERNAME: pactbroker
       PACT_BROKER_BASIC_AUTH_PASSWORD: pactbroker
+      PACT_BROKER_DATABASE_CONNECT_MAX_RETRIES: "5"
     # The Pact Broker provides a healthcheck endpoint which we will use to wait
     # for it to become available before starting up
     healthcheck:
@@ -55,3 +58,4 @@ services:
     depends_on:
       broker_app:
         condition: service_healthy
+        

--- a/examples/common/sharedfixtures.py
+++ b/examples/common/sharedfixtures.py
@@ -1,3 +1,4 @@
+import platform
 import pathlib
 
 import docker
@@ -65,6 +66,11 @@ def publish_existing_pact(broker):
         "PACT_BROKER_PASSWORD": "pactbroker",
     }
 
+    target_platform = platform.platform().lower()
+
+    if 'macos' in target_platform or 'windows' in target_platform:
+        envs["PACT_BROKER_BASE_URL"] = "http://host.docker.internal:80"
+
     client = docker.from_env()
 
     print("Publishing existing Pact")
@@ -72,7 +78,7 @@ def publish_existing_pact(broker):
         remove=True,
         network="broker_default",
         volumes=pacts,
-        image="pactfoundation/pact-cli:latest",
+        image="pactfoundation/pact-cli:latest-multi",
         environment=envs,
         command="publish /pacts --consumer-app-version 1",
     )

--- a/pact/message_provider.py
+++ b/pact/message_provider.py
@@ -1,4 +1,5 @@
 """Contract Message Provider."""
+
 import os
 import time
 
@@ -107,12 +108,14 @@ class MessageProvider(object):
         if isinstance(self._process, Process):
             self._wait_for_server_stop()
 
-    def verify(self):
+    def verify(self, *pacts, **kwargs):
         """Verify pact files with executable verifier."""
-        pact_files = f'{self.pact_dir}/{self._pact_file()}'
+        if len(pacts) == 0:
+            pacts = [f'{self.pact_dir}/{self._pact_file()}']
+
         verifier = Verifier(provider=self.provider,
                             provider_base_url=self._proxy_url())
-        return_code, _ = verifier.verify_pacts(pact_files, verbose=False)
+        return_code, _ = verifier.verify_pacts(*pacts, **kwargs)
         assert (return_code == 0), f'Expected returned_code = 0, actual = {return_code}'
 
     def verify_with_broker(self, enable_pending=False, include_wip_pacts_since=None, **kwargs):

--- a/pact/verifier.py
+++ b/pact/verifier.py
@@ -71,15 +71,9 @@ class Verifier(object):
             publish_version ([String])
 
         """
-        broker_username = kwargs.get('broker_username', None)
-        broker_password = kwargs.get('broker_password', None)
         broker_url = kwargs.get('broker_url', None)
-        broker_token = kwargs.get('broker_token', None)
 
         options = {
-            'broker_password': broker_password,
-            'broker_username': broker_username,
-            'broker_token': broker_token,
             'broker_url': broker_url
         }
         options.update(self.extract_params(**kwargs))
@@ -106,6 +100,9 @@ class Verifier(object):
         raw_consumer_selectors = kwargs.get('consumer_version_selectors', [])
         consumer_selectors = self._build_consumer_selectors(raw_consumer_selectors)
         provider_version_branch = kwargs.get('provider_version_branch')
+        broker_username = kwargs.get('broker_username', None)
+        broker_password = kwargs.get('broker_password', None)
+        broker_token = kwargs.get('broker_token', None)
 
         options = {
             'log_dir': log_dir,
@@ -119,7 +116,10 @@ class Verifier(object):
             'verbose': verbose,
             'consumer_selectors': consumer_selectors,
             'publish_verification_results': publish_verification_results,
-            'provider_version_branch': provider_version_branch
+            'provider_version_branch': provider_version_branch,
+            'broker_password': broker_password,
+            'broker_username': broker_username,
+            'broker_token': broker_token
         }
         return self.filter_empty_options(**options)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.command.sdist import sdist as sdist_orig
 
 
 IS_64 = sys.maxsize > 2 ** 32
-PACT_STANDALONE_VERSION = '2.0.2'
+PACT_STANDALONE_VERSION = '2.0.3'
 PACT_STANDALONE_SUFFIXES = ['osx-x86_64.tar.gz',
                             'osx-arm64.tar.gz',
                             'linux-x86_64.tar.gz',

--- a/tests/test_message_provider.py
+++ b/tests/test_message_provider.py
@@ -56,7 +56,7 @@ class MessageProviderTestCase(TestCase):
         self.provider.verify()
 
         assert mock_verify_pacts.call_count == 1
-        mock_verify_pacts.assert_called_with(f'{self.provider.pact_dir}/{self.provider._pact_file()}', verbose=False)
+        mock_verify_pacts.assert_called_with(f'{self.provider.pact_dir}/{self.provider._pact_file()}')
 
     @patch('pact.Verifier.verify_with_broker', return_value=(0, 'logs'))
     def test_verify_with_broker(self, mock_verify_pacts):


### PR DESCRIPTION
fixes #332 

provides the ability to

- use `verify` function to verify by pact Url(s) or local file(s)
- use `verify_with_broker` function to verify by consumer version selectors (dynamically fetched pacts)
- Allow support for MessageProvider to verify by pact Url(s) or local file(s), 
  - otherwise default to its existing behaviour of verifying by pactDir and constructing the path from the consumer/provider name
- update Flask Provider example and Message Provider example to demonstrate
  - verifying by file
  - verifying by url
  - verifying by consumer version selectors
- updated README to show verification options