### PR TITLE
chore(deps): update to pact-ruby-standalone-v2.4.0

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -31,7 +31,7 @@ ROOT_DIR = Path(__file__).parent.resolve()
 
 # Latest version available at:
 # https://github.com/pact-foundation/pact-ruby-standalone/releases
-PACT_BIN_VERSION = os.getenv("PACT_BIN_VERSION", "2.1.0")
+PACT_BIN_VERSION = os.getenv("PACT_BIN_VERSION", "2.4.0")
 PACT_BIN_URL = "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v{version}/pact-{version}-{os}-{machine}.{ext}"
 
 # Latest version available at:


### PR DESCRIPTION
Updates Ruby 3.3.0 (from Ruby 3.2.2) & OpenSSL 3.2.0 (from OpenSSL 1.1.1)

Drops requirement for bash 

See full changelog v2.0.1 -> v2.4.0

https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md
