### PR TITLE
Add renovate dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "pre-commit": {
+    "enabled": true
+  },
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create wheels
-        uses: pypa/cibuildwheel@v2.15.0
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
 
@@ -88,7 +88,7 @@ jobs:
           platforms: arm64
 
       - name: Create wheels
-        uses: pypa/cibuildwheel@v2.15.0
+        uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload coverage
         # TODO: Configure code coverage monitoring
         if: false && matrix.python-version == env.STABLE_PYTHON_VERSION && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_install_hook_types:
 repos:
   # Generic hooks that apply to a lot of files
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -38,7 +38,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.289
+    rev: v0.1.1
     hooks:
       - id: ruff
         # Exclude python files in pact/** and tests/**, except for the
@@ -48,7 +48,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.10.0
     hooks:
       - id: black
         # Exclude python files in pact/** and tests/**, except for the
@@ -57,7 +57,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 3.8.2
+    rev: v3.12.0
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,20 @@ classifiers = [
 ]
 
 requires-python = ">=3.8,<4.0"
+
+# Dependencies of Pact Python should be specified using the broadest range
+# compatible version unless:
+#
+# - A specific feature is required in a new minor release
+# - A minor version address vulnerability which directly impacts Pact Python
 dependencies = [
-  "click      ~= 8.1",
-  "fastapi    ~= 0.103",
-  "psutil     ~= 5.9",
-  "requests   ~= 2.31",
-  "six        ~= 1.16",
-  "typing-extensions ~= 4.8 ; python_version < '3.10'",
-  "uvicorn    ~= 0.13",
+  "click             ~= 8.0",
+  "fastapi           ~= 0.0",
+  "psutil            ~= 5.0",
+  "requests          ~= 2.0",
+  "six               ~= 1.0",
+  "typing-extensions ~= 4.0 ; python_version < '3.10'",
+  "uvicorn           ~= 0.0",
 ]
 
 [project.urls]
@@ -48,28 +54,30 @@ dependencies = [
 pact-verifier = "pact.cli.verify:main"
 
 [project.optional-dependencies]
+# Linting and formatting tools use a more narrow specification to ensure
+# developper consistency. All other dependencies are as above.
 types = [
-  "mypy ~= 1.1",
-  "types-cffi     ~= 1.15",
-  "types-requests ~= 2.31",
+  "mypy           ~= 1.6.0",
+  "types-cffi     ~= 1.0",
+  "types-requests ~= 2.0",
 ]
 test = [
-  "aiohttp[speedups] ~= 3.8",
-  "coverage[toml]    ~= 7.3",
-  "flask[async]      ~= 2.3",
-  "httpx             ~= 0.24",
-  "mock              ~= 5.1",
-  "pytest            ~= 7.4",
-  "pytest-asyncio    ~= 0.21",
-  "pytest-cov        ~= 4.1",
-  "testcontainers    ~= 3.7",
-  "yarl              ~= 1.9",
+  "aiohttp[speedups] ~= 3.0",
+  "coverage[toml]    ~= 7.0",
+  "flask[async]      ~= 3.0",
+  "httpx             ~= 0.0",
+  "mock              ~= 5.0",
+  "pytest            ~= 7.0",
+  "pytest-asyncio    ~= 0.0",
+  "pytest-cov        ~= 4.0",
+  "testcontainers    ~= 3.0",
+  "yarl              ~= 1.0",
 ]
 dev = [
   "pact-python[types]",
   "pact-python[test]",
-  "black          ~= 23.7",
-  "ruff           ~= 0.0",
+  "black          ~= 23.10.0",
+  "ruff           ~= 0.1.0",
 ]
 
 ################################################################################


### PR DESCRIPTION
## :memo: Summary

This adds [Renovate](https://renovatebot.com/) to monitor and automatically update dependencies. The functionality is very similar to GitHub's own [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) but with a few notable differences:

- Renovate allows grouping dependencies into one PR. This can be particularly useful where a larger package is split across a number of smaller packages (some SDKs do this, though not as common in the Python ecosystem).
- Renovate is significantly more [configurable](https://docs.renovatebot.com/configuration-options) than Dependabot
- Renovate supports more ecosystems than Dependabot. Of relevance here is pre-commit.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Simplify maintenance.

## :hammer: Test Plan

This has been tested on [my fork](https://github.com/JP-Ellis/pact-foundation-pact-python/pulls?q=is%3Apr+author%3Aapp%2Frenovate).

## :link: Related issues/PRs

- Resolves: #423 