### PR TITLE
Feat/v2 consumer suite

### DIFF
--- a/pact/v3/ffi.py
+++ b/pact/v3/ffi.py
@@ -5687,7 +5687,14 @@ def with_matching_rules(
     Raises:
         RuntimeError: If the rules could not be added.
     """
-    raise NotImplementedError
+    success: bool = lib.pactffi_with_matching_rules(
+        interaction._ref,
+        part.value,
+        rules.encode("utf-8"),
+    )
+    if not success:
+        msg = f"Unable to set matching rules for {interaction}."
+        raise RuntimeError(msg)
 
 
 def with_multipart_file_v2(  # noqa: PLR0913

--- a/pact/v3/pact.py
+++ b/pact/v3/pact.py
@@ -380,6 +380,41 @@ class Interaction(abc.ABC):
         )
         return self
 
+    def with_matching_rules(
+        self,
+        rules: dict[str, Any] | str,
+        part: Literal["Request", "Response"] | None = None,
+    ) -> Self:
+        """
+        Add matching rules to the interaction.
+
+        Matching rules are used to specify how the request or response should be
+        matched. This is useful for specifying that certain parts of the request
+        or response are flexible, such as the date or time.
+
+        Args:
+            rules:
+                Matching rules to add to the interaction. This must be
+                encodable using [`json.dumps(...)`][json.dumps], or a string.
+
+            part:
+                Whether the matching rules should be added to the request or the
+                response. If `None`, then the function intelligently determines
+                whether the matching rules should be added to the request or the
+                response, based on whether the
+                [`will_respond_with(...)`][pact.v3.Interaction.will_respond_with]
+                method has been called.
+        """
+        if isinstance(rules, dict):
+            rules = json.dumps(rules)
+
+        pact.v3.ffi.with_matching_rules(
+            self._handle,
+            self._parse_interaction_part(part),
+            rules,
+        )
+        return self
+
 
 class HttpInteraction(Interaction):
     """

--- a/tests/v3/compatiblity_suite/test_v1_consumer.py
+++ b/tests/v3/compatiblity_suite/test_v1_consumer.py
@@ -2,28 +2,36 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import re
-from typing import TYPE_CHECKING, Any, Generator
 
 import pytest
-import requests
-from pytest_bdd import given, parsers, scenario, then, when
-from yarl import URL
+from pytest_bdd import given, parsers, scenario
 
-from pact.v3 import Pact
-from tests.v3.compatiblity_suite.util import (
-    FIXTURES_ROOT,
-    InteractionDefinition,
-    string_to_int,
-    truncate,
+from tests.v3.compatiblity_suite.util import InteractionDefinition, parse_markdown_table
+from tests.v3.compatiblity_suite.util.consumer import (
+    a_response_is_returned,
+    request_n_is_made_to_the_mock_server,
+    request_n_is_made_to_the_mock_server_with_the_following_changes,
+    the_content_type_will_be_set_as,
+    the_mismatches_will_contain_a_mismatch_with_path_with_the_error,
+    the_mismatches_will_contain_a_mismatch_with_the_error,
+    the_mock_server_is_started_with_interactions,
+    the_mock_server_status_will_be,
+    the_mock_server_status_will_be_an_expected_but_not_received_error_for_interaction_n,
+    the_mock_server_status_will_be_an_unexpected_request_received_for_interaction_n,
+    the_mock_server_status_will_be_an_unexpected_request_received_for_path,
+    the_mock_server_status_will_be_mismatches,
+    the_mock_server_will_write_out_a_pact_file_for_the_interaction_when_done,
+    the_nth_interaction_request_content_type_will_be,
+    the_nth_interaction_request_query_parameters_will_be,
+    the_nth_interaction_request_will_be_for_method,
+    the_nth_interaction_request_will_contain_the_document,
+    the_nth_interaction_request_will_contain_the_header,
+    the_nth_interaction_will_contain_the_document,
+    the_pact_file_will_contain_n_interactions,
+    the_pact_test_is_done,
+    the_payload_will_contain_the_json_document,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from pact.v3.pact import PactServer
 
 logger = logging.getLogger(__name__)
 
@@ -289,9 +297,10 @@ def test_request_with_a_multipart_body_negative_case() -> None:
 @given(
     parsers.parse("the following HTTP interactions have been defined:\n{content}"),
     target_fixture="interaction_definitions",
+    converters={"content": parse_markdown_table},
 )
 def the_following_http_interactions_have_been_defined(
-    content: str,
+    content: list[dict[str, str]],
 ) -> dict[int, InteractionDefinition]:
     """
     Parse the HTTP interactions table into a dictionary.
@@ -311,20 +320,14 @@ def the_following_http_interactions_have_been_defined(
     The first row is ignored, as it is assumed to be the column headers. The
     order of the columns is similarly ignored.
     """
-    rows = [
-        list(map(str.strip, row.split("|")))[1:-1]
-        for row in content.split("\n")
-        if row.strip()
-    ]
-
     # Check that the table is well-formed
-    assert len(rows[0]) == 9
-    assert rows[0][0] == "No"
+    assert len(content[0]) == 9, f"Expected 9 columns, got {len(content[0])}"
+    assert "No" in content[0], "'No' column not found"
 
     # Parse the table into a more useful format
     interactions: dict[int, InteractionDefinition] = {}
-    for row in rows[1:]:
-        interactions[int(row[0])] = InteractionDefinition(**dict(zip(rows[0], row)))
+    for row in content:
+        interactions[int(row["No"])] = InteractionDefinition(**row)
     return interactions
 
 
@@ -332,597 +335,30 @@ def the_following_http_interactions_have_been_defined(
 ## When
 ################################################################################
 
-
-@when(
-    parsers.re(
-        r"the mock server is started"
-        r" with interactions?"
-        r' "?(?P<ids>((\d+)(,\s)?)+)"?',
-    ),
-    converters={"ids": lambda s: list(map(int, s.split(",")))},
-    target_fixture="srv",
-)
-def the_mock_server_is_started_with_interactions(  # noqa: C901
-    ids: list[int],
-    interaction_definitions: dict[int, InteractionDefinition],
-) -> Generator[PactServer, Any, None]:
-    """The mock server is started with interactions."""
-    pact = Pact("consumer", "provider")
-    pact.with_specification("V1")
-    for iid in ids:
-        definition = interaction_definitions[iid]
-        logging.info("Adding interaction %s", iid)
-
-        interaction = pact.upon_receiving(f"interactions {iid}")
-        logging.info("-> with_request(%s, %s)", definition.method, definition.path)
-        interaction.with_request(definition.method, definition.path)
-
-        if definition.query:
-            query = URL.build(query_string=definition.query).query
-            logging.info("-> with_query_parameters(%s)", query.items())
-            interaction.with_query_parameters(query.items())
-
-        if definition.headers:
-            logging.info("-> with_headers(%s)", definition.headers.items())
-            interaction.with_headers(definition.headers.items())
-
-        if definition.body:
-            if definition.body.string:
-                logging.info(
-                    "-> with_body(%s, %s)",
-                    truncate(definition.body.string),
-                    definition.body.mime_type,
-                )
-                interaction.with_body(
-                    definition.body.string,
-                    definition.body.mime_type,
-                )
-            elif definition.body.bytes:
-                logging.info(
-                    "-> with_binary_file(%s, %s)",
-                    truncate(definition.body.bytes),
-                    definition.body.mime_type,
-                )
-                interaction.with_binary_body(
-                    definition.body.bytes,
-                    definition.body.mime_type,
-                )
-            else:
-                msg = "Unexpected body definition"
-                raise RuntimeError(msg)
-
-        logging.info("-> will_respond_with(%s)", definition.response)
-        interaction.will_respond_with(definition.response)
-
-        if definition.response_content:
-            if definition.response_body is None:
-                msg = "Expected response body along with response content type"
-                raise ValueError(msg)
-
-            if definition.response_body.string:
-                logging.info(
-                    "-> with_body(%s, %s)",
-                    truncate(definition.response_body.string),
-                    definition.response_content,
-                )
-                interaction.with_body(
-                    definition.response_body.string,
-                    definition.response_content,
-                )
-            elif definition.response_body.bytes:
-                logging.info(
-                    "-> with_binary_file(%s, %s)",
-                    truncate(definition.response_body.bytes),
-                    definition.response_content,
-                )
-                interaction.with_binary_body(
-                    definition.response_body.bytes,
-                    definition.response_content,
-                )
-            else:
-                msg = "Unexpected body definition"
-                raise RuntimeError(msg)
-
-    with pact.serve(raises=False) as srv:
-        yield srv
-
-
-@when(
-    parsers.re(
-        r"request (?P<request_id>\d+) is made to the mock server",
-    ),
-    converters={"request_id": int},
-    target_fixture="response",
-)
-def request_n_is_made_to_the_mock_server(
-    interaction_definitions: dict[int, InteractionDefinition],
-    request_id: int,
-    srv: PactServer,
-) -> requests.Response:
-    """
-    Request n is made to the mock server.
-    """
-    definition = interaction_definitions[request_id]
-    if (
-        definition.body
-        and definition.body.mime_type
-        and "Content-Type" not in definition.headers
-    ):
-        definition.headers.add("Content-Type", definition.body.mime_type)
-
-    return requests.request(
-        definition.method,
-        str(srv.url.with_path(definition.path)),
-        params=(
-            URL.build(query_string=definition.query).query if definition.query else None
-        ),
-        headers=definition.headers if definition.headers else None,  # type: ignore[arg-type]
-        data=definition.body.bytes if definition.body else None,
-    )
-
-
-@when(
-    parsers.re(
-        r"request (?P<request_id>\d+) is made to the mock server"
-        r" with the following changes?:\n(?P<content>.*)",
-        re.DOTALL,
-    ),
-    converters={"request_id": int},
-    target_fixture="response",
-)
-def request_n_is_made_to_the_mock_server_with_the_following_changes(
-    interaction_definitions: dict[int, InteractionDefinition],
-    request_id: int,
-    content: str,
-    srv: PactServer,
-) -> requests.Response:
-    """
-    Request n is made to the mock server with changes.
-
-    The content is a markdown table with a subset of the columns defining the
-    definition (as in the given step).
-    """
-    definition = interaction_definitions[request_id]
-    rows = [
-        list(map(str.strip, row.split("|")))[1:-1]
-        for row in content.split("\n")
-        if row.strip()
-    ]
-    assert len(rows) == 2, "Expected two rows in the table"
-    updates = dict(zip(rows[0], rows[1]))
-    definition.update(**updates)
-
-    if (
-        definition.body
-        and definition.body.mime_type
-        and "Content-Type" not in definition.headers
-    ):
-        definition.headers.add("Content-Type", definition.body.mime_type)
-
-    return requests.request(
-        definition.method,
-        str(srv.url.with_path(definition.path)),
-        params=(
-            URL.build(query_string=definition.query).query if definition.query else None
-        ),
-        headers=definition.headers if definition.headers else None,  # type: ignore[arg-type]
-        data=definition.body.bytes if definition.body else None,
-    )
-
+request_n_is_made_to_the_mock_server()
+request_n_is_made_to_the_mock_server_with_the_following_changes()
+the_mock_server_is_started_with_interactions("V1")
+the_pact_test_is_done()
 
 ################################################################################
 ## Then
 ################################################################################
 
-
-@then(
-    parsers.re(
-        r"a (?P<code>\d+) (success|error) response is returned",
-    ),
-    converters={"code": int},
-)
-def a_response_is_returned(
-    response: requests.Response,
-    code: int,
-    srv: PactServer,
-) -> None:
-    """
-    A response is returned.
-    """
-    logging.info("Request Information:")
-    logging.info("-> Method: %s", response.request.method)
-    logging.info("-> URL: %s", response.request.url)
-    logging.info(
-        "-> Headers: %s",
-        json.dumps(
-            dict(**response.request.headers),
-            indent=2,
-        ),
-    )
-    logging.info(
-        "-> Body: %s",
-        truncate(response.request.body) if response.request.body else None,
-    )
-    logging.info("Mismatches:\n%s", json.dumps(srv.mismatches, indent=2))
-    assert response.status_code == code
-
-
-@then(
-    parsers.re(
-        r'the payload will contain the "(?P<file>[^"]+)" JSON document',
-    ),
-)
-def the_payload_will_contain_the_json_document(
-    response: requests.Response,
-    file: str,
-) -> None:
-    """
-    The payload will contain the JSON document.
-    """
-    path = FIXTURES_ROOT / f"{file}.json"
-    assert response.json() == json.loads(path.read_text())
-
-
-@then(
-    parsers.re(
-        r'the content type will be set as "(?P<content_type>[^"]+)"',
-    ),
-)
-def the_content_type_will_be_set_as(
-    response: requests.Response,
-    content_type: str,
-) -> None:
-    assert response.headers["Content-Type"] == content_type
-
-
-@when("the pact test is done")
-def the_pact_test_is_done() -> None:
-    """
-    The pact test is done.
-    """
-
-
-@then(
-    parsers.re(r"the mock server status will (?P<negated>(NOT )?)be OK"),
-    converters={"negated": lambda s: s == "NOT "},
-)
-def the_mock_server_status_will_be(
-    srv: PactServer,
-    negated: bool,  # noqa: FBT001
-) -> None:
-    """
-    The mock server status will be.
-    """
-    assert srv.matched is not negated
-
-
-@then(
-    parsers.re(
-        r"the mock server status will be"
-        r" an expected but not received error"
-        r" for interaction \{(?P<n>\d+)\}",
-    ),
-    converters={"n": int},
-)
-def the_mock_server_status_will_be_an_expected_but_not_received_error_for_interaction_n(
-    srv: PactServer,
-    n: int,
-    interaction_definitions: dict[int, InteractionDefinition],
-) -> None:
-    """
-    The mock server status will be an expected but not received error for interaction n.
-    """
-    assert srv.matched is False
-    assert len(srv.mismatches) > 0
-
-    for mismatch in srv.mismatches:
-        if (
-            mismatch["method"] == interaction_definitions[n].method
-            and mismatch["path"] == interaction_definitions[n].path
-            and mismatch["type"] == "missing-request"
-        ):
-            return
-    pytest.fail("Expected mismatch not found")
-
-
-@then(
-    parsers.re(
-        r"the mock server status will be"
-        r' an unexpected "(?P<method>[^"]+)" request received error'
-        r" for interaction \{(?P<n>\d+)\}",
-    ),
-    converters={"n": int},
-)
-def the_mock_server_status_will_be_an_unexpected_request_received_for_interaction_n(
-    srv: PactServer,
-    method: str,
-    n: int,
-    interaction_definitions: dict[int, InteractionDefinition],
-) -> None:
-    """
-    The mock server status will be an expected but not received error for interaction n.
-    """
-    assert srv.matched is False
-    assert len(srv.mismatches) > 0
-
-    for mismatch in srv.mismatches:
-        if (
-            mismatch["method"] == interaction_definitions[n].method
-            and mismatch["request"]["method"] == method
-            and mismatch["path"] == interaction_definitions[n].path
-            and mismatch["type"] == "request-not-found"
-        ):
-            return
-    pytest.fail("Expected mismatch not found")
-
-
-@then(
-    parsers.re(
-        r"the mock server status will be"
-        r' an unexpected "(?P<method>[^"]+)" request received error'
-        r' for path "(?P<path>[^"]+)"',
-    ),
-    converters={"n": int},
-)
-def the_mock_server_status_will_be_an_unexpected_request_received_for_path(
-    srv: PactServer,
-    method: str,
-    path: str,
-) -> None:
-    """
-    The mock server status will be an expected but not received error for interaction n.
-    """
-    assert srv.matched is False
-    assert len(srv.mismatches) > 0
-
-    for mismatch in srv.mismatches:
-        if (
-            mismatch["request"]["method"] == method
-            and mismatch["path"] == path
-            and mismatch["type"] == "request-not-found"
-        ):
-            return
-    pytest.fail("Expected mismatch not found")
-
-
-@then("the mock server status will be mismatches")
-def the_mock_server_status_will_be_mismatches(
-    srv: PactServer,
-) -> None:
-    """
-    The mock server status will be mismatches.
-    """
-    assert srv.matched is False
-    assert len(srv.mismatches) > 0
-
-
-@then(
-    parsers.re(
-        r'the mismatches will contain a "(?P<mismatch_type>[^"]+)" mismatch'
-        r' with error "(?P<error>[^"]+)"',
-    ),
-)
-def the_mismatches_will_contain_a_mismatch_with_the_error(
-    srv: PactServer,
-    mismatch_type: str,
-    error: str,
-) -> None:
-    """
-    The mismatches will contain a mismatch with the error.
-    """
-    if mismatch_type == "query":
-        mismatch_type = "QueryMismatch"
-    elif mismatch_type == "header":
-        mismatch_type = "HeaderMismatch"
-    elif mismatch_type == "body":
-        mismatch_type = "BodyMismatch"
-    elif mismatch_type == "body-content-type":
-        mismatch_type = "BodyTypeMismatch"
-    else:
-        msg = f"Unexpected mismatch type: {mismatch_type}"
-        raise ValueError(msg)
-
-    logger.info("Expecting mismatch: %s", mismatch_type)
-    logger.info("With error: %s", error)
-    for mismatch in srv.mismatches:
-        for sub_mismatch in mismatch["mismatches"]:
-            if (
-                error in sub_mismatch["mismatch"]
-                and sub_mismatch["type"] == mismatch_type
-            ):
-                return
-    pytest.fail("Expected mismatch not found")
-
-
-@then(
-    parsers.re(
-        r'the mismatches will contain a "(?P<mismatch_type>[^"]+)" mismatch'
-        r' with path "(?P<path>[^"]+)"'
-        r' with error "(?P<error>[^"]+)"',
-    ),
-)
-def the_mismatches_will_contain_a_mismatch_with_path_with_the_error(
-    srv: PactServer,
-    mismatch_type: str,
-    path: str,
-    error: str,
-) -> None:
-    """
-    The mismatches will contain a mismatch with the error.
-    """
-    mismatch_type = "BodyMismatch" if mismatch_type == "body" else mismatch_type
-    for mismatch in srv.mismatches:
-        for sub_mismatch in mismatch["mismatches"]:
-            if (
-                sub_mismatch["mismatch"] == error
-                and sub_mismatch["type"] == mismatch_type
-                and sub_mismatch["path"] == path
-            ):
-                return
-    pytest.fail("Expected mismatch not found")
-
-
-@then(
-    parsers.re(
-        r"the mock server will (?P<negated>(NOT )?)write out"
-        r" a Pact file for the interactions? when done",
-    ),
-    converters={"negated": lambda s: s == "NOT "},
-    target_fixture="pact_file",
-)
-def the_mock_server_will_write_out_a_pact_file_for_the_interaction_when_done(
-    srv: PactServer,
-    temp_dir: Path,
-    negated: bool,  # noqa: FBT001
-) -> dict[str, Any] | None:
-    """
-    The mock server will write out a Pact file for the interaction when done.
-    """
-    if not negated:
-        srv.write_file(temp_dir)
-        output = temp_dir / "consumer-provider.json"
-        assert output.is_file()
-        return json.load(output.open())
-    return None
-
-
-@then(
-    parsers.re(r"the pact file will contain \{(?P<n>\d+)\} interactions?"),
-    converters={"n": int},
-)
-def the_pact_file_will_contain_n_interactions(
-    pact_file: dict[str, Any],
-    n: int,
-) -> None:
-    """
-    The pact file will contain n interactions.
-    """
-    assert len(pact_file["interactions"]) == n
-
-
-@then(
-    parsers.re(
-        r"the \{(?P<n>\w+)\} interaction response"
-        r' will contain the "(?P<file>[^"]+)" document',
-    ),
-    converters={"n": string_to_int},
-)
-def the_nth_interaction_will_contain_the_document(
-    pact_file: dict[str, Any],
-    n: int,
-    file: str,
-) -> None:
-    """
-    The nth interaction response will contain the document.
-    """
-    file_path = FIXTURES_ROOT / file
-    if file.endswith(".json"):
-        assert pact_file["interactions"][n - 1]["response"]["body"] == json.load(
-            file_path.open(),
-        )
-
-
-@then(
-    parsers.re(
-        r'the \{(?P<n>\w+)\} interaction request will be for a "(?P<method>[A-Z]+)"',
-    ),
-    converters={"n": string_to_int},
-)
-def the_nth_interaction_request_will_be_for_method(
-    pact_file: dict[str, Any],
-    n: int,
-    method: str,
-) -> None:
-    """
-    The nth interaction request will be for a method.
-    """
-    assert pact_file["interactions"][n - 1]["request"]["method"] == method
-
-
-@then(
-    parsers.re(
-        r"the \{(?P<n>\w+)\} interaction request"
-        r' query parameters will be "(?P<query>[^"]+)"',
-    ),
-    converters={"n": string_to_int},
-)
-def the_nth_interaction_request_query_parameters_will_be(
-    pact_file: dict[str, Any],
-    n: int,
-    query: str,
-) -> None:
-    """
-    The nth interaction request query parameters will be.
-    """
-    assert query == pact_file["interactions"][n - 1]["request"]["query"]
-
-
-@then(
-    parsers.re(
-        r"the \{(?P<n>\w+)\} interaction request"
-        r' will contain the header "(?P<key>[^"]+)"'
-        r' with value "(?P<value>[^"]+)"',
-    ),
-    converters={"n": string_to_int},
-)
-def the_nth_interaction_request_will_contain_the_header(
-    pact_file: dict[str, Any],
-    n: int,
-    key: str,
-    value: str,
-) -> None:
-    """
-    The nth interaction request will contain the header.
-    """
-    expected = {key: value}
-    actual = pact_file["interactions"][n - 1]["request"]["headers"]
-    assert expected.keys() == actual.keys()
-    for key in expected:
-        assert expected[key] == actual[key] or [expected[key]] == actual[key]
-
-
-@then(
-    parsers.re(
-        r"the \{(?P<n>\w+)\} interaction request"
-        r' content type will be "(?P<content_type>[^"]+)"',
-    ),
-    converters={"n": string_to_int},
-)
-def the_nth_interaction_request_content_type_will_be(
-    pact_file: dict[str, Any],
-    n: int,
-    content_type: str,
-) -> None:
-    """
-    The nth interaction request will contain the header.
-    """
-    assert (
-        pact_file["interactions"][n - 1]["request"]["headers"]["Content-Type"]
-        == content_type
-    )
-
-
-@then(
-    parsers.re(
-        r"the \{(?P<n>\w+)\} interaction request"
-        r' will contain the "(?P<file>[^"]+)" document',
-    ),
-    converters={"n": string_to_int},
-)
-def the_nth_interaction_request_will_contain_the_document(
-    pact_file: dict[str, Any],
-    n: int,
-    file: str,
-) -> None:
-    """
-    The nth interaction request will contain the document.
-    """
-    file_path = FIXTURES_ROOT / file
-    if file.endswith(".json"):
-        assert pact_file["interactions"][n - 1]["request"]["body"] == json.load(
-            file_path.open(),
-        )
-    else:
-        assert (
-            pact_file["interactions"][n - 1]["request"]["body"] == file_path.read_text()
-        )
+a_response_is_returned()
+the_content_type_will_be_set_as()
+the_mismatches_will_contain_a_mismatch_with_path_with_the_error()
+the_mismatches_will_contain_a_mismatch_with_the_error()
+the_mock_server_status_will_be()
+the_mock_server_status_will_be_an_expected_but_not_received_error_for_interaction_n()
+the_mock_server_status_will_be_an_unexpected_request_received_for_interaction_n()
+the_mock_server_status_will_be_an_unexpected_request_received_for_path()
+the_mock_server_status_will_be_mismatches()
+the_mock_server_will_write_out_a_pact_file_for_the_interaction_when_done()
+the_nth_interaction_request_content_type_will_be()
+the_nth_interaction_request_query_parameters_will_be()
+the_nth_interaction_request_will_be_for_method()
+the_nth_interaction_request_will_contain_the_document()
+the_nth_interaction_request_will_contain_the_header()
+the_nth_interaction_will_contain_the_document()
+the_pact_file_will_contain_n_interactions()
+the_payload_will_contain_the_json_document()

--- a/tests/v3/compatiblity_suite/test_v2_consumer.py
+++ b/tests/v3/compatiblity_suite/test_v2_consumer.py
@@ -1,0 +1,232 @@
+"""Basic HTTP consumer feature tests."""
+
+from __future__ import annotations
+
+import logging
+
+from pytest_bdd import given, parsers, scenario
+
+from tests.v3.compatiblity_suite.util import InteractionDefinition, parse_markdown_table
+from tests.v3.compatiblity_suite.util.consumer import (
+    a_response_is_returned,
+    request_n_is_made_to_the_mock_server,
+    request_n_is_made_to_the_mock_server_with_the_following_changes,
+    the_content_type_will_be_set_as,
+    the_mismatches_will_contain_a_mismatch_with_path_with_the_error,
+    the_mismatches_will_contain_a_mismatch_with_the_error,
+    the_mock_server_is_started_with_interaction_n_but_with_the_following_changes,
+    the_mock_server_is_started_with_interactions,
+    the_mock_server_status_will_be,
+    the_mock_server_status_will_be_an_expected_but_not_received_error_for_interaction_n,
+    the_mock_server_status_will_be_an_unexpected_request_received_for_interaction_n,
+    the_mock_server_status_will_be_an_unexpected_request_received_for_path,
+    the_mock_server_status_will_be_mismatches,
+    the_mock_server_will_write_out_a_pact_file_for_the_interaction_when_done,
+    the_nth_interaction_request_content_type_will_be,
+    the_nth_interaction_request_query_parameters_will_be,
+    the_nth_interaction_request_will_be_for_method,
+    the_nth_interaction_request_will_contain_the_document,
+    the_nth_interaction_request_will_contain_the_header,
+    the_nth_interaction_will_contain_the_document,
+    the_pact_file_will_contain_n_interactions,
+    the_pact_test_is_done,
+    the_payload_will_contain_the_json_document,
+)
+
+logger = logging.getLogger(__name__)
+
+################################################################################
+## Scenario
+################################################################################
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports a regex matcher (negative case)",
+)
+def test_supports_a_regex_matcher_negative_case() -> None:
+    """Supports a regex matcher (negative case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports a regex matcher (positive case)",
+)
+def test_supports_a_regex_matcher_positive_case() -> None:
+    """Supports a regex matcher (positive case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports a type matcher (negative case)",
+)
+def test_supports_a_type_matcher_negative_case() -> None:
+    """Supports a type matcher (negative case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports a type matcher (positive case)",
+)
+def test_supports_a_type_matcher_positive_case() -> None:
+    """Supports a type matcher (positive case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports matchers for repeated request headers (negative case)",
+)
+def test_supports_matchers_for_repeated_request_headers_negative_case() -> None:
+    """Supports matchers for repeated request headers (negative case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports matchers for repeated request headers (positive case)",
+)
+def test_supports_matchers_for_repeated_request_headers_positive_case() -> None:
+    """Supports matchers for repeated request headers (positive case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports matchers for repeated request query parameters (negative case)",
+)
+def test_supports_matchers_for_repeated_request_query_parameters_negative_case() -> (
+    None
+):
+    """Supports matchers for repeated request query parameters (negative case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports matchers for repeated request query parameters (positive case)",
+)
+def test_supports_matchers_for_repeated_request_query_parameters_positive_case() -> (
+    None
+):
+    """Supports matchers for repeated request query parameters (positive case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports matchers for request bodies",
+)
+def test_supports_matchers_for_request_bodies() -> None:
+    """Supports matchers for request bodies."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports matchers for request headers",
+)
+def test_supports_matchers_for_request_headers() -> None:
+    """Supports matchers for request headers."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports matchers for request query parameters",
+)
+def test_supports_matchers_for_request_query_parameters() -> None:
+    """Supports matchers for request query parameters."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Type matchers cascade to children (negative case)",
+)
+def test_type_matchers_cascade_to_children_negative_case() -> None:
+    """Type matchers cascade to children (negative case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Type matchers cascade to children (positive case)",
+)
+def test_type_matchers_cascade_to_children_positive_case() -> None:
+    """Type matchers cascade to children (positive case)."""
+
+
+@scenario(
+    "definition/features/V2/http_consumer.feature",
+    "Supports a matcher for request paths",
+)
+def test_supports_a_matcher_for_request_paths() -> None:
+    """Supports a matcher for request paths."""
+
+
+################################################################################
+## Given
+################################################################################
+
+
+@given(
+    parsers.parse("the following HTTP interactions have been defined:\n{content}"),
+    target_fixture="interaction_definitions",
+)
+def the_following_http_interactions_have_been_defined(
+    content: str,
+) -> dict[int, InteractionDefinition]:
+    """
+    Parse the HTTP interactions table into a dictionary.
+
+    The table columns are expected to be:
+
+    - No
+    - method
+    - path
+    - query
+    - headers
+    - body
+    - matching rules
+
+    The first row is ignored, as it is assumed to be the column headers. The
+    order of the columns is similarly ignored.
+    """
+    table = parse_markdown_table(content)
+
+    # Check that the table is well-formed
+    assert len(table[0]) == 7, f"Expected 7 columns, got {len(table[0])}"
+    assert "No" in table[0], "'No' column not found"
+
+    # Parse the table into a more useful format
+    interactions: dict[int, InteractionDefinition] = {}
+    for row in table:
+        interactions[int(row["No"])] = InteractionDefinition(**row)
+
+    return interactions
+
+
+################################################################################
+## When
+################################################################################
+
+request_n_is_made_to_the_mock_server()
+request_n_is_made_to_the_mock_server_with_the_following_changes()
+the_mock_server_is_started_with_interactions("V2")
+the_mock_server_is_started_with_interaction_n_but_with_the_following_changes("V2")
+the_pact_test_is_done()
+
+################################################################################
+## Then
+################################################################################
+
+a_response_is_returned()
+the_content_type_will_be_set_as()
+the_mismatches_will_contain_a_mismatch_with_path_with_the_error()
+the_mismatches_will_contain_a_mismatch_with_the_error()
+the_mock_server_status_will_be()
+the_mock_server_status_will_be_an_expected_but_not_received_error_for_interaction_n()
+the_mock_server_status_will_be_an_unexpected_request_received_for_interaction_n()
+the_mock_server_status_will_be_an_unexpected_request_received_for_path()
+the_mock_server_status_will_be_mismatches()
+the_mock_server_will_write_out_a_pact_file_for_the_interaction_when_done()
+the_nth_interaction_request_content_type_will_be()
+the_nth_interaction_request_query_parameters_will_be()
+the_nth_interaction_request_will_be_for_method()
+the_nth_interaction_request_will_contain_the_document()
+the_nth_interaction_request_will_contain_the_header()
+the_nth_interaction_will_contain_the_document()
+the_pact_file_will_contain_n_interactions()
+the_payload_will_contain_the_json_document()

--- a/tests/v3/compatiblity_suite/util/consumer.py
+++ b/tests/v3/compatiblity_suite/util/consumer.py
@@ -1,0 +1,654 @@
+"""
+Utility functions for the consumer tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import requests
+from pytest_bdd import parsers, then, when
+from yarl import URL
+
+from pact.v3 import Pact
+from tests.v3.compatiblity_suite.util import (
+    FIXTURES_ROOT,
+    parse_markdown_table,
+    string_to_int,
+    truncate,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from pact.v3.pact import PactServer
+    from tests.v3.compatiblity_suite.util import InteractionDefinition
+
+logger = logging.getLogger(__name__)
+
+################################################################################
+## When
+################################################################################
+
+
+def the_mock_server_is_started_with_interactions(
+    version: str,
+    stacklevel: int = 1,
+) -> None:
+    @when(
+        parsers.re(
+            r"the mock server is started"
+            r" with interactions?"
+            r' "?(?P<ids>((\d+)(,\s)?)+)"?',
+        ),
+        converters={"ids": lambda s: list(map(int, s.split(",")))},
+        target_fixture="srv",
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        ids: list[int],
+        interaction_definitions: dict[int, InteractionDefinition],
+    ) -> Generator[PactServer, Any, None]:
+        """The mock server is started with interactions."""
+        pact = Pact("consumer", "provider")
+        pact.with_specification(version)
+        for iid in ids:
+            definition = interaction_definitions[iid]
+            logging.info("Adding interaction %s", iid)
+            definition.add_to_pact(pact, f"interaction {iid}")
+
+        with pact.serve(raises=False) as srv:
+            yield srv
+
+
+def the_mock_server_is_started_with_interaction_n_but_with_the_following_changes(
+    version: str,
+    stacklevel: int = 1,
+) -> None:
+    @when(
+        parsers.re(
+            r"the mock server is started"
+            r" with interaction (?P<iid>\d+)"
+            r" but with the following changes?:\n(?P<content>.*)",
+            re.DOTALL,
+        ),
+        converters={"iid": int, "content": parse_markdown_table},
+        target_fixture="srv",
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        iid: int,
+        interaction_definitions: dict[int, InteractionDefinition],
+        content: list[dict[str, str]],
+    ) -> Generator[PactServer, Any, None]:
+        """The mock server is started with interactions."""
+        pact = Pact("consumer", "provider")
+        pact.with_specification(version)
+        definition = interaction_definitions[iid]
+        definition.update(**content[0])
+        logging.info("Adding modified interaction %s", iid)
+        definition.add_to_pact(pact, f"interaction {iid}")
+
+        with pact.serve(raises=False) as srv:
+            yield srv
+
+
+def request_n_is_made_to_the_mock_server(stacklevel: int = 1) -> None:
+    @when(
+        parsers.re(
+            r"request (?P<request_id>\d+) is made to the mock server",
+        ),
+        converters={"request_id": int},
+        target_fixture="response",
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        interaction_definitions: dict[int, InteractionDefinition],
+        request_id: int,
+        srv: PactServer,
+    ) -> requests.Response:
+        """
+        Request n is made to the mock server.
+        """
+        definition = interaction_definitions[request_id]
+        if (
+            definition.body
+            and definition.body.mime_type
+            and "Content-Type" not in definition.headers
+        ):
+            definition.headers.add("Content-Type", definition.body.mime_type)
+
+        return requests.request(
+            definition.method,
+            str(srv.url.with_path(definition.path)),
+            params=(
+                URL.build(query_string=definition.query).query
+                if definition.query
+                else None
+            ),
+            headers=definition.headers if definition.headers else None,  # type: ignore[arg-type]
+            data=definition.body.bytes if definition.body else None,
+        )
+
+
+def request_n_is_made_to_the_mock_server_with_the_following_changes(
+    stacklevel: int = 1,
+) -> None:
+    @when(
+        parsers.re(
+            r"request (?P<request_id>\d+) is made to the mock server"
+            r" with the following changes?:\n(?P<content>.*)",
+            re.DOTALL,
+        ),
+        converters={"request_id": int, "content": parse_markdown_table},
+        target_fixture="response",
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        interaction_definitions: dict[int, InteractionDefinition],
+        request_id: int,
+        content: list[dict[str, str]],
+        srv: PactServer,
+    ) -> requests.Response:
+        """
+        Request n is made to the mock server with changes.
+
+        The content is a markdown table with a subset of the columns defining the
+        definition (as in the given step).
+        """
+        definition = interaction_definitions[request_id]
+        assert len(content) == 1, "Expected exactly one row in the table"
+        definition.update(**content[0])
+
+        if (
+            definition.body
+            and definition.body.mime_type
+            and "Content-Type" not in definition.headers
+        ):
+            definition.headers.add("Content-Type", definition.body.mime_type)
+
+        return requests.request(
+            definition.method,
+            str(srv.url.with_path(definition.path)),
+            params=(
+                URL.build(query_string=definition.query).query
+                if definition.query
+                else None
+            ),
+            headers=definition.headers if definition.headers else None,  # type: ignore[arg-type]
+            data=definition.body.bytes if definition.body else None,
+        )
+
+
+def the_pact_test_is_done(stacklevel: int = 1) -> None:
+    @when("the pact test is done", stacklevel=stacklevel + 1)
+    def _() -> None:
+        """
+        The pact test is done.
+        """
+
+
+################################################################################
+## Then
+################################################################################
+
+
+def a_response_is_returned(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r"a (?P<code>\d+) (success|error) response is returned",
+        ),
+        converters={"code": int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        response: requests.Response,
+        code: int,
+        srv: PactServer,
+    ) -> None:
+        """
+        A response is returned.
+        """
+        logging.info(
+            "Request Information:\n%s",
+            json.dumps(
+                {
+                    "method": response.request.method,
+                    "url": response.request.url,
+                    "headers": dict(**response.request.headers),
+                    "body": truncate(response.request.body)
+                    if response.request.body
+                    else None,
+                },
+                indent=2,
+            ),
+        )
+        logging.info("Mismatches:\n%s", json.dumps(srv.mismatches, indent=2))
+        assert response.status_code == code
+
+
+def the_payload_will_contain_the_json_document(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r'the payload will contain the "(?P<file>[^"]+)" JSON document',
+        ),
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        response: requests.Response,
+        file: str,
+    ) -> None:
+        """
+        The payload will contain the JSON document.
+        """
+        path = FIXTURES_ROOT / f"{file}.json"
+        assert response.json() == json.loads(path.read_text())
+
+
+def the_content_type_will_be_set_as(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r'the content type will be set as "(?P<content_type>[^"]+)"',
+        ),
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        response: requests.Response,
+        content_type: str,
+    ) -> None:
+        assert response.headers["Content-Type"] == content_type
+
+
+def the_mock_server_status_will_be(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(r"the mock server status will (?P<negated>(NOT )?)be OK"),
+        converters={"negated": lambda s: s == "NOT "},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+        negated: bool,  # noqa: FBT001
+    ) -> None:
+        """
+        The mock server status will be.
+        """
+        assert srv.matched is not negated
+
+
+def the_mock_server_status_will_be_an_expected_but_not_received_error_for_interaction_n(
+    stacklevel: int = 1,
+) -> None:
+    @then(
+        parsers.re(
+            r"the mock server status will be"
+            r" an expected but not received error"
+            r" for interaction \{(?P<n>\d+)\}",
+        ),
+        converters={"n": int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+        n: int,
+        interaction_definitions: dict[int, InteractionDefinition],
+    ) -> None:
+        """
+        The mock server status will be an expected but not received error.
+        """
+        assert srv.matched is False
+        assert len(srv.mismatches) > 0
+
+        for mismatch in srv.mismatches:
+            if (
+                mismatch["method"] == interaction_definitions[n].method
+                and mismatch["path"] == interaction_definitions[n].path
+                and mismatch["type"] == "missing-request"
+            ):
+                return
+        pytest.fail("Expected mismatch not found")
+
+
+def the_mock_server_status_will_be_an_unexpected_request_received_for_interaction_n(
+    stacklevel: int = 1,
+) -> None:
+    @then(
+        parsers.re(
+            r"the mock server status will be"
+            r' an unexpected "(?P<method>[^"]+)" request received error'
+            r" for interaction \{(?P<n>\d+)\}",
+        ),
+        converters={"n": int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+        method: str,
+        n: int,
+        interaction_definitions: dict[int, InteractionDefinition],
+    ) -> None:
+        """
+        The mock server status will be an expected but not received error.
+        """
+        assert srv.matched is False
+        assert len(srv.mismatches) > 0
+
+        for mismatch in srv.mismatches:
+            if (
+                mismatch["method"] == interaction_definitions[n].method
+                and mismatch["request"]["method"] == method
+                and mismatch["path"] == interaction_definitions[n].path
+                and mismatch["type"] == "request-not-found"
+            ):
+                return
+        pytest.fail("Expected mismatch not found")
+
+
+def the_mock_server_status_will_be_an_unexpected_request_received_for_path(
+    stacklevel: int = 1,
+) -> None:
+    @then(
+        parsers.re(
+            r"the mock server status will be"
+            r' an unexpected "(?P<method>[^"]+)" request received error'
+            r' for path "(?P<path>[^"]+)"',
+        ),
+        converters={"n": int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+        method: str,
+        path: str,
+    ) -> None:
+        """
+        The mock server status will be an expected but not received.
+        """
+        assert srv.matched is False
+        assert len(srv.mismatches) > 0
+
+        for mismatch in srv.mismatches:
+            if (
+                mismatch["request"]["method"] == method
+                and mismatch["path"] == path
+                and mismatch["type"] == "request-not-found"
+            ):
+                return
+        pytest.fail("Expected mismatch not found")
+
+
+def the_mock_server_status_will_be_mismatches(stacklevel: int = 1) -> None:
+    @then(
+        "the mock server status will be mismatches",
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+    ) -> None:
+        """
+        The mock server status will be mismatches.
+        """
+        assert srv.matched is False
+        assert len(srv.mismatches) > 0
+
+
+def the_mismatches_will_contain_a_mismatch_with_the_error(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r'the mismatches will contain a "(?P<mismatch_type>[^"]+)" mismatch'
+            r' with error "(?P<error>[^"]+)"',
+        ),
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+        mismatch_type: str,
+        error: str,
+    ) -> None:
+        """
+        The mismatches will contain a mismatch with the error.
+        """
+        if mismatch_type == "query":
+            mismatch_type = "QueryMismatch"
+        elif mismatch_type == "header":
+            mismatch_type = "HeaderMismatch"
+        elif mismatch_type == "body":
+            mismatch_type = "BodyMismatch"
+        elif mismatch_type == "body-content-type":
+            mismatch_type = "BodyTypeMismatch"
+        else:
+            msg = f"Unexpected mismatch type: {mismatch_type}"
+            raise ValueError(msg)
+
+        logger.info("Expecting mismatch: %s", mismatch_type)
+        logger.info("With error: %s", error)
+        for mismatch in srv.mismatches:
+            for sub_mismatch in mismatch["mismatches"]:
+                if (
+                    error in sub_mismatch["mismatch"]
+                    and sub_mismatch["type"] == mismatch_type
+                ):
+                    return
+        pytest.fail("Expected mismatch not found")
+
+
+def the_mismatches_will_contain_a_mismatch_with_path_with_the_error(
+    stacklevel: int = 1,
+) -> None:
+    @then(
+        parsers.re(
+            r'the mismatches will contain a "(?P<mismatch_type>[^"]+)" mismatch'
+            r' with path "(?P<path>[^"]+)"'
+            r' with error "(?P<error>[^"]+)"',
+        ),
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+        mismatch_type: str,
+        path: str,
+        error: str,
+    ) -> None:
+        """
+        The mismatches will contain a mismatch with the error.
+        """
+        mismatch_type = "BodyMismatch" if mismatch_type == "body" else mismatch_type
+        for mismatch in srv.mismatches:
+            for sub_mismatch in mismatch["mismatches"]:
+                if (
+                    sub_mismatch["mismatch"] == error
+                    and sub_mismatch["type"] == mismatch_type
+                    and sub_mismatch["path"] == path
+                ):
+                    return
+        pytest.fail("Expected mismatch not found")
+
+
+def the_mock_server_will_write_out_a_pact_file_for_the_interaction_when_done(
+    stacklevel: int = 1,
+) -> None:
+    @then(
+        parsers.re(
+            r"the mock server will (?P<negated>(NOT )?)write out"
+            r" a Pact file for the interactions? when done",
+        ),
+        converters={"negated": lambda s: s == "NOT "},
+        target_fixture="pact_file",
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        srv: PactServer,
+        temp_dir: Path,
+        negated: bool,  # noqa: FBT001
+    ) -> dict[str, Any] | None:
+        """
+        The mock server will write out a Pact file for the interaction when done.
+        """
+        if not negated:
+            srv.write_file(temp_dir)
+            output = temp_dir / "consumer-provider.json"
+            assert output.is_file()
+            return json.load(output.open())
+        return None
+
+
+def the_pact_file_will_contain_n_interactions(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(r"the pact file will contain \{(?P<n>\d+)\} interactions?"),
+        converters={"n": int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        pact_file: dict[str, Any],
+        n: int,
+    ) -> None:
+        """
+        The pact file will contain n interactions.
+        """
+        assert len(pact_file["interactions"]) == n
+
+
+def the_nth_interaction_will_contain_the_document(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r"the \{(?P<n>\w+)\} interaction response"
+            r' will contain the "(?P<file>[^"]+)" document',
+        ),
+        converters={"n": string_to_int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        pact_file: dict[str, Any],
+        n: int,
+        file: str,
+    ) -> None:
+        """
+        The nth interaction response will contain the document.
+        """
+        file_path = FIXTURES_ROOT / file
+        if file.endswith(".json"):
+            assert pact_file["interactions"][n - 1]["response"]["body"] == json.load(
+                file_path.open(),
+            )
+
+
+def the_nth_interaction_request_will_be_for_method(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r"the \{(?P<n>\w+)\} interaction request"
+            r' will be for a "(?P<method>[A-Z]+)"',
+        ),
+        converters={"n": string_to_int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        pact_file: dict[str, Any],
+        n: int,
+        method: str,
+    ) -> None:
+        """
+        The nth interaction request will be for a method.
+        """
+        assert pact_file["interactions"][n - 1]["request"]["method"] == method
+
+
+def the_nth_interaction_request_query_parameters_will_be(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r"the \{(?P<n>\w+)\} interaction request"
+            r' query parameters will be "(?P<query>[^"]+)"',
+        ),
+        converters={"n": string_to_int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        pact_file: dict[str, Any],
+        n: int,
+        query: str,
+    ) -> None:
+        """
+        The nth interaction request query parameters will be.
+        """
+        assert query == pact_file["interactions"][n - 1]["request"]["query"]
+
+
+def the_nth_interaction_request_will_contain_the_header(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r"the \{(?P<n>\w+)\} interaction request"
+            r' will contain the header "(?P<key>[^"]+)"'
+            r' with value "(?P<value>[^"]+)"',
+        ),
+        converters={"n": string_to_int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        pact_file: dict[str, Any],
+        n: int,
+        key: str,
+        value: str,
+    ) -> None:
+        """
+        The nth interaction request will contain the header.
+        """
+        expected = {key: value}
+        actual = pact_file["interactions"][n - 1]["request"]["headers"]
+        assert expected.keys() == actual.keys()
+        for key in expected:
+            assert expected[key] == actual[key] or [expected[key]] == actual[key]
+
+
+def the_nth_interaction_request_content_type_will_be(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r"the \{(?P<n>\w+)\} interaction request"
+            r' content type will be "(?P<content_type>[^"]+)"',
+        ),
+        converters={"n": string_to_int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        pact_file: dict[str, Any],
+        n: int,
+        content_type: str,
+    ) -> None:
+        """
+        The nth interaction request will contain the header.
+        """
+        assert (
+            pact_file["interactions"][n - 1]["request"]["headers"]["Content-Type"]
+            == content_type
+        )
+
+
+def the_nth_interaction_request_will_contain_the_document(stacklevel: int = 1) -> None:
+    @then(
+        parsers.re(
+            r"the \{(?P<n>\w+)\} interaction request"
+            r' will contain the "(?P<file>[^"]+)" document',
+        ),
+        converters={"n": string_to_int},
+        stacklevel=stacklevel + 1,
+    )
+    def _(
+        pact_file: dict[str, Any],
+        n: int,
+        file: str,
+    ) -> None:
+        """
+        The nth interaction request will contain the document.
+        """
+        file_path = FIXTURES_ROOT / file
+        if file.endswith(".json"):
+            assert pact_file["interactions"][n - 1]["request"]["body"] == json.load(
+                file_path.open(),
+            )
+        else:
+            assert (
+                pact_file["interactions"][n - 1]["request"]["body"]
+                == file_path.read_text()
+            )


### PR DESCRIPTION
## :memo: Summary

This consists of two main changes:

- On the feature front, the addition of `with_matching_rules` to the `Interaction`. This allows for matching rules to be explicitly given, without the need to pass the matching rule JSON format to one of the other `with_*` functions.
- The implementation of the `v2/consumer` compatibility suite, which makes use of the new `with_matching_rules`.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Another step towards the compatibility suite being implemented

## :hammer: Test Plan

Compatibility suite, as part of CI/CD

## :link: Related issues/PRs

- Closes #474 