### PR TITLE
chore: use uv to install packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ artifacts = [
 # Install dev dependencies in the default environment to simplify the developer
 # workflow.
 [tool.hatch.envs.default]
+installer = "uv"
 features = ["devel"]
 extra-dependencies = [
   "hatchling",
@@ -169,6 +170,7 @@ docs-build = "mkdocs build {args}"
 # Test environment for running unit tests. This automatically tests against all
 # supported Python versions.
 [tool.hatch.envs.test]
+installer = "uv"
 features = ["devel-test"]
 
 [[tool.hatch.envs.test.matrix]]


### PR DESCRIPTION
## :memo: Summary

[uv](https://github.com/astral-sh/uv) provides similar capabilities to `pip` and `venv`, but is _significantly_ faster. Since `hatch` now supports using `uv` under the hood when managing virtual environments, we can get the speed ups for free.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

To provide a better contributor experience.

## :hammer: Test Plan

Regular CI

## :link: Related issues/PRs

N/A