### PR TITLE
chore: regroup ruff in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
   "packageRules": [
     {
       "groupName": "Ruff",
-      "matchPackageNames": ["astral-sh/ruff-pre-commit", "devel/ruff"]
+      "matchPackageNames": ["astral-sh/ruff-pre-commit", "ruff"]
     }
   ]
 }


### PR DESCRIPTION
## :memo: Summary

There appears to have been a change in the way renovate names packages.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Avoid the noise and possible incompatibilities due to having different versions of Ruff in the pre-commits and the dev dependencies.

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None
