### PR TITLE
ci: narrow when docs are built and published

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,13 @@ name: docs
 
 on:
   push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   STABLE_PYTHON_VERSION: "3.12"
@@ -41,7 +48,7 @@ jobs:
   publish:
     name: Publish docs
 
-    if: github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
 
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## :memo: Summary

With this change:

- Docs are built on pushes to `master`, PRs targetting `master`, and when new `v*` tags are pushed.
- Docs are published only when new `v*` tags are pushed (in line with new releases).

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Reduce the noise of 'releases' on Slack which thinks that every update to the docs is worthy of a notification.

## ~:hammer: Test Plan~

## :link: Related issues/PRs

None
