### PR TITLE
chore(ci): fix pypy linux builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,3 +276,14 @@ assert isinstance(pact.v3.ffi.version(), str);\""""
 # The repair tool unfortunately did not like the bundled Ruby distributable.
 # TODO: Check whether delocate-wheel can be configured.
 repair-wheel-command = ""
+
+[[tool.cibuildwheel.overrides]]
+# Pydantic for pypy needs to be built from source, which requires Rust.
+select = "pp*-*linux*"
+before-test = """
+curl -sSf https://sh.rustup.rs -sSf | sh -s -- --profile=minimal -y
+for bin in $(ls "$HOME/.cargo/bin"); do
+  ln -v "$HOME/.cargo/bin/$bin" "/usr/bin/$bin"
+done
+rustup show
+"""


### PR DESCRIPTION
## :memo: Summary

The test segment of the CIBuildWheel process was failing due to Rust not being available for the installation/building of `pydantic_core`.

This should resolve the issue by installing Rust in the Docker image just before the test step. This is only done on pypy Linux builds, as the other interpreters and platforms seem to be working fine.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

To fix CI

## :hammer: Test Plan

Regular CI

## :link: Related issues/PRs

None
