### PR TITLE
Chore/more wheel fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build source distribution
 
     if: github.event_name == 'push' || ! github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -62,11 +62,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             archs: x86_64
-          - os: macos-latest
+          - os: macos-12
             archs: x86_64
-          - os: windows-latest
+          - os: windows-2019
             archs: AMD64
 
     steps:
@@ -123,13 +123,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             archs: aarch64
             build: manylinux
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             archs: aarch64
             build: musllinux
-          - os: macos-latest
+          - os: macos-12
             archs: arm64
             build: ""
 
@@ -150,7 +150,7 @@ jobs:
             ${{ github.workflow }}
 
       - name: Set up QEMU
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os, 'ubuntu-')
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
         with:
           platforms: arm64
@@ -173,7 +173,7 @@ jobs:
     name: Publish wheels and sdist
 
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: pypi
 
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,11 @@ jobs:
             echo "build=*" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set macOS deployment target
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=10.12" >> "$GITHUB_ENV"
+
       - name: Create wheels
         uses: pypa/cibuildwheel@ce3fb7832089eb3e723a0a99cab7f3eaccf074fd # v2.16.5
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,16 +293,14 @@ exclude = '^(src/pact|tests)/(?!v3).+\.py$'
 ## CI Build Wheel
 ################################################################################
 [tool.cibuildwheel]
+skip = "pp38-*"
 before-build = """
-python -m pip install hatch
-hatch clean
-if ! command -v cargo &> /dev/null; then
-  curl -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y
-  for bin in $(ls "$HOME/.cargo/bin"); do
-    ln -v "$HOME/.cargo/bin/$bin" "/usr/bin/$bin"
-  done
-  rustup show
-fi
+rm -rvf src/pact/v3/bin
+rm -rvf src/pact/v3/data
+rm -rvf src/pact/v3/lib
+mv -v src/pact/v3/_ffi.pyi _ffi.pyi
+rm -rvf src/pact/v3/_ffi.*
+mv -v _ffi.pyi src/pact/v3/_ffi.pyi
 """
 test-command = """
 python -c \


### PR DESCRIPTION
## :memo: Summary

A combination of a few additional fixes:

* chore(ci): replace hatch clean with rm (228dfa7) <JP-Ellis>

  Install hatch on the PyPy images seems unnecessarily difficult, just to run a
  few `rm` commands. So I am replacing the before-build step with the required
  `rm` commands.

* chore(ci): set osx deployment target (5085931) <JP-Ellis>

  To avoid ambiguity, setting the macOS deployment target explicitly.

* chore(ci): pin os to older versions (325f731) <JP-Ellis>

  To ensure that the wheels generated are compatible with as many devices as
  possible, I am pinning the operating systems of the runners to the oldest
  version currently supported.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Ensuring greater compatibility, and fixing the PyPy builds.

## :hammer: Test Plan

In CI

## :link: Related issues/PRs

None