### PR TITLE
chore(ci): switch to uv fully

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,18 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
 
       - name: Install hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Create source distribution
         run: |
@@ -231,10 +236,19 @@ jobs:
           path: wheels
           merge-multiple: true
 
-      - name: Setup Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
+
+      - name: Install commitizen
+        run: uv tool install commitizen
 
       - name: Update changelog
         id: changelog

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,14 +27,19 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Build docs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,14 +86,19 @@ jobs:
           cd tests/v3/compatibility_suite
           patch -p1 -d definition < definition-update.diff
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Ensure broker is live
         run: |
@@ -152,14 +157,19 @@ jobs:
           cd tests/v3/compatibility_suite
           patch -p1 -d definition < definition-update.diff
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Run tests
         run: hatch run test
@@ -186,14 +196,19 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
-      - name: Set up Python 3
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Ensure broker is live
         run: |
@@ -225,14 +240,19 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
-      - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Format
         run: hatch run format
@@ -245,14 +265,19 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
-      - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Format
         run: hatch run lint
@@ -265,14 +290,19 @@ jobs:
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
-      - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3.1.5
         with:
-          python-version: ${{ env.STABLE_PYTHON_VERSION }}
-          cache: pip
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+
+      - name: Install Python
+        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
 
       - name: Install Hatch
-        run: pip install --upgrade hatch
+        run: uv tool install hatch
 
       - name: Format
         run: hatch run typecheck
@@ -283,10 +313,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
-    - name: Spell Check Repo
-      uses: crate-ci/typos@master
+      - name: Spell Check Repo
+        uses: crate-ci/typos@master
 
   pre-commit:
     name: Pre-commit
@@ -294,7 +324,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
-    - name: Run pre-commit
-      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
## :memo: Summary

We were still using the actions/setup-python action, which does not properly support uv (especially caching). We switch instead to `astral-sh/setup-uv` and use uv to manage Python version as well.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Improve CI performance

## :hammer: Test Plan

As part of CI

## :link: Related issues/PRs

None
