### PR TITLE
fix(github): fix typo in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -51,4 +51,4 @@ body:
 
         If you do check this box, please send a pull request. If circumstances change and you can't work on it anymore, let us know and we can re-assign it.
       options:
-        - label: I'd be willing to contribute this feature to Docusaurus myself.
+        - label: I'd be willing to contribute this feature to Pact Python myself.


### PR DESCRIPTION
## :memo: Summary

The template was adapted from the amazing Docusaurus templates, and unfortunately a mention to Docusaurus was missed.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

## :hammer: Test Plan

N/A

## :link: Related issues/PRs

N/A