### PR TITLE
feat(ffi): add OwnedString class

### DIFF
--- a/tests/v3/test_ffi.py
+++ b/tests/v3/test_ffi.py
@@ -51,3 +51,19 @@ def test_get_error_message() -> None:
     ret: int = ffi.lib.pactffi_validate_datetime(invalid_utf8, invalid_utf8)
     assert ret == 2
     assert ffi.get_error_message() == "error parsing value as UTF-8"
+
+
+def test_owned_string() -> None:
+    string = ffi.get_tls_ca_certificate()
+    assert isinstance(string, str)
+    assert len(string) > 0
+    assert str(string) == string
+    assert repr(string).startswith("<OwnedString: ")
+    assert repr(string).endswith(">")
+    assert string.startswith("-----BEGIN CERTIFICATE-----")
+    assert string.endswith(
+        (
+            "-----END CERTIFICATE-----\n",
+            "-----END CERTIFICATE-----\r\n",
+        )
+    )


### PR DESCRIPTION
## :memo: Summary

- Add an `OwnedString` class
- Update type annotations for functions which return strings which must be freed.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

A number of FFI functions return strings that are owned by the library and must be freed manually. Unfortunately, returning a `str` from a function would result in a memory leak, as the Python runtime would not know to free the string.

This commit adds an `OwnedString` class that wraps a `str` and a function that frees the string. The `__del__` method of the class calls the free function, ensuring that the string is freed when the object is garbage collected.

## :hammer: Test Plan

- Unit tests have been included

## :link: Related issues/PRs

- Resolves: #437 
