### PR TITLE
chore: fix missed s/test/devel-test/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ docs-build = "mkdocs build {args}"
 # Test environment for running unit tests. This automatically tests against all
 # supported Python versions.
 [tool.hatch.envs.test]
-features = ["test"]
+features = ["devel-test"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]


### PR DESCRIPTION
## :memo: Summary

Fix a missed renaming of `test` to `devel-test` in the optional feature groups.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Hatch test matrix doesn't work otherwise.

## :hammer: Test Plan

Tested locally

## :link: Related issues/PRs

None