### PR TITLE
chore(ci): remove check of wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,31 +163,6 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
-  check:
-    name: Check wheels
-
-    runs-on: ubuntu-latest
-
-    needs:
-      - build-x86_64
-      - build-arm64
-
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-
-      - name: Setup Python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5
-        with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
-          cache: pip
-
-      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4
-        with:
-          path: wheelhouse
-
-      - run: |
-          pipx run twine check --strict wheelhouse/*
-
   publish:
     name: Publish wheels and sdist
 


### PR DESCRIPTION
## :memo: Summary

The cibuildwheel process does a check that the wheels are valid, and also performs an installation of the wheel and a basic check that the import is working fine. It seems redundant to be doing a separate check.

This was intended in commit 9604839, but a rebase inadvertently re-introduced the check.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Speed up the pipeline.

## :hammer: Test Plan

Regular CI

## :link: Related issues/PRs

- 02eab542cc667ac3d19bd6acaf0d7a4a0
- #567

