### PR TITLE
chore: update examples to work with podman on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ pact-broker publish /path/to/pacts/consumer-provider.json --consumer-app-version
 ### Python API
 
 ```python
-broker = Broker(broker_base_url="http://localhost")
+broker = Broker(broker_base_url="http://localhost:9292")
 broker.publish("TestConsumer",
                        "2.0.1",
                        branch='consumer-branch',

--- a/examples/broker/docker-compose.yml
+++ b/examples/broker/docker-compose.yml
@@ -21,12 +21,14 @@ services:
     # As well as changing the image, the destination port will need to be changed
     # from 9292 below, and in the nginx.conf proxy_pass section
     image: pactfoundation/pact-broker:latest-multi
+# PODMAN:- Error response from daemon: rootlessport cannot expose privileged port 80, you can add 'net.ipv4.ip_unprivileged_port_start=80' to /etc/sysctl.conf (currently 1024), or choose a larger port number (>= 1024): listen tcp 0.0.0.0:80: bind: permission denied
     ports:
-      - "80:9292"
+      - "9292:9292"
     depends_on:
       - postgres
-    links:
-      - postgres
+# PODMAN:- Error response from daemon: bad parameter: link is not supported
+    # links:
+    #   - postgres
     environment:
       PACT_BROKER_DATABASE_USERNAME: postgres
       PACT_BROKER_DATABASE_PASSWORD: password
@@ -47,8 +49,9 @@ services:
   # terminate with SSL
   nginx:
     image: nginx:alpine
-    links:
-      - broker_app:broker
+# PODMAN:- Error response from daemon: bad parameter: link is not supported
+    # links:
+    #   - broker_app:broker
     volumes:
       - ./ssl/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./ssl:/etc/nginx/ssl

--- a/examples/common/sharedfixtures.py
+++ b/examples/common/sharedfixtures.py
@@ -68,8 +68,9 @@ def publish_existing_pact(broker):
 
     target_platform = platform.platform().lower()
 
-    if 'macos' in target_platform or 'windows' in target_platform:
-        envs["PACT_BROKER_BASE_URL"] = "http://host.docker.internal:80"
+    # PODMAN:- Can't bind to port <1024
+    # if 'macos' in target_platform or 'windows' in target_platform:
+    #     envs["PACT_BROKER_BASE_URL"] = "http://host.docker.internal:80"
 
     client = docker.from_env()
 

--- a/examples/consumer/run_pytest.sh
+++ b/examples/consumer/run_pytest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -o pipefail
 
-pytest tests --run-broker True --publish-pact 1
+# PODMAN:- Log verbosely when failing tests to work out whats going on!
+pytest tests --run-broker True --publish-pact 1 -rP

--- a/examples/consumer/tests/consumer/test_user_consumer.py
+++ b/examples/consumer/tests/consumer/test_user_consumer.py
@@ -15,7 +15,8 @@ logging.basicConfig(level=logging.INFO)
 # If publishing the Pact(s), they will be submitted to the Pact Broker here.
 # For the purposes of this example, the broker is started up as a fixture defined
 # in conftest.py. For normal usage this would be self-hosted or using PactFlow.
-PACT_BROKER_URL = "http://localhost"
+# PODMAN:- Can't bind to port <1024
+PACT_BROKER_URL = "http://localhost:9292"
 PACT_BROKER_USERNAME = "pactbroker"
 PACT_BROKER_PASSWORD = "pactbroker"
 

--- a/examples/fastapi_provider/tests/provider/test_provider.py
+++ b/examples/fastapi_provider/tests/provider/test_provider.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
 
 # For the purposes of this example, the broker is started up as a fixture defined
 # in conftest.py. For normal usage this would be self-hosted or using PactFlow.
-PACT_BROKER_URL = "http://localhost"
+PACT_BROKER_URL = "http://localhost:9292"
 PACT_BROKER_USERNAME = "pactbroker"
 PACT_BROKER_PASSWORD = "pactbroker"
 

--- a/examples/flask_provider/tests/provider/test_provider.py
+++ b/examples/flask_provider/tests/provider/test_provider.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
 
 # For the purposes of this example, the broker is started up as a fixture defined
 # in conftest.py. For normal usage this would be self-hosted or using PactFlow.
-PACT_BROKER_URL = "http://localhost"
+PACT_BROKER_URL = "http://localhost:9292"
 PACT_BROKER_USERNAME = "pactbroker"
 PACT_BROKER_PASSWORD = "pactbroker"
 

--- a/examples/message/README.md
+++ b/examples/message/README.md
@@ -141,7 +141,7 @@ import pytest
 from pact import MessageProvider
 
 
-PACT_BROKER_URL = "http://localhost"
+PACT_BROKER_URL = "http://localhost:9292"
 PACT_BROKER_USERNAME = "pactbroker"
 PACT_BROKER_PASSWORD = "pactbroker"
 PACT_DIR = "pacts"

--- a/examples/message/tests/consumer/test_message_consumer.py
+++ b/examples/message/tests/consumer/test_message_consumer.py
@@ -13,7 +13,7 @@ from src.message_handler import MessageHandler, CustomError
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-PACT_BROKER_URL = "http://localhost"
+PACT_BROKER_URL = "http://localhost:9292"
 PACT_BROKER_USERNAME = "pactbroker"
 PACT_BROKER_PASSWORD = "pactbroker"
 PACT_DIR = "pacts"

--- a/examples/message/tests/provider/test_message_provider.py
+++ b/examples/message/tests/provider/test_message_provider.py
@@ -1,7 +1,7 @@
 import pytest
 from pact import MessageProvider
 
-PACT_BROKER_URL = "http://localhost"
+PACT_BROKER_URL = "http://localhost:9292"
 PACT_BROKER_USERNAME = "pactbroker"
 PACT_BROKER_PASSWORD = "pactbroker"
 PACT_DIR = "pacts"

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -31,7 +31,7 @@ class BrokerTestCase(TestCase):
 
     def test_publish_fails(self):
         self.mock_Popen.return_value.returncode = 1
-        broker = Broker(broker_base_url="http://localhost",
+        broker = Broker(broker_base_url="http://localhost:9292",
                         broker_username="username",
                         broker_password="password",
                         broker_token="token")
@@ -72,7 +72,7 @@ class BrokerTestCase(TestCase):
         del os.environ["PACT_BROKER_BASE_URL"]
 
     def test_basic_authenticated_publish(self):
-        broker = Broker(broker_base_url="http://localhost",
+        broker = Broker(broker_base_url="http://localhost:9292",
                         broker_username="username",
                         broker_password="password")
 
@@ -89,7 +89,7 @@ class BrokerTestCase(TestCase):
             './TestConsumer-TestProvider.json'])
 
     def test_token_authenticated_publish(self):
-        broker = Broker(broker_base_url="http://localhost",
+        broker = Broker(broker_base_url="http://localhost:9292",
                         broker_username="username",
                         broker_password="password",
                         broker_token="token")
@@ -108,7 +108,7 @@ class BrokerTestCase(TestCase):
             './TestConsumer-TestProvider.json'])
 
     def test_git_tagged_publish(self):
-        broker = Broker(broker_base_url="http://localhost")
+        broker = Broker(broker_base_url="http://localhost:9292")
 
         broker.publish("TestConsumer",
                        "2.0.1",
@@ -123,7 +123,7 @@ class BrokerTestCase(TestCase):
             '--tag-with-git-branch'])
 
     def test_manual_tagged_publish(self):
-        broker = Broker(broker_base_url="http://localhost")
+        broker = Broker(broker_base_url="http://localhost:9292")
 
         broker.publish("TestConsumer",
                        "2.0.1",
@@ -139,7 +139,7 @@ class BrokerTestCase(TestCase):
             '-t', 'tag2'])
 
     def test_branch_publish(self):
-        broker = Broker(broker_base_url="http://localhost")
+        broker = Broker(broker_base_url="http://localhost:9292")
 
         broker.publish("TestConsumer",
                        "2.0.1",
@@ -154,7 +154,7 @@ class BrokerTestCase(TestCase):
             '--branch=consumer-branch'])
 
     def test_build_url_publish(self):
-        broker = Broker(broker_base_url="http://localhost")
+        broker = Broker(broker_base_url="http://localhost:9292")
 
         broker.publish("TestConsumer",
                        "2.0.1",
@@ -169,7 +169,7 @@ class BrokerTestCase(TestCase):
             '--build-url=http://ci'])
 
     def test_auto_detect_version_properties_publish(self):
-        broker = Broker(broker_base_url="http://localhost")
+        broker = Broker(broker_base_url="http://localhost:9292")
 
         broker.publish("TestConsumer",
                        "2.0.1",

--- a/tests/test_message_provider.py
+++ b/tests/test_message_provider.py
@@ -37,7 +37,7 @@ class MessageProviderTestCase(TestCase):
         self.options = {
             'broker_username': "test",
             'broker_password': "test",
-            'broker_url': "http://localhost",
+            'broker_url': "http://localhost:9292",
             'publish_version': '3',
             'publish_verification_results': False
         }
@@ -65,7 +65,7 @@ class MessageProviderTestCase(TestCase):
         assert mock_verify_pacts.call_count == 1
         mock_verify_pacts.assert_called_with(False, None, broker_username="test",
                                              broker_password="test",
-                                             broker_url="http://localhost",
+                                             broker_url="http://localhost:9292",
                                              publish_version='3',
                                              publish_verification_results=False)
 


### PR DESCRIPTION
Testing out the examples on MacOS with Podman, over Docker compose

```console
brew install podman
podman machine init
podman machine start
export DOCKER_HOST='unix:///Users/yousaf.nabi/.local/share/containers/podman/machine/qemu/podman.sock'
make examples
```