### PR TITLE
chore(ci): disable docs workflow on tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: docs
 
 on:
   push:
-    tags:
-      - v*
     branches:
       - master
   pull_request:


### PR DESCRIPTION
## :memo: Summary

Since the dogs are updated with all updates to `master`, it is redundant to also run the workflow for tags.

This was left-over from a time when the docs were only updates with releases.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Lessen CI workload

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None