### PR TITLE
fix: delay pytest 8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ test = [
   "flask[async]      ~= 3.0",
   "httpx             ~= 0.0",
   "mock              ~= 5.0",
-  "pytest            ~=8.0",
+  # pytest 8.1.0 is not compatible with pytest-bdd yet
+  "pytest            ~= 8.0.0",
   "pytest-asyncio    ~= 0.0",
   "pytest-bdd        ~= 7.0",
   "pytest-cov        ~= 4.0",


### PR DESCRIPTION
## :memo: Summary

Unfortunately, pytest-bdd is not yet compatible with some of the internal changes introduced in PyTest 8.1.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Fix CI

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None