### PR TITLE
feat: upgrade FFI to 0.4.19

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -36,7 +36,7 @@ PACT_BIN_URL = "https://github.com/pact-foundation/pact-ruby-standalone/releases
 
 # Latest version available at:
 # https://github.com/pact-foundation/pact-reference/releases
-PACT_LIB_VERSION = os.getenv("PACT_LIB_VERSION", "0.4.18")
+PACT_LIB_VERSION = os.getenv("PACT_LIB_VERSION", "0.4.19")
 PACT_LIB_URL = "https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v{version}/{prefix}pact_ffi-{os}-{machine}.{ext}"
 
 
@@ -254,7 +254,7 @@ class PactBuildHook(BuildHookInterface[Any]):
         platform = next(sys_tags()).platform
 
         if platform.startswith("macosx"):
-            os = "osx"
+            os = "macos"
             if platform.endswith("arm64"):
                 machine = "aarch64-apple-darwin"
             elif platform.endswith("x86_64"):

--- a/src/pact/v3/ffi.py
+++ b/src/pact/v3/ffi.py
@@ -134,7 +134,7 @@ class InteractionHandle:
     Handle to a HTTP Interaction.
 
     [Rust
-    `InteractionHandle`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/mock_server/handles/struct.InteractionHandle.html)
+    `InteractionHandle`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/mock_server/handles/struct.InteractionHandle.html)
     """
 
     def __init__(self, ref: int) -> None:
@@ -225,7 +225,7 @@ class PactHandle:
     Handle to a Pact.
 
     [Rust
-    `PactHandle`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/mock_server/handles/struct.PactHandle.html)
+    `PactHandle`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/mock_server/handles/struct.PactHandle.html)
     """
 
     def __init__(self, ref: int) -> None:
@@ -539,7 +539,7 @@ class VerifierHandle:
     """
     Handle to a Verifier.
 
-    [Rust `VerifierHandle`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/verifier/handle/struct.VerifierHandle.html)
+    [Rust `VerifierHandle`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/verifier/handle/struct.VerifierHandle.html)
     """
 
     def __init__(self, ref: cffi.FFI.CData) -> None:
@@ -575,7 +575,7 @@ class ExpressionValueType(Enum):
     """
     Expression Value Type.
 
-    [Rust `ExpressionValueType`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/models/expressions/enum.ExpressionValueType.html)
+    [Rust `ExpressionValueType`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/models/expressions/enum.ExpressionValueType.html)
     """
 
     UNKNOWN = lib.ExpressionValueType_Unknown
@@ -602,7 +602,7 @@ class GeneratorCategory(Enum):
     """
     Generator Category.
 
-    [Rust `GeneratorCategory`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/models/generators/enum.GeneratorCategory.html)
+    [Rust `GeneratorCategory`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/models/generators/enum.GeneratorCategory.html)
     """
 
     METHOD = lib.GeneratorCategory_METHOD
@@ -630,7 +630,7 @@ class InteractionPart(Enum):
     """
     Interaction Part.
 
-    [Rust `InteractionPart`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/mock_server/handles/enum.InteractionPart.html)
+    [Rust `InteractionPart`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/mock_server/handles/enum.InteractionPart.html)
     """
 
     REQUEST = lib.InteractionPart_Request
@@ -676,7 +676,7 @@ class MatchingRuleCategory(Enum):
     """
     Matching Rule Category.
 
-    [Rust `MatchingRuleCategory`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/models/matching_rules/enum.MatchingRuleCategory.html)
+    [Rust `MatchingRuleCategory`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/models/matching_rules/enum.MatchingRuleCategory.html)
     """
 
     METHOD = lib.MatchingRuleCategory_METHOD
@@ -705,7 +705,7 @@ class PactSpecification(Enum):
     """
     Pact Specification.
 
-    [Rust `PactSpecification`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/models/pact_specification/enum.PactSpecification.html)
+    [Rust `PactSpecification`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/models/pact_specification/enum.PactSpecification.html)
     """
 
     UNKNOWN = lib.PactSpecification_Unknown
@@ -758,7 +758,7 @@ class StringResult:
         """
         Internal enum from Pact FFI.
 
-        [Rust `StringResult`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/mock_server/enum.StringResult.html)
+        [Rust `StringResult`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/mock_server/enum.StringResult.html)
         """
 
         FAILED = lib.StringResult_Failed
@@ -905,7 +905,7 @@ def version() -> str:
     """
     Return the version of the pact_ffi library.
 
-    [Rust `pactffi_version`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_version)
+    [Rust `pactffi_version`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_version)
 
     Returns:
         The version of the pact_ffi library as a string, in the form of `x.y.z`.
@@ -925,7 +925,7 @@ def init(log_env_var: str) -> None:
     tracing subscriber.
 
     [Rust
-    `pactffi_init`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_init)
+    `pactffi_init`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_init)
 
     # Safety
 
@@ -942,7 +942,7 @@ def init_with_log_level(level: str = "INFO") -> None:
     tracing subscriber.
 
     [Rust
-    `pactffi_init_with_log_level`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_init_with_log_level)
+    `pactffi_init_with_log_level`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_init_with_log_level)
 
     Args:
         level:
@@ -962,7 +962,7 @@ def enable_ansi_support() -> None:
     On non-Windows platforms, this function is a no-op.
 
     [Rust
-    `pactffi_enable_ansi_support`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_enable_ansi_support)
+    `pactffi_enable_ansi_support`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_enable_ansi_support)
 
     # Safety
 
@@ -980,7 +980,7 @@ def log_message(
     Log using the shared core logging facility.
 
     [Rust
-    `pactffi_log_message`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_log_message)
+    `pactffi_log_message`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_log_message)
 
     This is useful for callers to have a single set of logs.
 
@@ -1014,7 +1014,7 @@ def match_message(msg_1: Message, msg_2: Message) -> Mismatches:
     If the messages match, the returned collection will be empty.
 
     [Rust
-    `pactffi_match_message`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_match_message)
+    `pactffi_match_message`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_match_message)
     """
     raise NotImplementedError
 
@@ -1024,7 +1024,7 @@ def mismatches_get_iter(mismatches: Mismatches) -> MismatchesIterator:
     Get an iterator over mismatches.
 
     [Rust
-    `pactffi_mismatches_get_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatches_get_iter)
+    `pactffi_mismatches_get_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatches_get_iter)
     """
     raise NotImplementedError
 
@@ -1033,7 +1033,7 @@ def mismatches_delete(mismatches: Mismatches) -> None:
     """
     Delete mismatches.
 
-    [Rust `pactffi_mismatches_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatches_delete)
+    [Rust `pactffi_mismatches_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatches_delete)
     """
     raise NotImplementedError
 
@@ -1042,7 +1042,7 @@ def mismatches_iter_next(iter: MismatchesIterator) -> Mismatch:
     """
     Get the next mismatch from a mismatches iterator.
 
-    [Rust `pactffi_mismatches_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatches_iter_next)
+    [Rust `pactffi_mismatches_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatches_iter_next)
 
     Returns a null pointer if no mismatches remain.
     """
@@ -1053,7 +1053,7 @@ def mismatches_iter_delete(iter: MismatchesIterator) -> None:
     """
     Delete a mismatches iterator when you're done with it.
 
-    [Rust `pactffi_mismatches_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatches_iter_delete)
+    [Rust `pactffi_mismatches_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatches_iter_delete)
     """
     raise NotImplementedError
 
@@ -1062,7 +1062,7 @@ def mismatch_to_json(mismatch: Mismatch) -> str:
     """
     Get a JSON representation of the mismatch.
 
-    [Rust `pactffi_mismatch_to_json`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatch_to_json)
+    [Rust `pactffi_mismatch_to_json`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatch_to_json)
     """
     raise NotImplementedError
 
@@ -1071,7 +1071,7 @@ def mismatch_type(mismatch: Mismatch) -> str:
     """
     Get the type of a mismatch.
 
-    [Rust `pactffi_mismatch_type`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatch_type)
+    [Rust `pactffi_mismatch_type`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatch_type)
     """
     raise NotImplementedError
 
@@ -1080,7 +1080,7 @@ def mismatch_summary(mismatch: Mismatch) -> str:
     """
     Get a summary of a mismatch.
 
-    [Rust `pactffi_mismatch_summary`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatch_summary)
+    [Rust `pactffi_mismatch_summary`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatch_summary)
     """
     raise NotImplementedError
 
@@ -1089,7 +1089,7 @@ def mismatch_description(mismatch: Mismatch) -> str:
     """
     Get a description of a mismatch.
 
-    [Rust `pactffi_mismatch_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatch_description)
+    [Rust `pactffi_mismatch_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatch_description)
     """
     raise NotImplementedError
 
@@ -1098,7 +1098,7 @@ def mismatch_ansi_description(mismatch: Mismatch) -> str:
     """
     Get an ANSI-compatible description of a mismatch.
 
-    [Rust `pactffi_mismatch_ansi_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mismatch_ansi_description)
+    [Rust `pactffi_mismatch_ansi_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mismatch_ansi_description)
     """
     raise NotImplementedError
 
@@ -1108,7 +1108,7 @@ def get_error_message(length: int = 1024) -> str | None:
     Provide the error message from `LAST_ERROR` to the calling C code.
 
     [Rust
-    `pactffi_get_error_message`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_get_error_message)
+    `pactffi_get_error_message`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_get_error_message)
 
     This function should be called after any other function in the pact_matching
     FFI indicates a failure with its own error message, if the caller wants to
@@ -1161,7 +1161,7 @@ def log_to_stdout(level_filter: LevelFilter) -> int:
     """
     Convenience function to direct all logging to stdout.
 
-    [Rust `pactffi_log_to_stdout`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_log_to_stdout)
+    [Rust `pactffi_log_to_stdout`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_log_to_stdout)
     """
     raise NotImplementedError
 
@@ -1171,7 +1171,7 @@ def log_to_stderr(level_filter: LevelFilter | str = LevelFilter.ERROR) -> None:
     Convenience function to direct all logging to stderr.
 
     [Rust
-    `pactffi_log_to_stderr`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_log_to_stderr)
+    `pactffi_log_to_stderr`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_log_to_stderr)
 
     Args:
         level_filter:
@@ -1195,7 +1195,7 @@ def log_to_file(file_name: str, level_filter: LevelFilter) -> int:
     Convenience function to direct all logging to a file.
 
     [Rust
-    `pactffi_log_to_file`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_log_to_file)
+    `pactffi_log_to_file`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_log_to_file)
 
     # Safety
 
@@ -1209,7 +1209,7 @@ def log_to_buffer(level_filter: LevelFilter | str = LevelFilter.ERROR) -> None:
     """
     Convenience function to direct all logging to a task local memory buffer.
 
-    [Rust `pactffi_log_to_buffer`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_log_to_buffer)
+    [Rust `pactffi_log_to_buffer`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_log_to_buffer)
     """
     if isinstance(level_filter, str):
         level_filter = LevelFilter[level_filter.upper()]
@@ -1223,7 +1223,7 @@ def logger_init() -> None:
     """
     Initialize the FFI logger with no sinks.
 
-    [Rust `pactffi_logger_init`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_logger_init)
+    [Rust `pactffi_logger_init`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_logger_init)
 
     This initialized logger does nothing until `pactffi_logger_apply` has been called.
 
@@ -1245,7 +1245,7 @@ def logger_attach_sink(sink_specifier: str, level_filter: LevelFilter) -> int:
     Attach an additional sink to the thread-local logger.
 
     [Rust
-    `pactffi_logger_attach_sink`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_logger_attach_sink)
+    `pactffi_logger_attach_sink`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_logger_attach_sink)
 
     This logger does nothing until `pactffi_logger_apply` has been called.
 
@@ -1292,7 +1292,7 @@ def logger_apply() -> int:
     Apply the previously configured sinks and levels to the program.
 
     [Rust
-    `pactffi_logger_apply`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_logger_apply)
+    `pactffi_logger_apply`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_logger_apply)
 
     If no sinks have been setup, will set the log level to info and the target
     to standard out.
