### PR TITLE
chore: group renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,11 @@
     "enabled": true
   },
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 0
+  "prConcurrentLimit": 0,
+  "packageRules": [
+    {
+      "groupName": "Ruff",
+      "matchPackageNames": ["astral-sh/ruff-pre-commit", "devel/ruff"]
+    }
+  ]
 }


### PR DESCRIPTION
## :memo: Summary

Group renovate updates across pre-commit and explicit dependencies.


## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Help reduce a little bit of the noise from Renovate, but more importantly, ensures that the pre-commit hook uses the same version as the dependency in `pyproject.toml`.

## ~:hammer: Test Plan~

## :link: Related issues/PRs

None
