### PR TITLE
chore(ci): speed up wheels building on prs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,23 @@ jobs:
           # Fetch all tags
           fetch-depth: 0
 
+      - name: Filter targets
+        id: cibw-filter
+        shell: bash
+        # Building all wheels on PRs is too slow, so we filter them to target
+        # the latest stable version of Python.
+        run: |
+          if [[ "${{ github.event_name}}" == "pull_request" ]] ; then
+            echo "build=cp${STABLE_PYTHON_VERSION/./}-*" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=*" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create wheels
         uses: pypa/cibuildwheel@ce3fb7832089eb3e723a0a99cab7f3eaccf074fd # v2.16.5
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ steps.cibw-filter.outputs.build }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
         with:
           python-version: ${{ env.STABLE_PYTHON_VERSION }}
+          cache: pip
 
       - name: Install hatch
         run: pip install --upgrade hatch
@@ -73,6 +74,16 @@ jobs:
         with:
           # Fetch all tags
           fetch-depth: 0
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ github.workflow }}-pip-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ github.workflow }}-pip-${{ runner.os }}
+            ${{ github.workflow }}-pip
+            ${{ github.workflow }}
 
       - name: Filter targets
         id: cibw-filter
@@ -123,6 +134,16 @@ jobs:
           # Fetch all tags
           fetch-depth: 0
 
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ github.workflow }}-pip-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ github.workflow }}-pip-${{ runner.os }}
+            ${{ github.workflow }}-pip
+            ${{ github.workflow }}
+
       - name: Set up QEMU
         if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
@@ -153,10 +174,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
       - name: Setup Python
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
         with:
           python-version: ${{ env.STABLE_PYTHON_VERSION }}
+          cache: pip
 
       - uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       - name: Install Hatch
         run: pip install --upgrade hatch
@@ -96,6 +97,7 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
         with:
           python-version: ${{ env.STABLE_PYTHON_VERSION }}
+          cache: pip
 
       - name: Install Hatch
         run: pip install --upgrade hatch
@@ -128,6 +130,7 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
         with:
           python-version: ${{ env.STABLE_PYTHON_VERSION }}
+          cache: pip
 
       - name: Install Hatch
         run: pip install --upgrade hatch


### PR DESCRIPTION
## :memo: Summary

Use a filter to target the latest stable version of Python when building wheels on PRs. Otherwise, the workflow takes an unnecessarily long amount of time to execute.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

The workflow was unnecessarily slow.

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None