### PR TITLE
Fix hatch test scripts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+"""
+Global Pytest configuration.
+
+This file is used to define global Pytest configuration. In this case, we use it
+to define additional command line options to customise the examples.
+"""
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Define additional command lines to customise the examples."""
+    parser.addoption(
+        "--broker-url",
+        help=(
+            "The URL of the broker to use. If this option has been given, the container"
+            " will _not_ be started."
+        ),
+        type=str,
+    )

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -21,18 +21,6 @@ from yarl import URL
 EXAMPLE_DIR = Path(__file__).parent.resolve()
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    """Define additional command lines to customise the examples."""
-    parser.addoption(
-        "--broker-url",
-        help=(
-            "The URL of the broker to use. If this option has been given, the container"
-            " will _not_ be started."
-        ),
-        type=str,
-    )
-
-
 @pytest.fixture(scope="session")
 def broker(request: pytest.FixtureRequest) -> Generator[URL, Any, None]:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,10 +103,10 @@ features           = ["dev"]
 extra-dependencies = ["hatchling", "packaging", "requests"]
 
 [tool.hatch.envs.default.scripts]
-lint = ["black --check --diff {args:.}", "ruff {args:.}", "mypy {args:.}"]
-test = "pytest --cov-config=pyproject.toml --cov=pact --cov=tests tests/"
-example = "pytest examples/ {args}"
-all = ["lint", "test", "example"]
+lint    = ["black --check --diff {args:.}", "ruff {args:.}", "mypy {args:.}"]
+test    = "pytest {args:tests/}"
+example = "pytest {args:examples/}"
+all     = ["lint", "test", "example"]
 
 # Test environment for running unit tests. This automatically tests against all
 # supported Python versions.
@@ -117,16 +117,20 @@ features = ["test"]
 python = ["3.8", "3.9", "3.10", "3.11"]
 
 [tool.hatch.envs.test.scripts]
-test = "pytest --cov-config=pyproject.toml --cov=pact --cov=tests tests/"
-example = "pytest examples/ {args}"
-all = ["test", "example"]
+test    = "pytest {args:tests/}"
+example = "pytest {args:examples/}"
+all     = ["test", "example"]
 
 ################################################################################
 ## PyTest Configuration
 ################################################################################
 
 [tool.pytest.ini_options]
-addopts = ["--import-mode=importlib"]
+addopts = [
+  "--import-mode=importlib",
+  "--cov-config=pyproject.toml",
+  "--cov=pact",
+]
 
 ################################################################################
 ## Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,12 @@ addopts = [
   "--cov-config=pyproject.toml",
   "--cov=pact",
 ]
+filterwarnings = [
+  "ignore::DeprecationWarning:pact",
+  "ignore::DeprecationWarning:tests",
+  "ignore::PendingDeprecationWarning:pact",
+  "ignore::PendingDeprecationWarning:tests",
+]
 
 ################################################################################
 ## Coverage


### PR DESCRIPTION
## :memo: Summary

Commits describe the individual changes:

-   fix(test): ignore internal deprecation warnings
-   chore(test): add pytest options in root
    
    To help ensure there is a unified experience when running any/all tests,
    we need to define this in the root directory. The rest of the
    example-specific `conftest.py` can remain in `examples/conftest.py`.
    
    Running `pytest` in the root directory will now correctly execute _all_
    tests, including the examples.
-   chore: fix hatch test scripts
    
    Hatch scripts allow for additional arguments to be specified through the
    `{args:<default>}` placeholder. Unfortunately, this was not
    automatically enabled.
    
    In doing this, I have also simplified the scripts by moving some common
    pytest options into pytest's own `addopts` option.
    
## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## ~:fire: Motivation~

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## ~:hammer: Test Plan~

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

- Resolves #408 