@@ -1308,7 +1308,7 @@ def fetch_log_buffer(log_id: str) -> str:
     Fetch the in-memory logger buffer contents.
 
     [Rust
-    `pactffi_fetch_log_buffer`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_fetch_log_buffer)
+    `pactffi_fetch_log_buffer`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_fetch_log_buffer)
 
     This will only have any contents if the `buffer` sink has been configured to
     log to. The contents will be allocated on the heap and will need to be freed
@@ -1334,7 +1334,7 @@ def parse_pact_json(json: str) -> Pact:
     Parses the provided JSON into a Pact model.
 
     [Rust
-    `pactffi_parse_pact_json`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_parse_pact_json)
+    `pactffi_parse_pact_json`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_parse_pact_json)
 
     The returned Pact model must be freed with the `pactffi_pact_model_delete`
     function when no longer needed.
@@ -1351,7 +1351,7 @@ def pact_model_delete(pact: Pact) -> None:
     """
     Frees the memory used by the Pact model.
 
-    [Rust `pactffi_pact_model_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_model_delete)
+    [Rust `pactffi_pact_model_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_model_delete)
     """
     raise NotImplementedError
 
@@ -1361,7 +1361,7 @@ def pact_model_interaction_iterator(pact: Pact) -> PactInteractionIterator:
     Returns an iterator over all the interactions in the Pact.
 
     [Rust
-    `pactffi_pact_model_interaction_iterator`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_model_interaction_iterator)
+    `pactffi_pact_model_interaction_iterator`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_model_interaction_iterator)
 
     The iterator will have to be deleted using the
     `pactffi_pact_interaction_iter_delete` function. The iterator will contain a
@@ -1380,7 +1380,7 @@ def pact_spec_version(pact: Pact) -> PactSpecification:
     """
     Returns the Pact specification enum that the Pact is for.
 
-    [Rust `pactffi_pact_spec_version`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_spec_version)
+    [Rust `pactffi_pact_spec_version`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_spec_version)
     """
     raise NotImplementedError
 
@@ -1389,7 +1389,7 @@ def pact_interaction_delete(interaction: PactInteraction) -> None:
     """
     Frees the memory used by the Pact interaction model.
 
-    [Rust `pactffi_pact_interaction_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_interaction_delete)
+    [Rust `pactffi_pact_interaction_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_interaction_delete)
     """
     raise NotImplementedError
 
@@ -1398,7 +1398,7 @@ def async_message_new() -> AsynchronousMessage:
     """
     Get a mutable pointer to a newly-created default message on the heap.
 
-    [Rust `pactffi_async_message_new`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_new)
+    [Rust `pactffi_async_message_new`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_new)
 
     # Safety
 
@@ -1415,7 +1415,7 @@ def async_message_delete(message: AsynchronousMessage) -> None:
     """
     Destroy the `AsynchronousMessage` being pointed to.
 
-    [Rust `pactffi_async_message_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_delete)
+    [Rust `pactffi_async_message_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_delete)
     """
     raise NotImplementedError
 
@@ -1425,7 +1425,7 @@ def async_message_get_contents(message: AsynchronousMessage) -> MessageContents:
     Get the message contents of an `AsynchronousMessage` as a `MessageContents` pointer.
 
     [Rust
-    `pactffi_async_message_get_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_get_contents)
+    `pactffi_async_message_get_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_get_contents)
 
     # Safety
 
@@ -1444,7 +1444,7 @@ def async_message_get_contents_str(message: AsynchronousMessage) -> str:
     """
     Get the message contents of an `AsynchronousMessage` in string form.
 
-    [Rust `pactffi_async_message_get_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_get_contents_str)
+    [Rust `pactffi_async_message_get_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_get_contents_str)
 
     # Safety
 
@@ -1471,7 +1471,7 @@ def async_message_set_contents_str(
     Sets the contents of the message as a string.
 
     [Rust
-    `pactffi_async_message_set_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_set_contents_str)
+    `pactffi_async_message_set_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_set_contents_str)
 
     - `message` - the message to set the contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -1499,7 +1499,7 @@ def async_message_get_contents_length(message: AsynchronousMessage) -> int:
     Get the length of the contents of a `AsynchronousMessage`.
 
     [Rust
-    `pactffi_async_message_get_contents_length`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_get_contents_length)
+    `pactffi_async_message_get_contents_length`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_get_contents_length)
 
     # Safety
 
@@ -1518,7 +1518,7 @@ def async_message_get_contents_bin(message: AsynchronousMessage) -> str:
     Get the contents of an `AsynchronousMessage` as bytes.
 
     [Rust
-    `pactffi_async_message_get_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_get_contents_bin)
+    `pactffi_async_message_get_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_get_contents_bin)
 
     # Safety
 
