### PR TITLE
fix: provider verification should use publish_verification_results

### DIFF
--- a/examples/tests/test_01_provider_fastapi.py
+++ b/examples/tests/test_01_provider_fastapi.py
@@ -147,7 +147,12 @@ def test_against_broker(broker: URL, verifier: Verifier) -> None:
     """
     code, _ = verifier.verify_with_broker(
         broker_url=str(broker),
-        published_verification_results=True,
+        # Despite the auth being set in the broker URL, we still need to pass
+        # the username and password to the verify_with_broker method.
+        broker_username=broker.user,
+        broker_password=broker.password,
+        publish_version="0.0.0",
+        publish_verification_results=True,
         provider_states_setup_url=str(PROVIDER_URL / "_pact" / "provider_states"),
     )
 

--- a/examples/tests/test_01_provider_flask.py
+++ b/examples/tests/test_01_provider_flask.py
@@ -135,7 +135,12 @@ def test_against_broker(broker: URL, verifier: Verifier) -> None:
     """
     code, _ = verifier.verify_with_broker(
         broker_url=str(broker),
-        published_verification_results=True,
+        # Despite the auth being set in the broker URL, we still need to pass
+        # the username and password to the verify_with_broker method.
+        broker_username=broker.user,
+        broker_password=broker.password,
+        publish_version="0.0.0",
+        publish_verification_results=True,
         provider_states_setup_url=str(PROVIDER_URL / "_pact" / "provider_states"),
     )
 

--- a/examples/tests/test_03_message_provider.py
+++ b/examples/tests/test_03_message_provider.py
@@ -65,4 +65,12 @@ def test_verify(broker: URL) -> None:
     )
 
     with provider:
-        provider.verify_with_broker(broker_url=str(broker))
+        provider.verify_with_broker(
+            broker_url=str(broker),
+            # Despite the auth being set in the broker URL, we still need to pass
+            # the username and password to the verify_with_broker method.
+            broker_username=broker.user,
+            broker_password=broker.password,
+            publish_version="0.0.0",
+            publish_verification_results=True,
+        )


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Pact-python here: https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md

Happy contributing!
-->

## :airplane: Pre-flight checklist

-   [x] I have read the [Contributing Guidelines on pull requests](https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md#pull-requests).
-   [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
-   [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## :memo: Summary

Fixing typo in the examples 

## :rotating_light: Breaking Changes

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

It fixes a bug

## :hammer: Test Plan

Tested locally

## :link: Related issues/PRs

- Resolves: https://github.com/pact-foundation/pact-python/issues/445
