### PR TITLE
chore(ci): use pypi trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,9 @@ jobs:
 
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-20.04
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pact-python
 
     needs:
       - build-sdist
@@ -247,7 +249,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
         with:
           skip-existing: true
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: wheels
 
       - name: Create PR for changelog update


### PR DESCRIPTION
## :memo: Summary

Removing the password, as it should not longer be needed now that trusted publishing is enabled.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Trusted publishing doesn't rely on an individual's API key, and instead delegates the authorisation to publish to the specific workflow.

## :hammer: Test Plan

As this is a release process, this will be verified at the next release 🤞 

## :link: Related issues/PRs

None
