### PR TITLE
chore: disable wait

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -46,6 +46,7 @@ def broker(request: pytest.FixtureRequest) -> Generator[URL, Any, None]:
         EXAMPLE_DIR,
         compose_file_name=["docker-compose.yml"],
         pull=True,
+        wait=False,
     ) as _:
         yield URL("http://pactbroker:pactbroker@localhost:9292")
     return


### PR DESCRIPTION
## :memo: Summary

Disable the use of `--wait` as it is incompatible with Podman (if someone is using `podman-compose` instead of `docker-compose`)

Ref: containers/podman-compose#710

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Improve compatibility

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None