### PR TITLE
chore: add label sync

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,13 @@
+- name: area:v3
+  description: Relating to the pact.v3 module
+  color: "C2E0C6"
+
+- name: area:v2
+  description: Relating to v2 code
+  color: "C2E0C6"
+  aliases:
+    - documentation
+
+- name: area:examples
+  description: Relating to the examples
+  color: "C2E0C6"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,30 @@
+name: Labels
+
+on:
+  # For downstream repos, we want to run this on a schedule
+  # so that updates propagate automatically. Weekly is probably
+  # enough.
+  schedule:
+    - cron: "20 0 * * 0"
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yml
+
+jobs:
+  sync-labels:
+    name: Synchronise labels
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Synchronize labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: |
+            https://raw.githubusercontent.com/pact-foundation/.github/master/.github/labels.yml
+            .github/labels.yml


### PR DESCRIPTION
## :memo: Summary

This commit adds label synchronisation, pulling the labels from `pact-foundation/.github` and merging them with the labels in this repository's `.github/labels.yml`.

## ~:rotating_light: Breaking Changes~

## ~:fire: Motivation~


## ~:hammer: Test Plan~

## :link: Related issues/PRs

- Resolves: #428 