### PR TITLE
chore(ci): adapt before-build for windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,3 +315,11 @@ assert isinstance(pact.v3.ffi.version(), str);\""""
 # The repair tool unfortunately did not like the bundled Ruby distributable.
 # TODO: Check whether delocate-wheel can be configured.
 repair-wheel-command = ""
+
+[tool.cibuildwheel.windows]
+before-build = [
+  'FOR /R src\pact\v3 %G IN (_ffi.*) DO IF NOT %~nxG == _ffi.pyi DEL /F /Q "%G"',
+  'IF EXIST src\pact\v3\bin\ RMDIR /S /Q src\pact\v3\bin',
+  'IF EXIST src\pact\v3\data\ RMDIR /S /Q src\pact\v3\data',
+  'IF EXIST src\pact\v3\lib\ RMDIR /S /Q src\pact\v3\lib',
+]


### PR DESCRIPTION
## :memo: Summary

The `rm` and `mv` commands don't work well within Windows' default shell. As a result, a separate script for Windows is required.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Avoid bloat on Windows too (it is fixed for Linux and macOS).

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None