### PR TITLE
docs: fix repository link typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 
 [project.urls]
 "Homepage"      = "https://pact.io"
-"Repository"    = "https://github.com/pact-foundation-pact-python"
+"Repository"    = "https://github.com/pact-foundation/pact-python"
 "Documentation" = "https://docs.pact.io"
 "Bug Tracker"   = "https://github.com/pact-foundation/pact-python/issues"
 "Changelog"     = "https://github.com/pact-foundation/pact-python/blob/master/CHANGELOG.md"


### PR DESCRIPTION
## :memo: Summary

Fix a typo in the repository link.

## ~:rotating_light: Breaking Changes~