### PR TITLE
 chore: disable pypy builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,7 +313,7 @@ exclude = '^(src/pact|tests|examples|examples/tests)/(?!v3).+\.py$'
 ## CI Build Wheel
 ################################################################################
 [tool.cibuildwheel]
-skip = "pp38-*"
+skip = "pp*"
 before-build = """
 rm -rvf src/pact/v3/bin
 rm -rvf src/pact/v3/data


### PR DESCRIPTION
## :memo: Summary

It would appear that PyPy builds with CFFI are broken (once again).

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

This was surfaced when trying to do a release for `v2.2.2` targeting PyPy on Windows.

## ~:hammer: Test Plan~

CI (with a temporary commit)

## :link: Related issues/PRs

None