@@ -1545,7 +1545,7 @@ def async_message_set_contents_bin(
     Sets the contents of the message as an array of bytes.
 
     [Rust
-    `pactffi_async_message_set_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_set_contents_bin)
+    `pactffi_async_message_set_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_set_contents_bin)
 
     * `message` - the message to set the contents for
     * `contents` - pointer to contents to copy from
@@ -1572,7 +1572,7 @@ def async_message_get_description(message: AsynchronousMessage) -> str:
     Get a copy of the description.
 
     [Rust
-    `pactffi_async_message_get_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_get_description)
+    `pactffi_async_message_get_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_get_description)
 
     # Safety
 
@@ -1598,7 +1598,7 @@ def async_message_set_description(
     """
     Write the `description` field on the `AsynchronousMessage`.
 
-    [Rust `pactffi_async_message_set_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_set_description)
+    [Rust `pactffi_async_message_set_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_set_description)
 
     # Safety
 
@@ -1623,7 +1623,7 @@ def async_message_get_provider_state(
     Get a copy of the provider state at the given index from this message.
 
     [Rust
-    `pactffi_async_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_get_provider_state)
+    `pactffi_async_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_get_provider_state)
 
     # Safety
 
@@ -1648,7 +1648,7 @@ def async_message_get_provider_state_iter(
     """
     Get an iterator over provider states.
 
-    [Rust `pactffi_async_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_async_message_get_provider_state_iter)
+    [Rust `pactffi_async_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_async_message_get_provider_state_iter)
 
     # Safety
 
@@ -1665,7 +1665,7 @@ def consumer_get_name(consumer: Consumer) -> str:
     r"""
     Get a copy of this consumer's name.
 
-    [Rust `pactffi_consumer_get_name`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_consumer_get_name)
+    [Rust `pactffi_consumer_get_name`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_consumer_get_name)
 
     The copy must be deleted with `pactffi_string_delete`.
 
@@ -1711,7 +1711,7 @@ def pact_get_consumer(pact: Pact) -> Consumer:
     `pactffi_pact_consumer_delete` when no longer required.
 
     [Rust
-    `pactffi_pact_get_consumer`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_get_consumer)
+    `pactffi_pact_get_consumer`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_get_consumer)
 
     # Errors
 
@@ -1725,7 +1725,7 @@ def pact_consumer_delete(consumer: Consumer) -> None:
     """
     Frees the memory used by the Pact consumer.
 
-    [Rust `pactffi_pact_consumer_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_consumer_delete)
+    [Rust `pactffi_pact_consumer_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_consumer_delete)
     """
     raise NotImplementedError
 
@@ -1734,7 +1734,7 @@ def message_contents_get_contents_str(contents: MessageContents) -> str:
     """
     Get the message contents in string form.
 
-    [Rust `pactffi_message_contents_get_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_get_contents_str)
+    [Rust `pactffi_message_contents_get_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_get_contents_str)
 
     # Safety
 
@@ -1761,7 +1761,7 @@ def message_contents_set_contents_str(
     Sets the contents of the message as a string.
 
     [Rust
-    `pactffi_message_contents_set_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_set_contents_str)
+    `pactffi_message_contents_set_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_set_contents_str)
 
     * `contents` - the message contents to set the contents for
     * `contents_str` - pointer to contents to copy from. Must be a valid
@@ -1788,7 +1788,7 @@ def message_contents_get_contents_length(contents: MessageContents) -> int:
     """
     Get the length of the message contents.
 
-    [Rust `pactffi_message_contents_get_contents_length`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_get_contents_length)
+    [Rust `pactffi_message_contents_get_contents_length`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_get_contents_length)
 
     # Safety
 
@@ -1807,7 +1807,7 @@ def message_contents_get_contents_bin(contents: MessageContents) -> str:
     Get the contents of a message as a pointer to an array of bytes.
 
     [Rust
-    `pactffi_message_contents_get_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_get_contents_bin)
+    `pactffi_message_contents_get_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_get_contents_bin)
 
     # Safety
 
@@ -1834,7 +1834,7 @@ def message_contents_set_contents_bin(
     Sets the contents of the message as an array of bytes.
 
     [Rust
-    `pactffi_message_contents_set_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_set_contents_bin)
+    `pactffi_message_contents_set_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_set_contents_bin)
 
     * `message` - the message contents to set the contents for
     * `contents_bin` - pointer to contents to copy from
@@ -1863,7 +1863,7 @@ def message_contents_get_metadata_iter(
     Get an iterator over the metadata of a message.
 
     [Rust
-    `pactffi_message_contents_get_metadata_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_get_metadata_iter)
+    `pactffi_message_contents_get_metadata_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_get_metadata_iter)
 
     The returned pointer must be deleted with
     `pactffi_message_metadata_iter_delete` when done with it.
@@ -1894,7 +1894,7 @@ def message_contents_get_matching_rule_iter(
     Get an iterator over the matching rules for a category of a message.
 
     [Rust
-    `pactffi_message_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_get_matching_rule_iter)
+    `pactffi_message_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_get_matching_rule_iter)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_delete` when done with it.
@@ -1934,7 +1934,7 @@ def request_contents_get_matching_rule_iter(
     r"""
     Get an iterator over the matching rules for a category of an HTTP request.
 
-    [Rust `pactffi_request_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_request_contents_get_matching_rule_iter)
+    [Rust `pactffi_request_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_request_contents_get_matching_rule_iter)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_delete` when done with it.
@@ -1971,7 +1971,7 @@ def response_contents_get_matching_rule_iter(
     r"""
     Get an iterator over the matching rules for a category of an HTTP response.
 
-    [Rust `pactffi_response_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_response_contents_get_matching_rule_iter)
+    [Rust `pactffi_response_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_response_contents_get_matching_rule_iter)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_delete` when done with it.
@@ -2009,7 +2009,7 @@ def message_contents_get_generators_iter(
     Get an iterator over the generators for a category of a message.
 
     [Rust
-    `pactffi_message_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_contents_get_generators_iter)
+    `pactffi_message_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_contents_get_generators_iter)
 
     The returned pointer must be deleted with `pactffi_generators_iter_delete`
     when done with it.
@@ -2034,7 +2034,7 @@ def request_contents_get_generators_iter(
     Get an iterator over the generators for a category of an HTTP request.
 
     [Rust
-    `pactffi_request_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_request_contents_get_generators_iter)
+    `pactffi_request_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_request_contents_get_generators_iter)
 
     The returned pointer must be deleted with `pactffi_generators_iter_delete`
     when done with it.
@@ -2059,7 +2059,7 @@ def response_contents_get_generators_iter(
     Get an iterator over the generators for a category of an HTTP response.
 
     [Rust
-    `pactffi_response_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_response_contents_get_generators_iter)
+    `pactffi_response_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_response_contents_get_generators_iter)
 
     The returned pointer must be deleted with `pactffi_generators_iter_delete`
     when done with it.
@@ -2084,7 +2084,7 @@ def parse_matcher_definition(expression: str) -> MatchingRuleDefinitionResult:
     any generator.
 
     [Rust
-    `pactffi_parse_matcher_definition`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_parse_matcher_definition)
+    `pactffi_parse_matcher_definition`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_parse_matcher_definition)
 
     The following are examples of matching rule definitions:
 
@@ -2120,7 +2120,7 @@ def matcher_definition_error(definition: MatchingRuleDefinitionResult) -> str:
     using the `pactffi_string_delete` function once done with it.
 
     [Rust
-    `pactffi_matcher_definition_error`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matcher_definition_error)
+    `pactffi_matcher_definition_error`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matcher_definition_error)
     """
     raise NotImplementedError
 
@@ -2134,7 +2134,7 @@ def matcher_definition_value(definition: MatchingRuleDefinitionResult) -> str:
     the `pactffi_string_delete` function once done with it.
 
     [Rust
-    `pactffi_matcher_definition_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matcher_definition_value)
+    `pactffi_matcher_definition_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matcher_definition_value)
 
     Note that different expressions values can have types other than a string.
     Use `pactffi_matcher_definition_value_type` to get the actual type of the
@@ -2148,7 +2148,7 @@ def matcher_definition_delete(definition: MatchingRuleDefinitionResult) -> None:
     """
     Frees the memory used by the result of parsing the matching definition expression.
 
-    [Rust `pactffi_matcher_definition_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matcher_definition_delete)
+    [Rust `pactffi_matcher_definition_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matcher_definition_delete)
     """
     raise NotImplementedError
 
@@ -2161,7 +2161,7 @@ def matcher_definition_generator(definition: MatchingRuleDefinitionResult) -> Ge
     NULL pointer, otherwise returns the generator as a pointer.
 
     [Rust
-    `pactffi_matcher_definition_generator`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matcher_definition_generator)
+    `pactffi_matcher_definition_generator`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matcher_definition_generator)
 
     The generator pointer will be a valid pointer as long as
     `pactffi_matcher_definition_delete` has not been called on the definition.
@@ -2180,7 +2180,7 @@ def matcher_definition_value_type(
     If there was an error parsing the expression, it will return Unknown.
 
     [Rust
-    `pactffi_matcher_definition_value_type`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matcher_definition_value_type)
+    `pactffi_matcher_definition_value_type`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matcher_definition_value_type)
     """
     raise NotImplementedError
 
@@ -2189,7 +2189,7 @@ def matching_rule_iter_delete(iter: MatchingRuleIterator) -> None:
     """
     Free the iterator when you're done using it.
 
-    [Rust `pactffi_matching_rule_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rule_iter_delete)
+    [Rust `pactffi_matching_rule_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rule_iter_delete)
     """
     raise NotImplementedError
 
@@ -2204,7 +2204,7 @@ def matcher_definition_iter(
     `pactffi_matching_rule_iter_delete` function once done with it.
 
     [Rust
-    `pactffi_matcher_definition_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matcher_definition_iter)
+    `pactffi_matcher_definition_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matcher_definition_iter)
 
     If there was an error parsing the expression, this function will return a
     NULL pointer.
@@ -2220,7 +2220,7 @@ def matching_rule_iter_next(iter: MatchingRuleIterator) -> MatchingRuleResult:
     deleted but will be cleaned up when the iterator is deleted.
 
     [Rust
-    `pactffi_matching_rule_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rule_iter_next)
+    `pactffi_matching_rule_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rule_iter_next)
 
     Will return a NULL pointer when the iterator has advanced past the end of
     the list.
@@ -2242,7 +2242,7 @@ def matching_rule_id(rule_result: MatchingRuleResult) -> int:
     Return the ID of the matching rule.
 
     [Rust
-    `pactffi_matching_rule_id`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rule_id)
+    `pactffi_matching_rule_id`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rule_id)
 
     The ID corresponds to the following rules:
 
@@ -2288,7 +2288,7 @@ def matching_rule_value(rule_result: MatchingRuleResult) -> str:
     pointer.
 
     [Rust
-    `pactffi_matching_rule_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rule_value)
+    `pactffi_matching_rule_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rule_value)
 
     The associated values for the rules are:
 
@@ -2336,7 +2336,7 @@ def matching_rule_pointer(rule_result: MatchingRuleResult) -> MatchingRule:
     Will return a NULL pointer if the matching rule result was a reference.
 
     [Rust
-    `pactffi_matching_rule_pointer`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rule_pointer)
+    `pactffi_matching_rule_pointer`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rule_pointer)
 
     # Safety
 
@@ -2354,7 +2354,7 @@ def matching_rule_reference_name(rule_result: MatchingRuleResult) -> str:
     structure. I.e.,
 
     [Rust
-    `pactffi_matching_rule_reference_name`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rule_reference_name)
+    `pactffi_matching_rule_reference_name`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rule_reference_name)
 
     ```json
     {
@@ -2388,7 +2388,7 @@ def validate_datetime(value: str, format: str) -> None:
     `pactffi_get_error_message`.
 
     [Rust
-    `pactffi_validate_datetime`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_validate_datetime)
+    `pactffi_validate_datetime`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_validate_datetime)
 
     # Errors If the function receives a panic, it will return 2 and the message
     associated with the panic can be retrieved with `pactffi_get_error_message`.
@@ -2416,7 +2416,7 @@ def generator_to_json(generator: Generator) -> str:
     Get the JSON form of the generator.
 
     [Rust
-    `pactffi_generator_to_json`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generator_to_json)
+    `pactffi_generator_to_json`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generator_to_json)
 
     The returned string must be deleted with `pactffi_string_delete`.
 
@@ -2439,7 +2439,7 @@ def generator_generate_string(generator: Generator, context_json: str) -> str:
     function).
 
     [Rust
-    `pactffi_generator_generate_string`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generator_generate_string)
+    `pactffi_generator_generate_string`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generator_generate_string)
 
     If anything goes wrong, it will return a NULL pointer.
     """
@@ -2455,7 +2455,7 @@ def generator_generate_integer(generator: Generator, context_json: str) -> int:
     should be the values returned from the Provider State callback function).
 
     [Rust
-    `pactffi_generator_generate_integer`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generator_generate_integer)
+    `pactffi_generator_generate_integer`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generator_generate_integer)
 
     If anything goes wrong or the generator is not a type that can generate an
     integer value, it will return a zero value.
@@ -2468,7 +2468,7 @@ def generators_iter_delete(iter: GeneratorCategoryIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_generators_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generators_iter_delete)
+    `pactffi_generators_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generators_iter_delete)
     """
     raise NotImplementedError
 
@@ -2478,7 +2478,7 @@ def generators_iter_next(iter: GeneratorCategoryIterator) -> GeneratorKeyValuePa
     Get the next path and generator out of the iterator, if possible.
 
     [Rust
-    `pactffi_generators_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generators_iter_next)
+    `pactffi_generators_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generators_iter_next)
 
     The returned pointer must be deleted with
     `pactffi_generator_iter_pair_delete`.
@@ -2500,7 +2500,7 @@ def generators_iter_pair_delete(pair: GeneratorKeyValuePair) -> None:
     Free a pair of key and value returned from `pactffi_generators_iter_next`.
 
     [Rust
-    `pactffi_generators_iter_pair_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generators_iter_pair_delete)
+    `pactffi_generators_iter_pair_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generators_iter_pair_delete)
     """
     raise NotImplementedError
 
@@ -2509,7 +2509,7 @@ def sync_http_new() -> SynchronousHttp:
     """
     Get a mutable pointer to a newly-created default interaction on the heap.
 
-    [Rust `pactffi_sync_http_new`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_new)
+    [Rust `pactffi_sync_http_new`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_new)
 
     # Safety
 
@@ -2527,7 +2527,7 @@ def sync_http_delete(interaction: SynchronousHttp) -> None:
     Destroy the `SynchronousHttp` interaction being pointed to.
 
     [Rust
-    `pactffi_sync_http_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_delete)
+    `pactffi_sync_http_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_delete)
     """
     raise NotImplementedError
 
@@ -2537,7 +2537,7 @@ def sync_http_get_request(interaction: SynchronousHttp) -> HttpRequest:
     Get the request of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_request`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_request)
+    `pactffi_sync_http_get_request`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_request)
 
     # Safety
 
@@ -2557,7 +2557,7 @@ def sync_http_get_request_contents(interaction: SynchronousHttp) -> str:
     Get the request contents of a `SynchronousHttp` interaction in string form.
 
     [Rust
-    `pactffi_sync_http_get_request_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_request_contents)
+    `pactffi_sync_http_get_request_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_request_contents)
 
     # Safety
 
@@ -2584,7 +2584,7 @@ def sync_http_set_request_contents(
     Sets the request contents of the interaction.
 
     [Rust
-    `pactffi_sync_http_set_request_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_set_request_contents)
+    `pactffi_sync_http_set_request_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_set_request_contents)
 
     - `interaction` - the interaction to set the request contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -2612,7 +2612,7 @@ def sync_http_get_request_contents_length(interaction: SynchronousHttp) -> int:
     Get the length of the request contents of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_request_contents_length`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_request_contents_length)
+    `pactffi_sync_http_get_request_contents_length`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_request_contents_length)
 
     # Safety
 
@@ -2631,7 +2631,7 @@ def sync_http_get_request_contents_bin(interaction: SynchronousHttp) -> bytes:
     Get the request contents of a `SynchronousHttp` interaction as bytes.
 
     [Rust
-    `pactffi_sync_http_get_request_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_request_contents_bin)
+    `pactffi_sync_http_get_request_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_request_contents_bin)
 
     # Safety
 
@@ -2658,7 +2658,7 @@ def sync_http_set_request_contents_bin(
     Sets the request contents of the interaction as an array of bytes.
 
     [Rust
-    `pactffi_sync_http_set_request_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_set_request_contents_bin)
+    `pactffi_sync_http_set_request_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_set_request_contents_bin)
 
     - `interaction` - the interaction to set the request contents for
     - `contents` - pointer to contents to copy from
@@ -2685,7 +2685,7 @@ def sync_http_get_response(interaction: SynchronousHttp) -> HttpResponse:
     Get the response of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_response`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_response)
+    `pactffi_sync_http_get_response`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_response)
 
     # Safety
 
@@ -2705,7 +2705,7 @@ def sync_http_get_response_contents(interaction: SynchronousHttp) -> str:
     Get the response contents of a `SynchronousHttp` interaction in string form.
 
     [Rust
-    `pactffi_sync_http_get_response_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_response_contents)
+    `pactffi_sync_http_get_response_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_response_contents)
 
     # Safety
 
@@ -2733,7 +2733,7 @@ def sync_http_set_response_contents(
     Sets the response contents of the interaction.
 
     [Rust
-    `pactffi_sync_http_set_response_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_set_response_contents)
+    `pactffi_sync_http_set_response_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_set_response_contents)
 
     - `interaction` - the interaction to set the response contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -2761,7 +2761,7 @@ def sync_http_get_response_contents_length(interaction: SynchronousHttp) -> int:
     Get the length of the response contents of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_response_contents_length`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_response_contents_length)
+    `pactffi_sync_http_get_response_contents_length`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_response_contents_length)
 
     # Safety
 
@@ -2780,7 +2780,7 @@ def sync_http_get_response_contents_bin(interaction: SynchronousHttp) -> bytes:
     Get the response contents of a `SynchronousHttp` interaction as bytes.
 
     [Rust
-    `pactffi_sync_http_get_response_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_response_contents_bin)
+    `pactffi_sync_http_get_response_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_response_contents_bin)
 
     # Safety
 
