### PR TITLE
fix(ci): add missing environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     needs: [check]
     runs-on: ubuntu-latest
+    environment: Upload Python Package
 
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
## :memo: Summary

When migrating the CI publish script, I unfortunately missed the environment which contains the PyPI credentials.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Just fixing a mistake.

## ~:hammer: Test Plan~

## :link: Related issues/PRs

None