### PR TITLE
chore(ci): revise pypi publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,37 @@ env:
   CIBW_BUILD_FRONTEND: build
 
 jobs:
+  build-sdit:
+    name: Build source distribution
+
+    if: github.event_name == 'push' || ! github.event.pull_request.draft
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch all tags
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.STABLE_PYTHON_VERSION }}
+
+      - name: Install hatch
+        run: pip install --upgrade hatch
+
+      - name: Create source distribution
+        run: |
+          hatch build --target sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./dist/*.tar.*
+          if-no-files-found: error
+
   build-x86_64:
     name: Build wheels on ${{ matrix.os }} (x86, 64-bit)
 
@@ -123,20 +154,23 @@ jobs:
 
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    environment: Upload Python Package
+    environment: pypi
 
     needs: [check]
+
+    permissions:
+      # Required for trusted publishing
+      id-token: write
 
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: wheels
-          path: wheelhouse
+          path: wheels
 
       - name: Push build artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
           skip-existing: true
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
-          packages-dir: wheelhouse
+          password: ${{ secrets.PYPI_TOKEN }}
+          packages-dir: wheels


### PR DESCRIPTION
## :memo: Summary

Firstly, this commits adds the building of a source distribution. When a Python package is installed, it is typically installed from a binary wheel and will fallback to the source distribution if it cannot find a matching wheel.

Additionally, I have created a new GitHub environment called `pypi` which stores a token authorising publication to Pact Python (and only Pact Python). The token is associated with my account, and will hopefully be replaced by trusted publishing soon (which bypasses tokens entirely).

For the time being, I will keep the old GitHub environments in case I need to use the secrets there, but once I have confirmed the new credentials work (or that we don't need credentials at all thanks to trusted publishing), then I will remove the secrets.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

The automated publishing to Pypi is unfortunately broken, likely because Pypi now [enforces that 2FA be enabled](https://blog.pypi.org/posts/2023-06-01-2fa-enforcement-for-upload/). This consequently prevents a username/password pair from being used for authentication, and requires an authentication token to be generated for the account.

The current [`build.yml`](https://github.com/pact-foundation/pact-python/blob/03462ca0d2c7a7c342aaa9955a72fe344ae06626/.github/workflows/build.yml) unfortunately makes use of the username/password pair and therefore needs to be fixed

## :hammer: Test Plan

Wait until the next release and see 🤷‍♂️ 

## :link: Related issues/PRs

- Resolves #453 
