### PR TITLE
fix and improve examples docker compose file

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -37,7 +37,7 @@ services:
           "-q",
           "-O",
           "-",
-          "http://pactbroker:pactbroker@localhost:9292/diagnostic/status/heartbeat",
+          "http://pactbroker:pactbroker@broker:9292/diagnostic/status/heartbeat",
         ]
       interval: 1s
       timeout: 2s

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -33,10 +33,10 @@ services:
       test:
         [
           "CMD",
-          "curl",
-          "--silent",
-          "--show-error",
-          "--fail",
+          "wget",
+          "-q",
+          "-O",
+          "-",
           "http://pactbroker:pactbroker@localhost:9292/diagnostic/status/heartbeat",
         ]
       interval: 1s

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -3,8 +3,6 @@ version: "3.9"
 services:
   postgres:
     image: postgres
-    ports:
-      - "5432:5432"
     healthcheck:
       test: psql postgres -U postgres --command 'SELECT 1'
     environment:


### PR DESCRIPTION
## :airplane: Pre-flight checklist

-   [x] I have read the [Contributing Guidelines on pull requests](https://github.com/pact-foundation/pact-python/blob/master/CONTRIBUTING.md#pull-requests).
-   [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
-   [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## :memo: Summary

This is a fix to the docker-compose file, so that the examples do run correctly with the broker.
There are 3 smaller fixes in the PR, submitted in 3 commits.

## :fire: Motivation

I was trying to get the broker tests running and they would always fail because the broker would not start correctly. After this changes all works fine and I can continue to learn about `pact-python` :student: 

## :hammer: Test Plan

```
hatch run example
/home/artur/.local/share/hatch/env/virtual/pact-python/wW3DfDZn/pact-python/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
====================================================================== test session starts ======================================================================
platform linux -- Python 3.12.3, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/artur/www/pact-python
configfile: pyproject.toml
plugins: asyncio-0.24.0, anyio-4.6.0, bdd-7.3.0, cov-5.0.0
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 18 items                                                                                                                                              

examples/tests/test_00_consumer.py ....                                                                                                                   [ 22%]
examples/tests/test_01_provider_fastapi.py .                                                                                                              [ 27%]
examples/tests/test_01_provider_flask.py .                                                                                                                [ 33%]
examples/tests/test_02_message_consumer.py ..                                                                                                             [ 44%]
examples/tests/test_03_message_provider.py .                                                                                                              [ 50%]
examples/tests/v3/test_00_consumer.py ....                                                                                                                [ 72%]
examples/tests/v3/test_01_fastapi_provider.py .                                                                                                           [ 77%]
examples/tests/v3/test_02_message_consumer.py ..                                                                                                          [ 88%]
examples/tests/v3/test_03_message_provider.py .                                                                                                           [ 94%]
examples/tests/v3/test_match.py .                                                                                                                         [100%]

======================================================================= warnings summary ========================================================================
examples/tests/v3/test_01_fastapi_provider.py::test_provider
  /usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=64021) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 18 passed, 1 warning in 76.51s (0:01:16) ============================================================
```
