### PR TITLE
chore(ci): re-enable pypy builds on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,3 @@ assert isinstance(pact.v3.ffi.version(), str);\""""
 # The repair tool unfortunately did not like the bundled Ruby distributable.
 # TODO: Check whether delocate-wheel can be configured.
 repair-wheel-command = ""
-
-[tool.cibuildwheel.windows]
-# Skipping pypy, see giampaolo/psutil#2325
-skip = "pp*"


### PR DESCRIPTION
## :memo: Summary

With the resolution of the upstream issue with psutil builds on Windows and PyPy, we can re-enable the building of wheels for this target.

## ~:rotating_light: Breaking Changes~

## :hammer: Test Plan

Covered by CI

## :link: Related issues/PRs

- Resolves: #446 
- Waiting on `v5.9.7` of psutil to be released.
