### PR TITLE
chore: exclude python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,6 @@ concurrency:
 env:
   STABLE_PYTHON_VERSION: "3.11"
   CIBW_BUILD_FRONTEND: build
-  CIBW_TEST_COMMAND: >
-    python -c
-    "from pact import EachLike;
-    assert EachLike(1).generate() == {'json_class': 'Pact::ArrayLike', 'contents': 1, 'min': 1}
-    "
 
 jobs:
   build-x86_64:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ requires-python = ">=3.8, <3.12"
 # - A specific feature is required in a new minor release
 # - A minor version address vulnerability which directly impacts Pact Python
 dependencies = [
+  "cffi              ~= 1.0",
   "click             ~= 8.0",
   "fastapi           ~= 0.0",
   "psutil            ~= 5.0",
@@ -92,12 +93,12 @@ build-backend = "hatchling.build"
 path = "pact/__version__.py"
 
 [tool.hatch.build]
-include   = ["pact/**/*.py", "*.md", "LICENSE"]
+include = ["**/py.typed", "**/*.md", "LICENSE", "pact/**/*.py", "pact/**/*.pyi"]
 
 [tool.hatch.build.targets.wheel]
 # Ignore the data files in the wheel as their contents are already included
 # in the package.
-artifacts = ["pact/bin/*", "pact/lib/*"]
+artifacts = ["pact/bin/*", "pact/lib/*", "pact/v3/_ffi.*"]
 
 [tool.hatch.build.targets.wheel.hooks.custom]
 
@@ -155,9 +156,9 @@ filterwarnings = [
 [tool.coverage.report]
 exclude_lines = [
   "if __name__ == .__main__.:", # Ignore non-runnable code
-  "if TYPE_CHECKING:", # Ignore typing
-  "raise NotImplementedError", # Ignore defensive assertions
-  "@(abc\\.)?abstractmethod", # Ignore abstract methods
+  "if TYPE_CHECKING:",          # Ignore typing
+  "raise NotImplementedError",  # Ignore defensive assertions
+  "@(abc\\.)?abstractmethod",   # Ignore abstract methods
 ]
 
 ################################################################################
@@ -176,10 +177,7 @@ ignore = [
   "ANN102", # `cls` must be typed
 ]
 
-extend-exclude = [
-  "tests/*.py",
-  "pact/*.py",
-]
+extend-exclude = ["tests/*.py", "pact/*.py"]
 
 [tool.ruff.pyupgrade]
 keep-runtime-typing = true
@@ -201,3 +199,25 @@ extend-exclude = '^/(pact|tests)/(?!v3).+\.py$'
 
 [tool.mypy]
 exclude = '^(pact|tests)/(?!v3).+\.py$'
+
+################################################################################
+## CI Build Wheel
+################################################################################
+[tool.cibuildwheel]
+test-command = """
+python -c \
+"from pact import EachLike; \
+assert \
+  EachLike(1).generate() \
+  == {'json_class': 'Pact::ArrayLike', 'contents': 1, 'min': 1}; \
+import pact.v3.ffi; \
+assert isinstance(pact.v3.ffi.version(), str);\""""
+
+[tool.cibuildwheel.macos]
+# The repair tool unfortunately did not like the bundled Ruby distributable.
+# TODO: Check whether delocate-wheel can be configured.
+repair-wheel-command = ""
+
+[tool.cibuildwheel.windows]
+# Skipping pypy, see giampaolo/psutil#2325
+skip = "pp*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "six               ~= 1.0",
   "typing-extensions ~= 4.0 ; python_version < '3.10'",
   "uvicorn           ~= 0.0",
+  "yarl              ~= 1.0",
 ]
 
 [project.urls]
@@ -72,7 +73,6 @@ test = [
   "pytest-asyncio    ~= 0.0",
   "pytest-cov        ~= 4.0",
   "testcontainers    ~= 3.0",
-  "yarl              ~= 1.0",
 ]
 dev = [
   "pact-python[types]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Testing",
 ]
 
-requires-python = ">=3.8,<4.0"
+requires-python = ">=3.8, <3.12"
 
 # Dependencies of Pact Python should be specified using the broadest range
 # compatible version unless:


### PR DESCRIPTION
## :memo: Summary

At this stage, Python 3.12 is not supported. There is a separate PR already resolving this, but it requires an update to a dependency.

### Update

The resolution of build issues with Python 3.12 uncovered another issue related to the bundling of Ruby. These have been resolved as well.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Make sure that the CI pipelines work again.

## ~:hammer: Test Plan~

## :link: Related issues/PRs

- Resolves: #442
- Superseded by: #405 
