### PR TITLE
Add Http Post and Delete examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,5 +81,5 @@ repos:
         entry: hatch run mypy
         language: system
         types: [python]
-        exclude: ^(src/pact|tests)/(?!v3/).*\.py$
+        exclude: ^(src/pact|tests|examples/tests)/(?!v3/).*\.py$
         stages: [pre-push]

--- a/examples/.ruff.toml
+++ b/examples/.ruff.toml
@@ -5,6 +5,7 @@ ignore = [
   "S101", # Forbid assert statements
   "D103", # Require docstring in public function
   "D104", # Require docstring in public package
+  "PLR2004" # Forbid Magic Numbers
 ]
 
 [lint.per-file-ignores]

--- a/examples/.ruff.toml
+++ b/examples/.ruff.toml
@@ -2,10 +2,10 @@ extend = "../pyproject.toml"
 
 [lint]
 ignore = [
-  "S101", # Forbid assert statements
-  "D103", # Require docstring in public function
-  "D104", # Require docstring in public package
-  "PLR2004" # Forbid Magic Numbers
+  "S101",    # Forbid assert statements
+  "D103",    # Require docstring in public function
+  "D104",    # Require docstring in public package
+  "PLR2004", # Forbid Magic Numbers
 ]
 
 [lint.per-file-ignores]

--- a/examples/src/consumer.py
+++ b/examples/src/consumer.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 import requests
 
@@ -102,3 +102,44 @@ class UserConsumer:
             name=data["name"],
             created_on=datetime.fromisoformat(data["created_on"]),
         )
+
+    def create_user(
+        self, user: Dict[str, Any], header: Dict[str, str]
+    ) -> Tuple[int, User]:
+        """
+        Create a new user on the server.
+
+        Args:
+            user: The user data to create.
+            header: The headers to send with the request.
+
+        Returns:
+            The user data including the ID assigned by the server; Error if user exists.
+        """
+        uri = f"{self.base_uri}/users/"
+        response = requests.post(uri, headers=header, json=user, timeout=5)
+        response.raise_for_status()
+        data: Dict[str, Any] = response.json()
+        return (
+            response.status_code,
+            User(
+                id=data["id"],
+                name=data["name"],
+                created_on=datetime.fromisoformat(data["created_on"]),
+            ),
+        )
+
+    def delete_user(self, user_id: int) -> int:
+        """
+        Delete a user by ID from the server.
+
+        Args:
+            user_id: The ID of the user to delete.
+
+        Returns:
+            The response status code.
+        """
+        uri = f"{self.base_uri}/users/{user_id}"
+        response = requests.delete(uri, timeout=5)
+        response.raise_for_status()
+        return response.status_code

--- a/examples/src/fastapi.py
+++ b/examples/src/fastapi.py
@@ -19,12 +19,30 @@ concerned with Pact, only the tests are.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict
 
-from fastapi import FastAPI
+from pydantic import BaseModel
+
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
 app = FastAPI()
+logger = logging.getLogger(__name__)
+
+
+class User(BaseModel):
+    """
+    User data class.
+
+    This class is used to represent a user in the application. It is used to
+    validate the incoming data and to dump the data to a dictionary.
+    """
+
+    id: int | None = None
+    name: str
+    email: str
+
 
 """
 As this is a simple example, we'll use a simple dict to represent a database.
@@ -52,3 +70,39 @@ async def get_user_by_id(uid: int) -> JSONResponse:
     if not user:
         return JSONResponse(status_code=404, content={"error": "User not found"})
     return JSONResponse(status_code=200, content=user)
+
+
+@app.post("/users/")
+async def create_new_user(user: User) -> JSONResponse:
+    """
+    Create a new user .
+
+    Args:
+        user: The user data to create
+
+    Returns:
+        The status code 200 and user data if successfully created, HTTP 404 if not
+    """
+    if user.id is not None:
+        raise HTTPException(status_code=400, detail="ID should not be provided.")
+    new_uid = len(FAKE_DB)
+    FAKE_DB[new_uid] = user.model_dump()
+
+    return JSONResponse(status_code=200, content=FAKE_DB[new_uid])
+
+
+@app.delete("/users/{user_id}", status_code=204)
+async def delete_user(user_id: int):  # noqa: ANN201
+    """
+     Delete an existing user .
+
+    Args:
+        user_id: The ID of the user to delete
+
+    Returns:
+        The status code 204, HTTP 404 if not
+    """
+    if user_id not in FAKE_DB:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    del FAKE_DB[user_id]

--- a/examples/tests/v3/conftest.py
+++ b/examples/tests/v3/conftest.py
@@ -1,0 +1,15 @@
+"""
+Common Pytest configuration for the V3 examples.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _setup_pact_logging() -> None:
+    """
+    Set up logging for the pact package.
+    """
+    from pact.v3 import ffi
+
+    ffi.log_to_stderr("INFO")

--- a/examples/tests/v3/test_00_consumer.py
+++ b/examples/tests/v3/test_00_consumer.py
@@ -131,3 +131,67 @@ def test_get_non_existent_user(pact: Pact) -> None:
         response = requests.get(f"{srv.url}/users/2", timeout=5)
 
         assert response.status_code == expected_response_code
+
+
+def test_post_request_to_create_user(pact: Pact) -> None:
+    """
+    Test the POST request for creating a new user.
+
+    This test defines the expected interaction for a POST request to create
+    a new user. It sets up the expected request and response from the provider,
+    including the request body and headers, and verifies that the response
+    status code is 200 and the response body matches the expected user data.
+    """
+    expected: Dict[str, Any] = {
+        "id": 124,
+        "name": "Jane Doe",
+        "email": "jane@example.com",
+    }
+    header = {"Content-Type": "application/json"}
+    body = {"name": "Jane Doe", "email": "jane@example.com"}
+    expected_response_code: int = 200
+
+    (
+        pact.upon_receiving("a request to create a new user")
+        .given("the specified user doesn't exist")
+        .with_request(method="POST", path="/users/")
+        .with_body(json.dumps(body))
+        .with_header("Content-Type", "application/json")
+        .will_respond_with(status=200)
+        .with_body(content_type="application/json", body=json.dumps(expected))
+    )
+
+    with pact.serve() as srv:
+        response = requests.post(
+            f"{srv.url}/users/", headers=header, json=body, timeout=5
+        )
+
+        assert response.status_code == expected_response_code
+        assert response.json() == {
+            "id": 124,
+            "name": "Jane Doe",
+            "email": "jane@example.com",
+        }
+
+
+def test_delete_request_to_delete_user(pact: Pact) -> None:
+    """
+    Test the DELETE request for deleting a user.
+
+    This test defines the expected interaction for a DELETE request to delete
+    a user. It sets up the expected request and response from the provider,
+    including the request body and headers, and verifies that the response
+    status code is 200 and the response body matches the expected user data.
+    """
+    expected_response_code: int = 204
+    (
+        pact.upon_receiving("a request for deleting user")
+        .given("user is present in DB")
+        .with_request(method="DELETE", path="/users/124")
+        .will_respond_with(204)
+    )
+
+    with pact.serve() as srv:
+        response = requests.delete(f"{srv.url}/users/124", timeout=5)
+
+        assert response.status_code == expected_response_code


### PR DESCRIPTION

## :memo: Summary
1. Added the http post and delete methods
2. updated the methods in v2 examples to verify the teardown
3. added new endpoints in flask and fastapi

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Provide more realistic examples for pact-python

## :hammer: Test Plan

Examples are inherently tested

## :link: Related issues/PRs
#757