@@ -2807,7 +2807,7 @@ def sync_http_set_response_contents_bin(
     Sets the response contents of the `SynchronousHttp` interaction as bytes.
 
     [Rust
-    `pactffi_sync_http_set_response_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_set_response_contents_bin)
+    `pactffi_sync_http_set_response_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_set_response_contents_bin)
 
     - `interaction` - the interaction to set the response contents for
     - `contents` - pointer to contents to copy from
@@ -2834,7 +2834,7 @@ def sync_http_get_description(interaction: SynchronousHttp) -> str:
     Get a copy of the description.
 
     [Rust
-    `pactffi_sync_http_get_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_description)
+    `pactffi_sync_http_get_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_description)
 
     # Safety
 
@@ -2858,7 +2858,7 @@ def sync_http_set_description(interaction: SynchronousHttp, description: str) ->
     Write the `description` field on the `SynchronousHttp`.
 
     [Rust
-    `pactffi_sync_http_set_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_set_description)
+    `pactffi_sync_http_set_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_set_description)
 
     # Safety
 
@@ -2883,7 +2883,7 @@ def sync_http_get_provider_state(
     Get a copy of the provider state at the given index from this interaction.
 
     [Rust
-    `pactffi_sync_http_get_provider_state`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_provider_state)
+    `pactffi_sync_http_get_provider_state`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_provider_state)
 
     # Safety
 
@@ -2909,7 +2909,7 @@ def sync_http_get_provider_state_iter(
     Get an iterator over provider states.
 
     [Rust
-    `pactffi_sync_http_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_http_get_provider_state_iter)
+    `pactffi_sync_http_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_http_get_provider_state_iter)
 
     # Safety
 
@@ -2934,7 +2934,7 @@ def pact_interaction_as_synchronous_http(
     longer required.
 
     [Rust
-    `pactffi_pact_interaction_as_synchronous_http`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_http)
+    `pactffi_pact_interaction_as_synchronous_http`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_http)
 
     # Safety This function is safe as long as the interaction pointer is a valid
     pointer.
@@ -2953,7 +2953,7 @@ def pact_interaction_as_message(interaction: PactInteraction) -> Message:
     must be freed with `pactffi_message_delete` when no longer required.
 
     [Rust
-    `pactffi_pact_interaction_as_message`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_interaction_as_message)
+    `pactffi_pact_interaction_as_message`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_interaction_as_message)
 
     Note that if the interaction is a V4 `AsynchronousMessage`, it will be
     converted to a V3 `Message` before being returned.
@@ -2978,7 +2978,7 @@ def pact_interaction_as_asynchronous_message(
     no longer required.
 
     [Rust
-    `pactffi_pact_interaction_as_asynchronous_message`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_interaction_as_asynchronous_message)
+    `pactffi_pact_interaction_as_asynchronous_message`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_interaction_as_asynchronous_message)
 
     Note that if the interaction is a V3 `Message`, it will be converted to a V4
     `AsynchronousMessage` before being returned.
@@ -3003,7 +3003,7 @@ def pact_interaction_as_synchronous_message(
     no longer required.
 
     [Rust
-    `pactffi_pact_interaction_as_synchronous_message`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_message)
+    `pactffi_pact_interaction_as_synchronous_message`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_message)
 
     # Safety This function is safe as long as the interaction pointer is a valid
     pointer.
@@ -3018,7 +3018,7 @@ def pact_message_iter_delete(iter: PactMessageIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_message_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_message_iter_delete)
+    `pactffi_pact_message_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_message_iter_delete)
     """
     lib.pactffi_pact_message_iter_delete(iter._ptr)
 
@@ -3028,7 +3028,7 @@ def pact_message_iter_next(iter: PactMessageIterator) -> Message:
     Get the next message from the message pact.
 
     [Rust
-    `pactffi_pact_message_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_message_iter_next)
+    `pactffi_pact_message_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_message_iter_next)
     """
     ptr = lib.pactffi_pact_message_iter_next(iter._ptr)
     if ptr == ffi.NULL:
@@ -3042,7 +3042,7 @@ def pact_sync_message_iter_next(iter: PactSyncMessageIterator) -> SynchronousMes
     Get the next synchronous request/response message from the V4 pact.
 
     [Rust
-    `pactffi_pact_sync_message_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_sync_message_iter_next)
+    `pactffi_pact_sync_message_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_sync_message_iter_next)
     """
     ptr = lib.pactffi_pact_sync_message_iter_next(iter._ptr)
     if ptr == ffi.NULL:
@@ -3056,7 +3056,7 @@ def pact_sync_message_iter_delete(iter: PactSyncMessageIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_sync_message_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_sync_message_iter_delete)
+    `pactffi_pact_sync_message_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_sync_message_iter_delete)
     """
     lib.pactffi_pact_sync_message_iter_delete(iter._ptr)
 
@@ -3066,7 +3066,7 @@ def pact_sync_http_iter_next(iter: PactSyncHttpIterator) -> SynchronousHttp:
     Get the next synchronous HTTP request/response interaction from the V4 pact.
 
     [Rust
-    `pactffi_pact_sync_http_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_sync_http_iter_next)
+    `pactffi_pact_sync_http_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_sync_http_iter_next)
     """
     ptr = lib.pactffi_pact_sync_http_iter_next(iter._ptr)
     if ptr == ffi.NULL:
@@ -3080,7 +3080,7 @@ def pact_sync_http_iter_delete(iter: PactSyncHttpIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_sync_http_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_sync_http_iter_delete)
+    `pactffi_pact_sync_http_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_sync_http_iter_delete)
     """
     lib.pactffi_pact_sync_http_iter_delete(iter._ptr)
 
@@ -3090,7 +3090,7 @@ def pact_interaction_iter_next(iter: PactInteractionIterator) -> PactInteraction
     Get the next interaction from the pact.
 
     [Rust
-    `pactffi_pact_interaction_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_interaction_iter_next)
+    `pactffi_pact_interaction_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_interaction_iter_next)
     """
     ptr = lib.pactffi_pact_interaction_iter_next(iter._ptr)
     if ptr == ffi.NULL:
@@ -3104,7 +3104,7 @@ def pact_interaction_iter_delete(iter: PactInteractionIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_interaction_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_interaction_iter_delete)
+    `pactffi_pact_interaction_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_interaction_iter_delete)
     """
     lib.pactffi_pact_interaction_iter_delete(iter._ptr)
 
@@ -3114,7 +3114,7 @@ def matching_rule_to_json(rule: MatchingRule) -> str:
     Get the JSON form of the matching rule.
 
     [Rust
-    `pactffi_matching_rule_to_json`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rule_to_json)
+    `pactffi_matching_rule_to_json`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rule_to_json)
 
     The returned string must be deleted with `pactffi_string_delete`.
 
@@ -3131,7 +3131,7 @@ def matching_rules_iter_delete(iter: MatchingRuleCategoryIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_matching_rules_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rules_iter_delete)
+    `pactffi_matching_rules_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rules_iter_delete)
     """
     raise NotImplementedError
 
