### PR TITLE
chore(ci): clean wheels

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -75,6 +75,11 @@ class PactBuildHook(BuildHookInterface[Any]):
         for subdir in ["bin", "lib", "data"]:
             shutil.rmtree(PACT_ROOT_DIR / subdir, ignore_errors=True)
 
+        for ffi in (PACT_ROOT_DIR / "v3").glob("_ffi.*"):
+            if ffi.name == "_ffi.pyi":
+                continue
+            ffi.unlink()
+
     def initialize(
         self,
         version: str,  # noqa: ARG002

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,6 +293,10 @@ exclude = '^(src/pact|tests)/(?!v3).+\.py$'
 ## CI Build Wheel
 ################################################################################
 [tool.cibuildwheel]
+before-build = """
+python -m pip install hatch
+hatch clean
+"""
 test-command = """
 python -c \
 "from pact import EachLike; \


### PR DESCRIPTION
## :memo: Summary

Have cibuildwheel clean the repository before each build.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

In the release of `2.1.2`, it was discovered that [cibuildwheel](https://cibuildwheel.readthedocs.io/) does not clean the repository between each build. This resulted in each wheel containing the binary artifacts of all previous wheels; resulting in in unnecessarily bloated wheels.

## :hammer: Test Plan

Tested locally

## :link: Related issues/PRs

None