### PR TITLE
feat: add python 3.12 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,6 +17,7 @@ linux_arm64_task:
       - IMAGE: "python:3.9-slim"
       - IMAGE: "python:3.10-slim"
       - IMAGE: "python:3.11-slim"
+      - IMAGE: "python:3.12-slim"
   arm_container:
     image: $IMAGE
   install_script:
@@ -37,6 +38,7 @@ macosx_arm64_task:
       - PYTHON: "3.9"
       - PYTHON: "3.10"
       - PYTHON: "3.11"
+      - PYTHON: "3.12"
   install_script:
     - brew update
     - brew install pyenv

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,7 @@ linux_arm64_task:
   env:
     PATH: ${HOME}/.local/bin:${PATH}
     CIRRUS_CLONE_SUBMODULES: "true"
+    HATCH_VERBOSE: 1
     matrix:
       - IMAGE: "python:3.8-slim"
       - IMAGE: "python:3.9-slim"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   STABLE_PYTHON_VERSION: "3.12"
+  HATCH_VERBOSE: 1
   CIBW_BUILD_FRONTEND: build
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  STABLE_PYTHON_VERSION: "3.11"
+  STABLE_PYTHON_VERSION: "3.12"
   CIBW_BUILD_FRONTEND: build
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  STABLE_PYTHON_VERSION: "3.11"
+  STABLE_PYTHON_VERSION: "3.12"
   PYTEST_ADDOPTS: --color=yes
 
 jobs:
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         experimental: [false]
         include:
           - # Run tests against the next Python version, but no need for the full list of OSes.
             os: ubuntu-latest
-            python-version: "3.12-dev"
+            python-version: "3.13.0-alpha.0 - 3.13"
             experimental: true
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ concurrency:
 env:
   STABLE_PYTHON_VERSION: "3.12"
   PYTEST_ADDOPTS: --color=yes
+  HATCH_VERBOSE: 1
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,16 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-conlusion:
+    name: Test matrix complete
+
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - run: echo "Test matrix completed successfully."
+
   example:
     name: Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,12 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Software Development :: Testing",
 ]
 
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8"
 
 # Dependencies of Pact Python should be specified using the broadest range
 # compatible version unless:
@@ -87,7 +88,13 @@ dev = [
 ################################################################################
 
 [build-system]
-requires      = ["hatchling", "packaging", "requests", "cffi"]
+requires = [
+  "hatchling",
+  "packaging",
+  "requests",
+  "cffi",
+  "setuptools ; python_version >= '3.12'",
+]
 build-backend = "hatchling.build"
 
 [tool.hatch.version]
@@ -110,8 +117,14 @@ artifacts = ["pact/bin/*", "pact/lib/*", "pact/v3/_ffi.*"]
 # Install dev dependencies in the default environment to simplify the developer
 # workflow.
 [tool.hatch.envs.default]
-features           = ["dev"]
-extra-dependencies = ["hatchling", "packaging", "requests", "cffi"]
+features = ["dev"]
+extra-dependencies = [
+  "hatchling",
+  "packaging",
+  "requests",
+  "cffi",
+  "setuptools ; python_version >= '3.12'",
+]
 
 [tool.hatch.envs.default.scripts]
 lint    = ["black --check --diff {args:.}", "ruff {args:.}", "mypy {args:.}"]
@@ -125,7 +138,7 @@ all     = ["lint", "test", "example"]
 features = ["test"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.scripts]
 test    = "pytest {args:tests/}"


### PR DESCRIPTION
## :memo: Summary

Update the build scripts to test and target Python 3.12 released on 2 October 2023. As the dependency on distutils has been removed already, there are no other changes required.

At present, this depends on a beta version of aiohttp. As a result, before this can be merged, we must wait for

- [x] aio-libs/aiohttp#7675

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

As detailed in the linked issue.

## :hammer: Test Plan

The regular test suite will suffice. There is no change to the library code.

## :link: Related issues/PRs

- Resolves #405 