@@ -3143,7 +3143,7 @@ def matching_rules_iter_next(
     Get the next path and matching rule out of the iterator, if possible.
 
     [Rust
-    `pactffi_matching_rules_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rules_iter_next)
+    `pactffi_matching_rules_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rules_iter_next)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_pair_delete`.
@@ -3165,7 +3165,7 @@ def matching_rules_iter_pair_delete(pair: MatchingRuleKeyValuePair) -> None:
     Free a pair of key and value returned from `message_metadata_iter_next`.
 
     [Rust
-    `pactffi_matching_rules_iter_pair_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matching_rules_iter_pair_delete)
+    `pactffi_matching_rules_iter_pair_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matching_rules_iter_pair_delete)
     """
     raise NotImplementedError
 
@@ -3175,7 +3175,7 @@ def message_new() -> Message:
     Get a mutable pointer to a newly-created default message on the heap.
 
     [Rust
-    `pactffi_message_new`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_new)
+    `pactffi_message_new`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_new)
 
     # Safety
 
@@ -3197,7 +3197,7 @@ def message_new_from_json(
     Constructs a `Message` from the JSON string.
 
     [Rust
-    `pactffi_message_new_from_json`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_new_from_json)
+    `pactffi_message_new_from_json`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_new_from_json)
 
     # Safety
 
@@ -3215,7 +3215,7 @@ def message_new_from_body(body: str, content_type: str) -> Message:
     Constructs a `Message` from a body with a given content-type.
 
     [Rust
-    `pactffi_message_new_from_body`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_new_from_body)
+    `pactffi_message_new_from_body`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_new_from_body)
 
     # Safety
 
@@ -3233,7 +3233,7 @@ def message_delete(message: Message) -> None:
     Destroy the `Message` being pointed to.
 
     [Rust
-    `pactffi_message_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_delete)
+    `pactffi_message_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_delete)
     """
     raise NotImplementedError
 
@@ -3243,7 +3243,7 @@ def message_get_contents(message: Message) -> OwnedString | None:
     Get the contents of a `Message` in string form.
 
     [Rust
-    `pactffi_message_get_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_get_contents)
+    `pactffi_message_get_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_get_contents)
 
     # Safety
 
@@ -3269,7 +3269,7 @@ def message_set_contents(message: Message, contents: str, content_type: str) -> 
     Sets the contents of the message.
 
     [Rust
-    `pactffi_message_set_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_set_contents)
+    `pactffi_message_set_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_set_contents)
 
     # Safety
 
@@ -3291,7 +3291,7 @@ def message_get_contents_length(message: Message) -> int:
     Get the length of the contents of a `Message`.
 
     [Rust
-    `pactffi_message_get_contents_length`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_get_contents_length)
+    `pactffi_message_get_contents_length`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_get_contents_length)
 
     # Safety
 
@@ -3310,7 +3310,7 @@ def message_get_contents_bin(message: Message) -> str:
     Get the contents of a `Message` as a pointer to an array of bytes.
 
     [Rust
-    `pactffi_message_get_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_get_contents_bin)
+    `pactffi_message_get_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_get_contents_bin)
 
     # Safety
 
@@ -3337,7 +3337,7 @@ def message_set_contents_bin(
     Sets the contents of the message as an array of bytes.
 
     [Rust
-    `pactffi_message_set_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_set_contents_bin)
+    `pactffi_message_set_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_set_contents_bin)
 
     # Safety
 
@@ -3358,7 +3358,7 @@ def message_get_description(message: Message) -> OwnedString:
     Get a copy of the description.
 
     [Rust
-    `pactffi_message_get_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_get_description)
+    `pactffi_message_get_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_get_description)
 
     # Safety
 
@@ -3381,7 +3381,7 @@ def message_set_description(message: Message, description: str) -> int:
     Write the `description` field on the `Message`.
 
     [Rust
-    `pactffi_message_set_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_set_description)
+    `pactffi_message_set_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_set_description)
 
     # Safety
 
@@ -3403,7 +3403,7 @@ def message_get_provider_state(message: Message, index: int) -> ProviderState:
     Get a copy of the provider state at the given index from this message.
 
     [Rust
-    `pactffi_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_get_provider_state)
+    `pactffi_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_get_provider_state)
 
     # Safety
 
@@ -3426,7 +3426,7 @@ def message_get_provider_state_iter(message: Message) -> ProviderStateIterator:
     Get an iterator over provider states.
 
     [Rust
-    `pactffi_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_get_provider_state_iter)
+    `pactffi_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_get_provider_state_iter)
 
     # Safety
 
@@ -3444,7 +3444,7 @@ def provider_state_iter_next(iter: ProviderStateIterator) -> ProviderState:
     Get the next value from the iterator.
 
     [Rust
-    `pactffi_provider_state_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_iter_next)
+    `pactffi_provider_state_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_iter_next)
 
     # Safety
 
@@ -3465,7 +3465,7 @@ def provider_state_iter_delete(iter: ProviderStateIterator) -> None:
     Delete the iterator.
 
     [Rust
-    `pactffi_provider_state_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_iter_delete)
+    `pactffi_provider_state_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_iter_delete)
     """
     raise NotImplementedError
 
@@ -3475,7 +3475,7 @@ def message_find_metadata(message: Message, key: str) -> str:
     Get a copy of the metadata value indexed by `key`.
 
     [Rust
-    `pactffi_message_find_metadata`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_find_metadata)
+    `pactffi_message_find_metadata`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_find_metadata)
 
     # Safety
 
@@ -3501,7 +3501,7 @@ def message_insert_metadata(message: Message, key: str, value: str) -> int:
     Insert the (`key`, `value`) pair into this Message's `metadata` HashMap.
 
     [Rust
-    `pactffi_message_insert_metadata`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_insert_metadata)
+    `pactffi_message_insert_metadata`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_insert_metadata)
 
     # Safety
 
@@ -3521,7 +3521,7 @@ def message_metadata_iter_next(iter: MessageMetadataIterator) -> MessageMetadata
     Get the next key and value out of the iterator, if possible.
 
     [Rust
-    `pactffi_message_metadata_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_metadata_iter_next)
+    `pactffi_message_metadata_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_metadata_iter_next)
 
     The returned pointer must be deleted with
     `pactffi_message_metadata_pair_delete`.
@@ -3544,7 +3544,7 @@ def message_get_metadata_iter(message: Message) -> MessageMetadataIterator:
     Get an iterator over the metadata of a message.
 
     [Rust
-    `pactffi_message_get_metadata_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_get_metadata_iter)
+    `pactffi_message_get_metadata_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_get_metadata_iter)
 
     # Safety
 
@@ -3569,7 +3569,7 @@ def message_metadata_iter_delete(iter: MessageMetadataIterator) -> None:
     Free the metadata iterator when you're done using it.
 
     [Rust
-    `pactffi_message_metadata_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_metadata_iter_delete)
+    `pactffi_message_metadata_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_metadata_iter_delete)
     """
     raise NotImplementedError
 
@@ -3579,7 +3579,7 @@ def message_metadata_pair_delete(pair: MessageMetadataPair) -> None:
     Free a pair of key and value returned from `message_metadata_iter_next`.
 
     [Rust
-    `pactffi_message_metadata_pair_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_metadata_pair_delete)
+    `pactffi_message_metadata_pair_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_metadata_pair_delete)
     """
     raise NotImplementedError
 
@@ -3591,7 +3591,7 @@ def message_pact_new_from_json(file_name: str, json_str: str) -> MessagePact:
     The provided file name is used when generating error messages.
 
     [Rust
-    `pactffi_message_pact_new_from_json`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_new_from_json)
+    `pactffi_message_pact_new_from_json`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_new_from_json)
 
     # Safety
 
@@ -3610,7 +3610,7 @@ def message_pact_delete(message_pact: MessagePact) -> None:
     Delete the `MessagePact` being pointed to.
 
     [Rust
-    `pactffi_message_pact_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_delete)
+    `pactffi_message_pact_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_delete)
     """
     raise NotImplementedError
 
@@ -3623,7 +3623,7 @@ def message_pact_get_consumer(message_pact: MessagePact) -> Consumer:
     pointer.
 
     [Rust
-    `pactffi_message_pact_get_consumer`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_get_consumer)
+    `pactffi_message_pact_get_consumer`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_get_consumer)
 
     # Safety
 
@@ -3645,7 +3645,7 @@ def message_pact_get_provider(message_pact: MessagePact) -> Provider:
     pointer.
 
     [Rust
-    `pactffi_message_pact_get_provider`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_get_provider)
+    `pactffi_message_pact_get_provider`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_get_provider)
 
     # Safety
 
@@ -3666,7 +3666,7 @@ def message_pact_get_message_iter(
     Get an iterator over the messages of a message pact.
 
     [Rust
-    `pactffi_message_pact_get_message_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_get_message_iter)
+    `pactffi_message_pact_get_message_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_get_message_iter)
 
     # Safety
 
@@ -3691,7 +3691,7 @@ def message_pact_message_iter_next(iter: MessagePactMessageIterator) -> Message:
     Get the next message from the message pact.
 
     [Rust
-    `pactffi_message_pact_message_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_message_iter_next)
+    `pactffi_message_pact_message_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_message_iter_next)
 
     # Safety
 
@@ -3710,7 +3710,7 @@ def message_pact_message_iter_delete(iter: MessagePactMessageIterator) -> None:
     Delete the iterator.
 
     [Rust
-    `pactffi_message_pact_message_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_message_iter_delete)
+    `pactffi_message_pact_message_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_message_iter_delete)
     """
     raise NotImplementedError
 
@@ -3720,7 +3720,7 @@ def message_pact_find_metadata(message_pact: MessagePact, key1: str, key2: str) 
     Get a copy of the metadata value indexed by `key1` and `key2`.
 
     [Rust
-    `pactffi_message_pact_find_metadata`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_find_metadata)
+    `pactffi_message_pact_find_metadata`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_find_metadata)
 
     # Safety
 
@@ -3748,7 +3748,7 @@ def message_pact_get_metadata_iter(
     Get an iterator over the metadata of a message pact.
 
     [Rust
-    `pactffi_message_pact_get_metadata_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_get_metadata_iter)
+    `pactffi_message_pact_get_metadata_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_get_metadata_iter)
 
     # Safety
 
@@ -3775,7 +3775,7 @@ def message_pact_metadata_iter_next(
     Get the next triple out of the iterator, if possible.
 
     [Rust
-    `pactffi_message_pact_metadata_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_metadata_iter_next)
+    `pactffi_message_pact_metadata_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_metadata_iter_next)
 
     # Safety
 
@@ -3793,7 +3793,7 @@ def message_pact_metadata_iter_delete(iter: MessagePactMetadataIterator) -> None
     """
     Free the metadata iterator when you're done using it.
 
-    [Rust `pactffi_message_pact_metadata_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_metadata_iter_delete)
+    [Rust `pactffi_message_pact_metadata_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_metadata_iter_delete)
     """
     raise NotImplementedError
 
@@ -3802,7 +3802,7 @@ def message_pact_metadata_triple_delete(triple: MessagePactMetadataTriple) -> No
     """
     Free a triple returned from `pactffi_message_pact_metadata_iter_next`.
 
-    [Rust `pactffi_message_pact_metadata_triple_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_pact_metadata_triple_delete)
+    [Rust `pactffi_message_pact_metadata_triple_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_pact_metadata_triple_delete)
     """
     raise NotImplementedError
 
@@ -3812,7 +3812,7 @@ def provider_get_name(provider: Provider) -> str:
     Get a copy of this provider's name.
 
     [Rust
-    `pactffi_provider_get_name`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_get_name)
+    `pactffi_provider_get_name`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_get_name)
 
     The copy must be deleted with `pactffi_string_delete`.
 
@@ -3858,7 +3858,7 @@ def pact_get_provider(pact: Pact) -> Provider:
     `pactffi_pact_provider_delete` when no longer required.
 
     [Rust
-    `pactffi_pact_get_provider`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_get_provider)
+    `pactffi_pact_get_provider`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_get_provider)
 
     # Errors
 
@@ -3873,7 +3873,7 @@ def pact_provider_delete(provider: Provider) -> None:
     Frees the memory used by the Pact provider.
 
     [Rust
-    `pactffi_pact_provider_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_provider_delete)
+    `pactffi_pact_provider_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_provider_delete)
     """
     raise NotImplementedError
 
@@ -3885,7 +3885,7 @@ def provider_state_get_name(provider_state: ProviderState) -> str:
     This needs to be deleted with `pactffi_string_delete`.
 
     [Rust
-    `pactffi_provider_state_get_name`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_get_name)
+    `pactffi_provider_state_get_name`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_get_name)
 
     # Safety
 
@@ -3905,7 +3905,7 @@ def provider_state_get_param_iter(
     Get an iterator over the params of a provider state.
 
     [Rust
-    `pactffi_provider_state_get_param_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_get_param_iter)
+    `pactffi_provider_state_get_param_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_get_param_iter)
 
     # Safety
 
@@ -3932,7 +3932,7 @@ def provider_state_param_iter_next(
     Get the next key and value out of the iterator, if possible.
 
     [Rust
-    `pactffi_provider_state_param_iter_next`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_param_iter_next)
+    `pactffi_provider_state_param_iter_next`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_param_iter_next)
 
     Returns a pointer to a heap allocated array of 2 elements, the pointer to
     the key string on the heap, and the pointer to the value string on the heap.
@@ -3955,7 +3955,7 @@ def provider_state_delete(provider_state: ProviderState) -> None:
     Free the provider state when you're done using it.
 
     [Rust
-    `pactffi_provider_state_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_delete)
+    `pactffi_provider_state_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_delete)
     """
     raise NotImplementedError
 
@@ -3965,7 +3965,7 @@ def provider_state_param_iter_delete(iter: ProviderStateParamIterator) -> None:
     Free the provider state param iterator when you're done using it.
 
     [Rust
-    `pactffi_provider_state_param_iter_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_param_iter_delete)
+    `pactffi_provider_state_param_iter_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_param_iter_delete)
     """
     raise NotImplementedError
 
@@ -3975,7 +3975,7 @@ def provider_state_param_pair_delete(pair: ProviderStateParamPair) -> None:
     Free a pair of key and value.
 
     [Rust
-    `pactffi_provider_state_param_pair_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_provider_state_param_pair_delete)
+    `pactffi_provider_state_param_pair_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_provider_state_param_pair_delete)
     """
     raise NotImplementedError
 
@@ -3985,7 +3985,7 @@ def sync_message_new() -> SynchronousMessage:
     Get a mutable pointer to a newly-created default message on the heap.
 
     [Rust
-    `pactffi_sync_message_new`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_new)
+    `pactffi_sync_message_new`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_new)
 
     # Safety
 
@@ -4003,7 +4003,7 @@ def sync_message_delete(message: SynchronousMessage) -> None:
     Destroy the `Message` being pointed to.
 
     [Rust
-    `pactffi_sync_message_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_delete)
+    `pactffi_sync_message_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_delete)
     """
     raise NotImplementedError
 
@@ -4013,7 +4013,7 @@ def sync_message_get_request_contents_str(message: SynchronousMessage) -> str:
     Get the request contents of a `SynchronousMessage` in string form.
 
     [Rust
-    `pactffi_sync_message_get_request_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_request_contents_str)
+    `pactffi_sync_message_get_request_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_request_contents_str)
 
     # Safety
 
@@ -4040,7 +4040,7 @@ def sync_message_set_request_contents_str(
     Sets the request contents of the message.
 
     [Rust
-    `pactffi_sync_message_set_request_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_set_request_contents_str)
+    `pactffi_sync_message_set_request_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_set_request_contents_str)
 
     - `message` - the message to set the request contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -4068,7 +4068,7 @@ def sync_message_get_request_contents_length(message: SynchronousMessage) -> int
     Get the length of the request contents of a `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_get_request_contents_length`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_request_contents_length)
+    `pactffi_sync_message_get_request_contents_length`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_request_contents_length)
 
     # Safety
 
@@ -4087,7 +4087,7 @@ def sync_message_get_request_contents_bin(message: SynchronousMessage) -> bytes:
     Get the request contents of a `SynchronousMessage` as a bytes.
 
     [Rust
-    `pactffi_sync_message_get_request_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_request_contents_bin)
+    `pactffi_sync_message_get_request_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_request_contents_bin)
 
     # Safety
 
@@ -4114,7 +4114,7 @@ def sync_message_set_request_contents_bin(
     Sets the request contents of the message as an array of bytes.
 
     [Rust
-    `pactffi_sync_message_set_request_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_set_request_contents_bin)
+    `pactffi_sync_message_set_request_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_set_request_contents_bin)
 
     * `message` - the message to set the request contents for
     * `contents` - pointer to contents to copy from
@@ -4141,7 +4141,7 @@ def sync_message_get_request_contents(message: SynchronousMessage) -> MessageCon
     Get the request contents of an `SynchronousMessage` as a `MessageContents`.
 
     [Rust
-    `pactffi_sync_message_get_request_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_request_contents)
+    `pactffi_sync_message_get_request_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_request_contents)
 
     # Safety
 
@@ -4161,7 +4161,7 @@ def sync_message_get_number_responses(message: SynchronousMessage) -> int:
     Get the number of response messages in the `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_get_number_responses`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_number_responses)
+    `pactffi_sync_message_get_number_responses`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_number_responses)
 
     # Safety
 
@@ -4182,7 +4182,7 @@ def sync_message_get_response_contents_str(
     Get the response contents of a `SynchronousMessage` in string form.
 
     [Rust
-    `pactffi_sync_message_get_response_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_response_contents_str)
+    `pactffi_sync_message_get_response_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_response_contents_str)
 
     # Safety
 
@@ -4215,7 +4215,7 @@ def sync_message_set_response_contents_str(
     with default values.
 
     [Rust
-    `pactffi_sync_message_set_response_contents_str`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_set_response_contents_str)
+    `pactffi_sync_message_set_response_contents_str`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_set_response_contents_str)
 
     * `message` - the message to set the response contents for
     * `index` - index of the response to set. 0 is the first response.
@@ -4247,7 +4247,7 @@ def sync_message_get_response_contents_length(
     Get the length of the response contents of a `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_get_response_contents_length`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_response_contents_length)
+    `pactffi_sync_message_get_response_contents_length`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_response_contents_length)
 
     # Safety
 
@@ -4269,7 +4269,7 @@ def sync_message_get_response_contents_bin(
     Get the response contents of a `SynchronousMessage` as bytes.
 
     [Rust
-    `pactffi_sync_message_get_response_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_response_contents_bin)
+    `pactffi_sync_message_get_response_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_response_contents_bin)
 
     # Safety
 
@@ -4300,7 +4300,7 @@ def sync_message_set_response_contents_bin(
     responses will be padded with default values.
 
     [Rust
-    `pactffi_sync_message_set_response_contents_bin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_set_response_contents_bin)
+    `pactffi_sync_message_set_response_contents_bin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_set_response_contents_bin)
 
     * `message` - the message to set the response contents for
     * `index` - index of the response to set. 0 is the first response
@@ -4331,7 +4331,7 @@ def sync_message_get_response_contents(
     Get the response contents of an `SynchronousMessage` as a `MessageContents`.
 
     [Rust
-    `pactffi_sync_message_get_response_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_response_contents)
+    `pactffi_sync_message_get_response_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_response_contents)
 
     # Safety
 
@@ -4351,7 +4351,7 @@ def sync_message_get_description(message: SynchronousMessage) -> str:
     Get a copy of the description.
 
     [Rust
-    `pactffi_sync_message_get_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_description)
+    `pactffi_sync_message_get_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_description)
 
     # Safety
 
@@ -4375,7 +4375,7 @@ def sync_message_set_description(message: SynchronousMessage, description: str) 
     Write the `description` field on the `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_set_description`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_set_description)
+    `pactffi_sync_message_set_description`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_set_description)
 
     # Safety
 
@@ -4400,7 +4400,7 @@ def sync_message_get_provider_state(
     Get a copy of the provider state at the given index from this message.
 
     [Rust
-    `pactffi_sync_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_provider_state)
+    `pactffi_sync_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_provider_state)
 
     # Safety
 
@@ -4426,7 +4426,7 @@ def sync_message_get_provider_state_iter(
     Get an iterator over provider states.
 
     [Rust
-    `pactffi_sync_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_sync_message_get_provider_state_iter)
+    `pactffi_sync_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_sync_message_get_provider_state_iter)
 
     # Safety
 
@@ -4444,7 +4444,7 @@ def string_delete(string: OwnedString) -> None:
     Delete a string previously returned by this FFI.
 
     [Rust
-    `pactffi_string_delete`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_string_delete)
+    `pactffi_string_delete`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_string_delete)
     """
     lib.pactffi_string_delete(string._ptr)
 
@@ -4459,7 +4459,7 @@ def create_mock_server(pact_str: str, addr_str: str, *, tls: bool) -> int:
     the mock server is returned.
 
     [Rust
-    `pactffi_create_mock_server`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_create_mock_server)
+    `pactffi_create_mock_server`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_create_mock_server)
 
     * `pact_str` - Pact JSON
     * `addr_str` - Address to bind to in the form name:port (i.e. 127.0.0.1:80)
@@ -4495,7 +4495,7 @@ def get_tls_ca_certificate() -> OwnedString:
     Fetch the CA Certificate used to generate the self-signed certificate.
 
     [Rust
-    `pactffi_get_tls_ca_certificate`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_get_tls_ca_certificate)
+    `pactffi_get_tls_ca_certificate`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_get_tls_ca_certificate)
 
     **NOTE:** The string for the result is allocated on the heap, and will have
     to be freed by the caller using pactffi_string_delete.
@@ -4516,7 +4516,7 @@ def create_mock_server_for_pact(pact: PactHandle, addr_str: str, *, tls: bool) -
     operating system. The port of the mock server is returned.
 
     [Rust
-    `pactffi_create_mock_server_for_pact`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_create_mock_server_for_pact)
+    `pactffi_create_mock_server_for_pact`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_create_mock_server_for_pact)
 
     * `pact` - Handle to a Pact model created with created with
       `pactffi_new_pact`.
@@ -4559,7 +4559,7 @@ def create_mock_server_for_transport(
     Create a mock server for the provided Pact handle and transport.
 
     [Rust
-    `pactffi_create_mock_server_for_transport`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_create_mock_server_for_transport)
+    `pactffi_create_mock_server_for_transport`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_create_mock_server_for_transport)
 
     Args:
         pact:
@@ -4620,7 +4620,7 @@ def mock_server_matched(mock_server_handle: PactServerHandle) -> bool:
     if any request has not been successfully matched, or the method panics.
 
     [Rust
-    `pactffi_mock_server_matched`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mock_server_matched)
+    `pactffi_mock_server_matched`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mock_server_matched)
     """
     return lib.pactffi_mock_server_matched(mock_server_handle._ref)
 
@@ -4632,7 +4632,7 @@ def mock_server_mismatches(
     External interface to get all the mismatches from a mock server.
 
     [Rust
-    `pactffi_mock_server_mismatches`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mock_server_mismatches)
+    `pactffi_mock_server_mismatches`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mock_server_mismatches)
 
     # Errors
 
@@ -4658,7 +4658,7 @@ def cleanup_mock_server(mock_server_handle: PactServerHandle) -> None:
     and cleanup any memory allocated for it.
 
     [Rust
-    `pactffi_cleanup_mock_server`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_cleanup_mock_server)
+    `pactffi_cleanup_mock_server`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_cleanup_mock_server)
 
     Args:
         mock_server_handle:
@@ -4686,7 +4686,7 @@ def write_pact_file(
     directory to write the file to is passed as the second parameter.
 
     [Rust
-    `pactffi_write_pact_file`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_write_pact_file)
+    `pactffi_write_pact_file`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_write_pact_file)
 
     Args:
         mock_server_handle:
@@ -4737,7 +4737,7 @@ def mock_server_logs(mock_server_handle: PactServerHandle) -> str:
     started.
 
     [Rust
-    `pactffi_mock_server_logs`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_mock_server_logs)
+    `pactffi_mock_server_logs`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_mock_server_logs)
 
     Raises:
         RuntimeError: If the logs for the mock server can not be retrieved.
@@ -4760,7 +4760,7 @@ def generate_datetime_string(format: str) -> StringResult:
     string needs to be freed with the `pactffi_string_delete` function
 
     [Rust
-    `pactffi_generate_datetime_string`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generate_datetime_string)
+    `pactffi_generate_datetime_string`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generate_datetime_string)
 
     # Safety
 
@@ -4777,7 +4777,7 @@ def check_regex(regex: str, example: str) -> bool:
     Checks that the example string matches the given regex.
 
     [Rust
-    `pactffi_check_regex`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_check_regex)
+    `pactffi_check_regex`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_check_regex)
 
     # Safety
 
@@ -4796,7 +4796,7 @@ def generate_regex_value(regex: str) -> StringResult:
     `pactffi_string_delete` function.
 
     [Rust
-    `pactffi_generate_regex_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_generate_regex_value)
+    `pactffi_generate_regex_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_generate_regex_value)
 
     # Safety
 
@@ -4811,7 +4811,7 @@ def free_string(s: str) -> None:
     [DEPRECATED] Frees the memory allocated to a string by another function.
 
     [Rust
-    `pactffi_free_string`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_free_string)
+    `pactffi_free_string`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_free_string)
 
     This function is deprecated. Use `pactffi_string_delete` instead.
 
@@ -4833,7 +4833,7 @@ def new_pact(consumer_name: str, provider_name: str) -> PactHandle:
     Creates a new Pact model and returns a handle to it.
 
     [Rust
-    `pactffi_new_pact`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_new_pact)
+    `pactffi_new_pact`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_new_pact)
 
     Args:
         consumer_name:
@@ -4874,7 +4874,7 @@ def new_interaction(pact: PactHandle, description: str) -> InteractionHandle:
     will result in that interaction being replaced with the new one.
 
     [Rust
-    `pactffi_new_interaction`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_new_interaction)
+    `pactffi_new_interaction`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_new_interaction)
 
     Args:
         pact:
@@ -4902,7 +4902,7 @@ def new_message_interaction(pact: PactHandle, description: str) -> InteractionHa
     will result in that interaction being replaced with the new one.
 
     [Rust
-    `pactffi_new_message_interaction`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_new_message_interaction)
+    `pactffi_new_message_interaction`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_new_message_interaction)
 
     Args:
         pact:
@@ -4933,7 +4933,7 @@ def new_sync_message_interaction(
     will result in that interaction being replaced with the new one.
 
     [Rust
-    `pactffi_new_sync_message_interaction`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_new_sync_message_interaction)
+    `pactffi_new_sync_message_interaction`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_new_sync_message_interaction)
 
     Args:
         pact:
@@ -4958,7 +4958,7 @@ def upon_receiving(interaction: InteractionHandle, description: str) -> None:
     Sets the description for the Interaction.
 
     [Rust
-    `pactffi_upon_receiving`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_upon_receiving)
+    `pactffi_upon_receiving`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_upon_receiving)
 
     This function
 
@@ -4995,7 +4995,7 @@ def given(interaction: InteractionHandle, description: str) -> None:
     Adds a provider state to the Interaction.
 
     [Rust
-    `pactffi_given`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_given)
+    `pactffi_given`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_given)
 
     Args:
         interaction:
@@ -5021,7 +5021,7 @@ def interaction_test_name(interaction: InteractionHandle, test_name: str) -> Non
     used with V4 interactions.
 
     [Rust
-    `pactffi_interaction_test_name`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_interaction_test_name)
+    `pactffi_interaction_test_name`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_interaction_test_name)
 
     Args:
         interaction:
@@ -5081,7 +5081,7 @@ def given_with_param(
     be parsed as JSON.
 
     [Rust
-    `pactffi_given_with_param`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_given_with_param)
+    `pactffi_given_with_param`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_given_with_param)
 
     Args:
         interaction:
@@ -5122,7 +5122,7 @@ def given_with_params(
     with a `value` key.
 
     [Rust
-    `pactffi_given_with_params`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_given_with_params)
+    `pactffi_given_with_params`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_given_with_params)
 
     Args:
         interaction:
@@ -5172,7 +5172,7 @@ def with_request(interaction: InteractionHandle, method: str, path: str) -> None
     Configures the request for the Interaction.
 
     [Rust
-    `pactffi_with_request`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_request)
+    `pactffi_with_request`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_request)
 
     Args:
         interaction:
@@ -5186,7 +5186,7 @@ def with_request(interaction: InteractionHandle, method: str, path: str) -> None
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md)
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md)
             which allows regex patterns. For examples:
 
             ```json
