### PR TITLE
feat(v3): add specification attribute to pacts

### DIFF
--- a/src/pact/v3/ffi.py
+++ b/src/pact/v3/ffi.py
@@ -675,6 +675,27 @@ class PactSpecification(Enum):
     V3 = lib.PactSpecification_V3
     V4 = lib.PactSpecification_V4
 
+    @classmethod
+    def from_str(cls, version: str) -> PactSpecification:
+        """
+        Instantiate a Pact Specification from a string.
+
+        This method is case-insensitive, and allows for the version to be
+        specified with or without a leading "V", and with either a dot or an
+        underscore as the separator.
+
+        Args:
+            version:
+                The version of the Pact Specification.
+
+        Returns:
+            The Pact Specification.
+        """
+        version = version.upper().replace(".", "_")
+        if version.startswith("V"):
+            return cls[version]
+        return cls["V" + version]
+
     def __str__(self) -> str:
         """
         Informal string representation of the Pact Specification.
@@ -5280,7 +5301,7 @@ def handle_get_pact_spec_version(handle: PactHandle) -> PactSpecification:
     Returns:
         The spec version for the Pact model.
     """
-    raise NotImplementedError
+    return PactSpecification(lib.pactffi_handle_get_pact_spec_version(handle._ref))
 
 
 def with_pact_metadata(

--- a/src/pact/v3/pact.py
+++ b/src/pact/v3/pact.py
@@ -109,6 +109,13 @@ class Pact:
         """
         return self._provider
 
+    @property
+    def specification(self) -> pact.v3.ffi.PactSpecification:
+        """
+        Pact specification version.
+        """
+        return pact.v3.ffi.handle_get_pact_spec_version(self._handle)
+
     def with_specification(
         self,
         version: str | pact.v3.ffi.PactSpecification,
@@ -128,11 +135,7 @@ class Pact:
                 prefix.
         """
         if isinstance(version, str):
-            version = version.upper().replace(".", "_")
-            if version.startswith("V"):
-                version = pact.v3.ffi.PactSpecification[version]
-            else:
-                version = pact.v3.ffi.PactSpecification["V" + version]
+            version = pact.v3.ffi.PactSpecification.from_str(version)
         pact.v3.ffi.with_specification(self._handle, version)
         return self
 

--- a/tests/v3/test_pact.py
+++ b/tests/v3/test_pact.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal
 import pytest
 
 from pact.v3 import Pact
+from pact.v3.ffi import PactSpecification
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -131,6 +132,7 @@ def test_write_file(pact: Pact, temp_dir: Path) -> None:
 )
 def test_specification(pact: Pact, version: str) -> None:
     pact.with_specification(version)
+    assert pact.specification == PactSpecification.from_str(version)
 
 
 def test_server_log(pact: Pact) -> None:


### PR DESCRIPTION
## :memo: Summary

Add new `.specification` attribute to the `Pact` class.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

A recent FFI release added the functionality to retrieve the specification behind a `PactHandle`. Using this feature, it is now possible to get the specification of the current Pact.

## :hammer: Test Plan

Added in unit tests.

## :link: Related issues/PRs

None