### PR TITLE
chore: use matchers in v3 examples

### DIFF
--- a/examples/tests/v3/test_00_consumer.py
+++ b/examples/tests/v3/test_00_consumer.py
@@ -76,7 +76,8 @@ def test_get_existing_user(pact: Pact) -> None:
         "id": 123,
         "name": "Verna Hampton",
         "created_on": match.datetime(
-            datetime.now(tz=timezone.utc).isoformat(),
+            # Python datetime objects are automatically formatted
+            datetime.now(tz=timezone.utc),
             format="%Y-%m-%dT%H:%M:%S.%fZ",
         ),
     }
@@ -139,7 +140,8 @@ def test_create_user(pact: Pact) -> None:
         "id": 124,
         "name": "Verna Hampton",
         "created_on": match.datetime(
-            datetime.now(tz=timezone.utc).isoformat(),
+            # Python datetime objects are automatically formatted
+            datetime.now(tz=timezone.utc),
             format="%Y-%m-%dT%H:%M:%S.%fZ",
         ),
     }


### PR DESCRIPTION
## :airplane: Pre-flight checklist

-   [x] I have read the [Contributing Guidelines on pull requests](https://github.com/pact-foundation/pact-python/blob/master/CONTRIBUTING.md#pull-requests).
-   [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
-   [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## :memo: Summary

As matchers are now supported in the V3 code, use them in the consumer example.

## :fire: Motivation

simplifying the examples

## :hammer: Test Plan

together with #808 run `hatch run example`