@@ -5220,7 +5220,7 @@ def with_query_parameter_v2(
     Configures a query parameter for the Interaction.
 
     [Rust
-    `pactffi_with_query_parameter_v2`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_query_parameter_v2)
+    `pactffi_with_query_parameter_v2`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_query_parameter_v2)
 
     To setup a query parameter with multiple values, you can either call this
     function multiple times with a different index value:
@@ -5257,7 +5257,7 @@ def with_query_parameter_v2(
     )
     ```
 
-    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md)
+    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md)
 
     If you want the matching rules to apply to all values (and not just the one
     with the given index), make sure to set the value to be an array.
@@ -5291,7 +5291,7 @@ def with_query_parameter_v2(
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md).
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError: If there was an error setting the query parameter.
@@ -5312,7 +5312,7 @@ def with_specification(pact: PactHandle, version: PactSpecification) -> None:
     Sets the specification version for a given Pact model.
 
     [Rust
-    `pactffi_with_specification`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_specification)
+    `pactffi_with_specification`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_specification)
 
     Args:
         pact:
@@ -5332,7 +5332,7 @@ def handle_get_pact_spec_version(handle: PactHandle) -> PactSpecification:
     Fetches the Pact specification version for the given Pact model.
 
     [Rust
-    `pactffi_handle_get_pact_spec_version`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_handle_get_pact_spec_version)
+    `pactffi_handle_get_pact_spec_version`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_handle_get_pact_spec_version)
 
     Args:
         handle:
@@ -5358,7 +5358,7 @@ def with_pact_metadata(
     mock server for it has already started)
 
     [Rust
-    `pactffi_with_pact_metadata`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_pact_metadata)
+    `pactffi_with_pact_metadata`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_pact_metadata)
 
     Args:
         pact:
@@ -5394,7 +5394,7 @@ def with_header_v2(
     r"""
     Configures a header for the Interaction.
 
-    [Rust `pactffi_with_header_v2`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_header_v2)
+    [Rust `pactffi_with_header_v2`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_header_v2)
 
     To setup a header with multiple values, you can either call this
     function multiple times with a different index value:
@@ -5432,7 +5432,7 @@ def with_header_v2(
     )
     ```
 
-    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md)
+    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md)
 
     Args:
         interaction:
@@ -5454,7 +5454,7 @@ def with_header_v2(
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md).
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError: If there was an error setting the header.
@@ -5485,7 +5485,7 @@ def set_header(
     and generators can not be configured with it.
 
     [Rust
-    `pactffi_set_header`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_set_header)
+    `pactffi_set_header`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_set_header)
 
     If matching rules are required to be set, use `pactffi_with_header_v2`.
 
