### PR TITLE
Add FFI type hinting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,15 @@ repos:
     hooks:
       - id: commitizen
         stages: [commit-msg]
+
+  - repo: local
+    hooks:
+      # Mypy is difficult to run pre-commit's isolated environment as it needs
+      # to be able to find dependencies.
+      - id: mypy
+        name: mypy
+        entry: hatch run mypy
+        language: system
+        types: [python]
+        exclude: ^(pact|tests)/(?!v3/).*\.py$
+        stages: [pre-push]

--- a/pact/v3/_ffi.pyi
+++ b/pact/v3/_ffi.pyi
@@ -1,0 +1,6 @@
+import ctypes
+
+import cffi
+
+lib: ctypes.CDLL
+ffi: cffi.FFI


### PR DESCRIPTION
## :memo: Summary

- [x] Adds `_ffi.pyi` file annotating the functions exposed by `_ffi.cpython-*.so`
- [x] Resolves type issues (including a refactor of `StringResult`)

As part of this PR, the following related work has been added:

- [x] Add mypy to the pre-commit type-checking. This will help ensure that typing error are caught more easily.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

The Rust FFI is wrapped by the Python CFFI package and a `_ffi.cpython-*.so` binary library is created. The binary library functions at runtime as a Python module, but obviously cannot be edited to add type hinting.

Instead, it is possible to add a `_ffi.pyi` file which provides type hinting in a separate file to the core implementation irrespective of whether the implementation being a Python text file, or a binary library.

## :hammer: Test Plan

Done as part of the pre-commit hook

## :link: Related issues/PRs

- Resolves: #435 
