### PR TITLE
fix: ensure interactions are not left when exception occur inside with statement (#533)

### DIFF
--- a/pact/pact.py
+++ b/pact/pact.py
@@ -383,6 +383,7 @@ class Pact(Broker):
         Calls the mock service to verify that all interactions occurred as
         expected, and has it write out the contracts to disk.
         """
+        self._interactions = []
         if (exc_type, exc_val, exc_tb) != (None, None, None):
             return
 

--- a/tests/test_pact.py
+++ b/tests/test_pact.py
@@ -562,6 +562,22 @@ class PactContextManagerTestCase(PactTestCase):
         self.mock_setup.assert_called_once_with(pact)
         self.assertFalse(self.mock_verify.called)
 
+    def test_does_not_leave_interactions_after_exception(self):
+        pact = Pact(self.consumer, self.provider)
+        (pact
+         .given('I am creating a new pact using the Pact class')
+         .upon_receiving('a specific request to the server')
+         .with_request('GET', '/path')
+         .will_respond_with(200, body='success'))
+        with self.assertRaises(RuntimeError):
+            with pact:
+                raise RuntimeError
+
+        assert pact._interactions == []
+
+
+
+
 
 class PactContextManagerSetupTestCase(PactTestCase):
     def test_definition_without_description(self):


### PR DESCRIPTION
## :airplane: Pre-flight checklist

-   [x] I have read the [Contributing Guidelines on pull requests](https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md#pull-requests).
-   [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.

## :memo: Summary

Interactions are cleared not only at "verify" but also at the time of error while leaving with statement.

## :fire: Motivation

It's a bug fix. Without it failure in one test can mess with the other test.

## :hammer: Test Plan

Run failing code submitted in the issue #533 

## :link: Related issues/PRs

closes #533 
