### PR TITLE
Reduce CI Runs on Draft PRs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,5 @@
 TEST_TEMPLATE: &TEST_TEMPLATE
+  skip: $CIRRUS_PR_DRAFT == "true"
   arch_check_script:
     - uname -am
   test_script:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   build-x86_64:
     name: Build wheels on ${{ matrix.os }} (x86, 64-bit)
+
+    if: github.event_name == 'push' || ! github.event.pull_request.draft
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -58,6 +60,8 @@ jobs:
 
   build-x86:
     name: Build wheels on ${{ matrix.os }} (x86, 32-bit)
+
+    if: github.event_name == 'push' || ! github.event.pull_request.draft
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -86,11 +90,12 @@ jobs:
 
   build-arm64:
     name: Build wheels on ${{ matrix.os }} (arm64)
-    runs-on: ${{ matrix.os }}
+
     # As this requires emulation, it's not worth running on PRs
     if: >-
       github.event_name == 'push' &&
       startsWith(github.event.ref, 'refs/tags')
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -129,11 +134,13 @@ jobs:
 
   check:
     name: Check wheels
+
+    runs-on: ubuntu-latest
+
     needs:
       - build-x86_64
       - build-x86
       - build-arm64
-    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -152,10 +159,12 @@ jobs:
 
   publish:
     name: Publish wheels
+
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    needs: [check]
     runs-on: ubuntu-latest
     environment: Upload Python Package
+
+    needs: [check]
 
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
     name: Example
 
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || ! github.event.pull_request.draft
+
     services:
       broker:
         image: pactfoundation/pact-broker:latest


### PR DESCRIPTION
## :memo: Summary

Limit a number CI workflows to run only on finalised PRs, specifically excluding draft PRs.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Draft PRs are a great way of sharing work that is in progress, but not yet ready to be reviewed and merged. Running a large number of CI workflows every time the draft PR is updated creates unnecessary noise.

Furthermore, Cirrus CI has monthly limits, and the draft PRs really have no reason to use up these resources.

## :hammer: Test Plan

See #413 

## :link: Related issues/PRs

- Resolves #411 