@@ -5522,7 +5522,7 @@ def response_status(interaction: InteractionHandle, status: int) -> None:
     Configures the response for the Interaction.
 
     [Rust
-    `pactffi_response_status`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_response_status)
+    `pactffi_response_status`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_response_status)
 
     Args:
         interaction:
@@ -5545,7 +5545,7 @@ def response_status_v2(interaction: InteractionHandle, status: str) -> None:
     Configures the response for the Interaction.
 
     [Rust
-    `pactffi_response_status_v2`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_response_status_v2)
+    `pactffi_response_status_v2`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_response_status_v2)
 
     To include matching rules for the status (only statusCode or integer really
     makes sense to use), include the matching rule JSON format with the value as
@@ -5564,7 +5564,7 @@ def response_status_v2(interaction: InteractionHandle, status: str) -> None:
     )
     ```
 
-    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md)
+    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md)
 
     Args:
         interaction:
@@ -5575,7 +5575,7 @@ def response_status_v2(interaction: InteractionHandle, status: str) -> None:
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md).
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError: If the response status could not be set.
@@ -5598,7 +5598,7 @@ def with_body(
     Adds the body for the interaction.
 
     [Rust
-    `pactffi_with_body`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_body)
+    `pactffi_with_body`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_body)
 
     For HTTP and async message interactions, this will overwrite the body. With
     asynchronous messages, the part parameter will be ignored. With synchronous
@@ -5619,7 +5619,7 @@ def with_body(
 
         body:
             The body contents. For JSON payloads, matching rules can be embedded
-            in the body. See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md).
+            in the body. See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError: If the body could not be specified.
@@ -5645,7 +5645,7 @@ def with_binary_body(
     Adds the body for the interaction.
 
     [Rust
-    `pactffi_with_binary_body`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_binary_body)
+    `pactffi_with_binary_body`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_binary_body)
 
     For HTTP and async message interactions, this will overwrite the body. With
     asynchronous messages, the part parameter will be ignored. With synchronous
@@ -5688,7 +5688,7 @@ def with_binary_file(
     already started)
 
     [Rust
-    `pactffi_with_binary_file`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_binary_file)
+    `pactffi_with_binary_file`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_binary_file)
 
     For HTTP and async message interactions, this will overwrite the body. With
     asynchronous messages, the part parameter will be ignored. With synchronous
@@ -5738,7 +5738,7 @@ def with_matching_rules(
     Add matching rules to the interaction.
 
     [Rust
-    `pactffi_with_matching_rules`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_matching_rules)
+    `pactffi_with_matching_rules`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_matching_rules)
 
     This function can be called multiple times, in which case the matching
     rules will be merged.
@@ -5782,7 +5782,7 @@ def with_multipart_file_v2(  # noqa: PLR0913
     already started) or an error occurs.
 
     [Rust
-    `pactffi_with_multipart_file_v2`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_multipart_file_v2)
+    `pactffi_with_multipart_file_v2`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_multipart_file_v2)
 
     This function can be called multiple times. In that case, each subsequent
     call will be appended to the existing multipart body as a new part.
@@ -5836,7 +5836,7 @@ def with_multipart_file(
     already started) or an error occurs.
 
     [Rust
-    `pactffi_with_multipart_file`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_multipart_file)
+    `pactffi_with_multipart_file`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_multipart_file)
 
     * `interaction` - Interaction handle to set the body for.
     * `part` - Request or response part.
@@ -5873,7 +5873,7 @@ def set_key(interaction: InteractionHandle, key: str | None) -> None:
     Sets the key attribute for the interaction.
 
     [Rust
-    `pactffi_set_key`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_set_key)
+    `pactffi_set_key`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_set_key)
 
     Args:
         interaction:
@@ -5897,7 +5897,7 @@ def set_pending(interaction: InteractionHandle, *, pending: bool) -> None:
     Mark the interaction as pending.
 
     [Rust
-    `pactffi_set_pending`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_set_pending)
+    `pactffi_set_pending`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_set_pending)
 
     Args:
         interaction:
@@ -5917,7 +5917,7 @@ def set_comment(interaction: InteractionHandle, key: str, value: str | None) -> 
     Add a comment to the interaction.
 
     [Rust
-    `pactffi_set_comment`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_set_comment)
+    `pactffi_set_comment`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_set_comment)
 
     Args:
         interaction:
@@ -5945,12 +5945,35 @@ def set_comment(interaction: InteractionHandle, key: str, value: str | None) -> 
         raise RuntimeError(msg)
 
 
+def add_text_comment(interaction: InteractionHandle, comment: str) -> None:
+    """
+    Add a text comment to the interaction.
+
+    [Rust
+    `pactffi_add_text_comment`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_add_text_comment)
+
+    Args:
+        interaction:
+            Interaction handle to set the comments for.
+
+        comment:
+            Comment value. This is a regular string value.
+    """
+    success: bool = lib.pactffi_add_text_comment(
+        interaction._ref,
+        comment.encode("utf-8"),
+    )
+    if not success:
+        msg = f"Failed to add text comment for {interaction}."
+        raise RuntimeError(msg)
+
+
 def pact_handle_get_message_iter(pact: PactHandle) -> PactMessageIterator:
     r"""
     Get an iterator over all the messages of the Pact.
 
     [Rust
-    `pactffi_pact_handle_get_message_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_handle_get_message_iter)
+    `pactffi_pact_handle_get_message_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_handle_get_message_iter)
 
     # Safety
 
@@ -5974,7 +5997,7 @@ def pact_handle_get_sync_message_iter(pact: PactHandle) -> PactSyncMessageIterat
     `pactffi_pact_sync_message_iter_delete`.
 
     [Rust
-    `pactffi_pact_handle_get_sync_message_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_handle_get_sync_message_iter)
+    `pactffi_pact_handle_get_sync_message_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_handle_get_sync_message_iter)
 
     # Safety
 
@@ -6000,7 +6023,7 @@ def pact_handle_get_sync_http_iter(pact: PactHandle) -> PactSyncHttpIterator:
     `pactffi_pact_sync_http_iter_delete`.
 
     [Rust
-    `pactffi_pact_handle_get_sync_http_iter`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_handle_get_sync_http_iter)
+    `pactffi_pact_handle_get_sync_http_iter`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_handle_get_sync_http_iter)
 
     # Safety
 
@@ -6021,7 +6044,7 @@ def new_message_pact(consumer_name: str, provider_name: str) -> MessagePactHandl
     Creates a new Pact Message model and returns a handle to it.
 
     [Rust
-    `pactffi_new_message_pact`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_new_message_pact)
+    `pactffi_new_message_pact`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_new_message_pact)
 
     * `consumer_name` - The name of the consumer for the pact.
     * `provider_name` - The name of the provider for the pact.
@@ -6037,7 +6060,7 @@ def new_message(pact: MessagePactHandle, description: str) -> MessageHandle:
     Creates a new Message and returns a handle to it.
 
     [Rust
-    `pactffi_new_message`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_new_message)
+    `pactffi_new_message`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_new_message)
 
     * `description` - The message description. It needs to be unique for each
       Message.
@@ -6052,7 +6075,7 @@ def message_expects_to_receive(message: MessageHandle, description: str) -> None
     Sets the description for the Message.
 
     [Rust
-    `pactffi_message_expects_to_receive`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_expects_to_receive)
+    `pactffi_message_expects_to_receive`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_expects_to_receive)
 
     * `description` - The message description. It needs to be unique for each
       message.
@@ -6065,7 +6088,7 @@ def message_given(message: MessageHandle, description: str) -> None:
     Adds a provider state to the Interaction.
 
     [Rust
-    `pactffi_message_given`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_given)
+    `pactffi_message_given`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_given)
 
     * `description` - The provider state description. It needs to be unique for
       each message
@@ -6083,7 +6106,7 @@ def message_given_with_param(
     Adds a provider state to the Message with a parameter key and value.
 
     [Rust
-    `pactffi_message_given_with_param`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_given_with_param)
+    `pactffi_message_given_with_param`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_given_with_param)
 
     * `description` - The provider state description. It needs to be unique.
     * `name` - Parameter name.
@@ -6102,7 +6125,7 @@ def message_with_contents(
     Adds the contents of the Message.
 
     [Rust
-    `pactffi_message_with_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_with_contents)
+    `pactffi_message_with_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_with_contents)
 
     Accepts JSON, binary and other payload types. Binary data will be base64
     encoded when serialised.
@@ -6129,7 +6152,7 @@ def message_with_metadata(message_handle: MessageHandle, key: str, value: str) -
     Adds expected metadata to the Message.
 
     [Rust
-    `pactffi_message_with_metadata`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_with_metadata)
+    `pactffi_message_with_metadata`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_with_metadata)
 
     * `key` - metadata key
     * `value` - metadata value.
@@ -6146,7 +6169,7 @@ def message_with_metadata_v2(
     Adds expected metadata to the Message.
 
     [Rust
-    `pactffi_message_with_metadata_v2`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_with_metadata_v2)
+    `pactffi_message_with_metadata_v2`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_with_metadata_v2)
 
     Args:
         message_handle:
@@ -6160,7 +6183,7 @@ def message_with_metadata_v2(
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md).
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md).
 
     To include matching rules for the metadata, include the matching rule JSON
     format with the value as a single JSON document. I.e.
@@ -6176,7 +6199,7 @@ def message_with_metadata_v2(
     )
     ```
 
-    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md).
+    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md).
     """
     raise NotImplementedError
 
@@ -6186,7 +6209,7 @@ def message_reify(message_handle: MessageHandle) -> OwnedString:
     Reifies the given message.
 
     [Rust
-    `pactffi_message_reify`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_message_reify)
+    `pactffi_message_reify`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_message_reify)
 
     Reification is the process of stripping away any matchers, and returning the
     original contents.
@@ -6215,7 +6238,7 @@ def write_message_pact_file(
     pointer is passed, the current working directory is used.
 
     [Rust
-    `pactffi_write_message_pact_file`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_write_message_pact_file)
+    `pactffi_write_message_pact_file`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_write_message_pact_file)
 
     If overwrite is true, the file will be overwritten with the contents of the
     current pact. Otherwise, it will be merged with any existing pact file.
@@ -6249,7 +6272,7 @@ def with_message_pact_metadata(
     version
 
     [Rust
-    `pactffi_with_message_pact_metadata`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_with_message_pact_metadata)
+    `pactffi_with_message_pact_metadata`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_with_message_pact_metadata)
 
     * `pact` - Handle to a Pact model
     * `namespace` - the top level metadat key to set any key values on
@@ -6269,7 +6292,7 @@ def pact_handle_write_file(
     External interface to write out the pact file.
 
     [Rust
-    `pactffi_pact_handle_write_file`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_pact_handle_write_file)
+    `pactffi_pact_handle_write_file`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_pact_handle_write_file)
 
     This function should be called if all the consumer tests have passed.
 
@@ -6309,7 +6332,7 @@ def free_pact_handle(pact: PactHandle) -> None:
     Delete a Pact handle and free the resources used by it.
 
     [Rust
-    `pactffi_free_pact_handle`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_free_pact_handle)
+    `pactffi_free_pact_handle`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_free_pact_handle)
 
     Raises:
         RuntimeError: If the handle could not be freed.
@@ -6329,7 +6352,7 @@ def free_message_pact_handle(pact: MessagePactHandle) -> int:
     Delete a Pact handle and free the resources used by it.
 
     [Rust
-    `pactffi_free_message_pact_handle`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_free_message_pact_handle)
+    `pactffi_free_message_pact_handle`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_free_message_pact_handle)
 
     # Error Handling
 
@@ -6346,7 +6369,7 @@ def verify(args: str) -> int:
     """
     External interface to verifier a provider.
 
-    [Rust `pactffi_verify`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verify)
+    [Rust `pactffi_verify`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verify)
 
     * `args` - the same as the CLI interface, except newline delimited
 
