### PR TITLE
chore: update GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -52,7 +52,7 @@ body:
       description: |
         Paste the link to an example repo if possible, and exact instructions to reproduce the issue.
 
-        > **What happens if you skip this step?** Someone will read your bug report, and maybe will be able to help you, but it's unlikely that it will get much attention from the team. Eventually, the issue will likely get closed in favor of issues that have reproducible demos.
+        > **What happens if you skip this step?** Someone will read your bug report, and maybe will be able to help you, but if we fail to reproduce the issue, we might not be able to fix it.
 
         Please remember that:
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: 🚀 Feature request
-    url: https://pact.canny.io
-    about: The Canny board to send us feature requests, vote and measure the interest of users. Useful to submit a feature request when you have an idea but no concrete API design proposal.
   - name: ❓ Simple question - Slack chat
     url: https://slack.pact.io
     about: If you have a simple question, or want to discuss a feature request, join our Slack chat.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,4 +1,4 @@
-name: 💅 Feature design / RFC
+name: 💡 Feature design / RFC
 description: Submit a detailed feature request with a concrete proposal
 labels: [feature, triage]
 body:
@@ -9,7 +9,6 @@ body:
 
         - We expect the feature request to be detailed.
         - The request does not have to be perfect, we'll discuss it and fix it if needed.
-        - For a more "casual" feature request, consider using Canny instead: https://pact.canny.io.
 
   - type: checkboxes
     attributes:
@@ -24,11 +23,6 @@ body:
       description: A clear and concise description of what the feature is.
     validations:
       required: true
-
-  - type: input
-    attributes:
-      label: Has this been requested on Canny?
-      description: Please post the [Canny](https://pact.canny.io) link, it is helpful to see how much interest there is for this feature.
 
   - type: textarea
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ If you're only fixing a bug, it's fine to submit a pull request right away but w
 
 ### Feature requests
 
-If you would like to request a new feature or enhancement but are not yet thinking about opening a pull request, you can file an issue with the [feature template](https://github.com/pact-foundation/pact-python/issues/new?assignees=&labels=feature%2Cstatus%3A+needs+triage&template=feature.yml) for more thought out ideas. Alternatively, you can use the [Canny board](https://pact.canny.io/) for more casual feature requests and gain enough traction before proposing an RFC.
+If you would like to request a new feature or enhancement but are not yet thinking about opening a pull request, you can file an issue with the [feature template](https://github.com/pact-foundation/pact-python/issues/new?assignees=&labels=feature%2Cstatus%3A+needs+triage&template=feature.yml) for more thought out ideas.
 
 ### Claiming issues
 


### PR DESCRIPTION
## :memo: Summary

Update GitHub issue templates:

- Remove links to Canny
- Minor rewording
- Allow blank issues (in case someone really doesn't want to use a template)

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Hopefully a better contributor experience.

## ~:hammer: Test Plan~

## :link: Related issues/PRs

None