### PR TITLE
chore(ci): speed up build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,8 +125,13 @@ jobs:
         include:
           - os: ubuntu-latest
             archs: aarch64
+            build: manylinux
+          - os: ubuntu-latest
+            archs: aarch64
+            build: musllinx
           - os: macos-latest
             archs: arm64
+            build: ""
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -154,11 +159,12 @@ jobs:
         uses: pypa/cibuildwheel@ce3fb7832089eb3e723a0a99cab7f3eaccf074fd # v2.16.5
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ matrix.build == '' && '*' || format('*{0}*', matrix.build) }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.archs }}
+          name: wheels-${{ matrix.os }}-${{ matrix.archs }}-${{  matrix.build }}
           path: ./wheelhouse/*.whl
           if-no-files-found: error
           compression-level: 0


### PR DESCRIPTION
## :memo: Summary

This commit simply parallelises the `musllinux` and `manylinux` builds.

## :fire: Motivation

The building of the `aarch64` wheels takes a _very_ long time. Until such time that GitHub provides ARM Linux runners, we unfortunately have to resort to emulation.

This is made worse specifically for Linux due the doubling of the number of targets from having both `manylinux` and `musllinux` wheels.

## :hammer: Test Plan

Build pipeline in CI

## :link: Related issues/PRs

None