@@ -6373,7 +6396,7 @@ def verifier_new_for_application() -> VerifierHandle:
     Get a Handle to a newly created verifier.
 
     [Rust
-    `pactffi_verifier_new_for_application`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_new_for_application)
+    `pactffi_verifier_new_for_application`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_new_for_application)
     """
     from pact import __version__
 
@@ -6388,7 +6411,7 @@ def verifier_shutdown(handle: VerifierHandle) -> None:
     """
     Shutdown the verifier and release all resources.
 
-    [Rust `pactffi_verifier_shutdown`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_shutdown)
+    [Rust `pactffi_verifier_shutdown`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_shutdown)
     """
     lib.pactffi_verifier_shutdown(handle._ref)
 
@@ -6405,7 +6428,7 @@ def verifier_set_provider_info(  # noqa: PLR0913
     Set the provider details for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_provider_info`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_provider_info)
+    `pactffi_verifier_set_provider_info`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_provider_info)
 
     Args:
         handle:
@@ -6451,7 +6474,7 @@ def verifier_add_provider_transport(
     Adds a new transport for the given provider.
 
     [Rust
-    `pactffi_verifier_add_provider_transport`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_add_provider_transport)
+    `pactffi_verifier_add_provider_transport`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_add_provider_transport)
 
     Args:
         handle:
@@ -6492,7 +6515,7 @@ def verifier_set_filter_info(
     Set the filters for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_filter_info`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_filter_info)
+    `pactffi_verifier_set_filter_info`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_filter_info)
 
     Set filters to narrow down the interactions to verify.
 
@@ -6528,7 +6551,7 @@ def verifier_set_provider_state(
     Set the provider state URL for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_provider_state`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_provider_state)
+    `pactffi_verifier_set_provider_state`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_provider_state)
 
     Args:
         handle:
@@ -6563,7 +6586,7 @@ def verifier_set_verification_options(
     Set the options used by the verifier when calling the provider.
 
     [Rust
-    `pactffi_verifier_set_verification_options`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_verification_options)
+    `pactffi_verifier_set_verification_options`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_verification_options)
 
     Args:
         handle:
@@ -6594,7 +6617,7 @@ def verifier_set_coloured_output(
     Enables or disables coloured output using ANSI escape codes.
 
     [Rust
-    `pactffi_verifier_set_coloured_output`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_coloured_output)
+    `pactffi_verifier_set_coloured_output`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_coloured_output)
 
     By default, coloured output is enabled.
 
@@ -6619,7 +6642,7 @@ def verifier_set_no_pacts_is_error(handle: VerifierHandle, *, enabled: bool) -> 
     Enables or disables if no pacts are found to verify results in an error.
 
     [Rust
-    `pactffi_verifier_set_no_pacts_is_error`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_no_pacts_is_error)
+    `pactffi_verifier_set_no_pacts_is_error`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_no_pacts_is_error)
 
     Args:
         handle:
@@ -6648,7 +6671,7 @@ def verifier_set_publish_options(
     Set the options used when publishing verification results to the Broker.
 
     [Rust
-    `pactffi_verifier_set_publish_options`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_publish_options)
+    `pactffi_verifier_set_publish_options`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_publish_options)
 
     Args:
         handle:
@@ -6687,7 +6710,7 @@ def verifier_set_consumer_filters(
     Set the consumer filters for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_consumer_filters`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_set_consumer_filters)
+    `pactffi_verifier_set_consumer_filters`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_set_consumer_filters)
     """
     lib.pactffi_verifier_set_consumer_filters(
         handle._ref,
@@ -6705,7 +6728,7 @@ def verifier_add_custom_header(
     Adds a custom header to be added to the requests made to the provider.
 
     [Rust
-    `pactffi_verifier_add_custom_header`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_add_custom_header)
+    `pactffi_verifier_add_custom_header`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_add_custom_header)
     """
     lib.pactffi_verifier_add_custom_header(
         handle._ref,
@@ -6719,7 +6742,7 @@ def verifier_add_file_source(handle: VerifierHandle, file: str) -> None:
     Adds a Pact file as a source to verify.
 
     [Rust
-    `pactffi_verifier_add_file_source`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_add_file_source)
+    `pactffi_verifier_add_file_source`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_add_file_source)
     """
     lib.pactffi_verifier_add_file_source(handle._ref, file.encode("utf-8"))
 
@@ -6731,7 +6754,7 @@ def verifier_add_directory_source(handle: VerifierHandle, directory: str) -> Non
     All pacts from the directory that match the provider name will be verified.
 
     [Rust
-    `pactffi_verifier_add_directory_source`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_add_directory_source)
+    `pactffi_verifier_add_directory_source`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_add_directory_source)
 
     # Safety
 
@@ -6753,7 +6776,7 @@ def verifier_url_source(
     Adds a URL as a source to verify.
 
     [Rust
-    `pactffi_verifier_url_source`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_url_source)
+    `pactffi_verifier_url_source`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_url_source)
 
     Args:
         handle:
@@ -6793,7 +6816,7 @@ def verifier_broker_source(
     Adds a Pact broker as a source to verify.
 
     [Rust
-    `pactffi_verifier_broker_source`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_broker_source)
+    `pactffi_verifier_broker_source`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_broker_source)
 
     This will fetch all the pact files from the broker that match the provider
     name.
@@ -6841,7 +6864,7 @@ def verifier_broker_source_with_selectors(  # noqa: PLR0913
     Adds a Pact broker as a source to verify.
 
     [Rust
-    `pactffi_verifier_broker_source_with_selectors`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_broker_source_with_selectors)
+    `pactffi_verifier_broker_source_with_selectors`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_broker_source_with_selectors)
 
     This will fetch all the pact files from the broker that match the provider
     name and the consumer version selectors (See [Consumer Version
@@ -6906,7 +6929,7 @@ def verifier_execute(handle: VerifierHandle) -> None:
     """
     Runs the verification.
 
-    (https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_execute)
+    (https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_execute)
     """
     success: int = lib.pactffi_verifier_execute(handle._ref)
     if success != 0:
@@ -6922,7 +6945,7 @@ def verifier_cli_args() -> str:
     string.
 
     [Rust
-    `pactffi_verifier_cli_args`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_cli_args)
+    `pactffi_verifier_cli_args`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_cli_args)
 
     The purpose is to then be able to use in other languages which wrap the FFI
     library, to implement the same CLI functionality automatically without
@@ -6978,7 +7001,7 @@ def verifier_logs(handle: VerifierHandle) -> OwnedString:
     Extracts the logs for the verification run.
 
     [Rust
-    `pactffi_verifier_logs`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_logs)
+    `pactffi_verifier_logs`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_logs)
 
     This needs the memory buffer log sink to be setup before the verification is
     executed. The returned string will need to be freed with the `free_string`
@@ -6996,7 +7019,7 @@ def verifier_logs_for_provider(provider_name: str) -> OwnedString:
     Extracts the logs for the verification run for the provider name.
 
     [Rust
-    `pactffi_verifier_logs_for_provider`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_logs_for_provider)
+    `pactffi_verifier_logs_for_provider`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_logs_for_provider)
 
     This needs the memory buffer log sink to be setup before the verification is
     executed. The returned string will need to be freed with the `free_string`
@@ -7014,7 +7037,7 @@ def verifier_output(handle: VerifierHandle, strip_ansi: int) -> OwnedString:
     Extracts the standard output for the verification run.
 
     [Rust
-    `pactffi_verifier_output`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_output)
+    `pactffi_verifier_output`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_output)
 
     Args:
         handle:
@@ -7037,7 +7060,7 @@ def verifier_json(handle: VerifierHandle) -> OwnedString:
     Extracts the verification result as a JSON document.
 
     [Rust
-    `pactffi_verifier_json`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_verifier_json)
+    `pactffi_verifier_json`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_verifier_json)
     """
     ptr = lib.pactffi_verifier_json(handle._ref)
     if ptr == ffi.NULL:
@@ -7061,7 +7084,7 @@ def using_plugin(
     otherwise you will have plugin processes left running.
 
     [Rust
-    `pactffi_using_plugin`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_using_plugin)
+    `pactffi_using_plugin`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_using_plugin)
 
     Args:
         pact:
@@ -7100,7 +7123,7 @@ def cleanup_plugins(pact: PactHandle) -> None:
     zero).
 
     [Rust
-    `pactffi_cleanup_plugins`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_cleanup_plugins)
+    `pactffi_cleanup_plugins`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_cleanup_plugins)
     """
     lib.pactffi_cleanup_plugins(pact._ref)
 
@@ -7119,7 +7142,7 @@ def interaction_contents(
     format of the JSON contents.
 
     [Rust
-    `pactffi_interaction_contents`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_interaction_contents)
+    `pactffi_interaction_contents`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_interaction_contents)
 
     Args:
         interaction:
@@ -7175,7 +7198,7 @@ def matches_string_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_string_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matches_string_value)
+    `pactffi_matches_string_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matches_string_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get as a NULL terminated string
@@ -7206,7 +7229,7 @@ def matches_u64_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_u64_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matches_u64_value)
+    `pactffi_matches_u64_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matches_u64_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -7236,7 +7259,7 @@ def matches_i64_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_i64_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matches_i64_value)
+    `pactffi_matches_i64_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matches_i64_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -7266,7 +7289,7 @@ def matches_f64_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_f64_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matches_f64_value)
+    `pactffi_matches_f64_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matches_f64_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -7296,7 +7319,7 @@ def matches_bool_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_bool_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matches_bool_value)
+    `pactffi_matches_bool_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matches_bool_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get, 0 == false and 1 == true
@@ -7328,7 +7351,7 @@ def matches_binary_value(  # noqa: PLR0913
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_binary_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matches_binary_value)
+    `pactffi_matches_binary_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matches_binary_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -7363,7 +7386,7 @@ def matches_json_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_json_value`](https://docs.rs/pact_ffi/0.4.18/pact_ffi/?search=pactffi_matches_json_value)
+    `pactffi_matches_json_value`](https://docs.rs/pact_ffi/0.4.19/pact_ffi/?search=pactffi_matches_json_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get as a NULL terminated string

--- a/src/pact/v3/interaction/_base.py
+++ b/src/pact/v3/interaction/_base.py
@@ -354,11 +354,37 @@ class Interaction(abc.ABC):
                 Value for the comment. This must be encodable using
                 [`json.dumps(...)`][json.dumps], or an existing JSON string. The
                 value of `None` will remove the comment with the given key.
+
+        # Warning
+
+        This function will overwrite any existing comment with the same key. In
+        particular, the `text` key is used by `add_text_comment`.
         """
         if isinstance(value, str) or value is None:
             pact.v3.ffi.set_comment(self._handle, key, value)
         else:
             pact.v3.ffi.set_comment(self._handle, key, json.dumps(value))
+        return self
+
+    def add_text_comment(self, comment: str) -> Self:
+        """
+        Add a text comment for the interaction.
+
+        This is used by V4 interactions to set arbitrary text comments for the
+        interaction.
+
+        Args:
+            comment:
+                Text of the comment.
+
+        # Warning
+
+        Internally, the comments are appended to an array under the `text`
+        comment key. Care should be taken to ensure that conflicts are not
+        introduced by
+        [`set_comment`][pact.v3.interaction.Interaction.set_comment].
+        """
+        pact.v3.ffi.add_text_comment(self._handle, comment)
         return self
 
     def test_name(

--- a/src/pact/v3/interaction/_http_interaction.py
+++ b/src/pact/v3/interaction/_http_interaction.py
@@ -149,7 +149,7 @@ class HttpInteraction(Interaction):
         # JSON Matching
 
         Pact's matching rules are defined in the [upstream
-        documentation](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md)
+        documentation](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md)
         and support a wide range of matching rules. These can be specified
         using a JSON object as a strong using `json.dumps(...)`. For example,
         the above rule whereby the `X-Foo` header has multiple values can be
@@ -391,7 +391,7 @@ class HttpInteraction(Interaction):
         ```
 
         For more information on the format of the JSON object, see the [upstream
-        documentation](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.18/rust/pact_ffi/IntegrationJson.md).
+        documentation](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.19/rust/pact_ffi/IntegrationJson.md).
 
         Args:
             name:


### PR DESCRIPTION
## :memo: Summary

Upgrade FFI to `0.4.19`.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Most relevant for Pact Python is a fix to passing through binary bodies which would be dropped by Python before the FFI has a chance to properly parse the contents.

## ~:hammer: Test Plan~

## ~:link: Related issues/PRs~