### PR TITLE
chore: rename master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Have you read the Contributing Guidelines on issues?
       options:
-        - label: I have read the [Contributing Guidelines on issues](https://github.com/pact-foundation/pact-python/blob/master/CONTRIBUTING.md#issues).
+        - label: I have read the [Contributing Guidelines on issues](https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md#issues).
           required: true
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Have you read the Contributing Guidelines on issues?
       options:
-        - label: I have read the [Contributing Guidelines on issues](https://github.com/pact-foundation/pact-python/blob/master/CONTRIBUTING.md#issues).
+        - label: I have read the [Contributing Guidelines on issues](https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md#issues).
           required: true
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
 <!--
 Thank you for sending the PR! We appreciate you spending the time to work on these changes.
-You can learn more about contributing to Pact-python here: https://github.com/pact-foundation/pact-python/blob/master/CONTRIBUTING.md
+You can learn more about contributing to Pact-python here: https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md
 
 Happy contributing!
 -->
 
 ## :airplane: Pre-flight checklist
 
--   [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/pact-foundation/pact-python/blob/master/CONTRIBUTING.md#pull-requests).
+-   [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md#pull-requests).
 -   [ ] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
 -   [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -142,7 +142,7 @@ jobs:
   build-arm64:
     name: Build wheels on ${{ matrix.os }} (arm64)
 
-    # As this requires emulation, it's not worth running on PRs or master
+    # As this requires emulation, it's not worth running on PRs or main
     if: >-
       github.event_name == 'push' &&
       startsWith(github.event.ref, 'refs/tags/v')
@@ -293,4 +293,4 @@ jobs:
           body: |
             This PR updates the changelog for ${{ github.ref_name }}.
           branch: chore/update-changelog
-          base: master
+          base: main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,10 +4,10 @@ name: docs
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 env:
   STABLE_PYTHON_VERSION: '3.13'
@@ -52,7 +52,7 @@ jobs:
   publish:
     name: Publish docs
 
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
 
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -9,7 +9,7 @@ on:
     - cron: 20 0 * * 0
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/labels.yml
 
@@ -27,5 +27,5 @@ jobs:
         uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a  # v2
         with:
           config-file: |-
-            https://raw.githubusercontent.com/pact-foundation/.github/master/.github/labels.yml
+            https://raw.githubusercontent.com/pact-foundation/.github/main/.github/labels.yml
             .github/labels.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ name: test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -328,7 +328,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
 
       - name: Spell Check Repo
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@main
 
   pre-commit:
     name: Pre-commit

--- a/.github/workflows/trigger_pact_docs_update.yml
+++ b/.github/workflows/trigger_pact_docs_update.yml
@@ -4,7 +4,7 @@ name: Trigger update to docs.pact.io
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '**.md'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ All pull requests will be checked by the continuous integration system, GitHub a
 
 ### Branch Organization
 
-Pact Python has one primary branch `master` and we use feature branches to deliver new features with pull requests. Typically, we scope the branch according to the [conventional commit](#conventional-commit-messages) categories. The more common ones are:
+Pact Python has one primary branch `main` and we use feature branches to deliver new features with pull requests. Typically, we scope the branch according to the [conventional commit](#conventional-commit-messages) categories. The more common ones are:
 
 -   `feature/<name>` or `feat/<name>` for new features
 -   `fix/<name>` for bug fixes
@@ -137,7 +137,7 @@ Please make sure the following is done when submitting a pull request:
 2.  **Use descriptive titles.** It is recommended to follow this [commit message style](#conventional-commit-messages).
 3.  **Test your changes.** Describe your [**test plan**](#test-plan) in your pull request description.
 
-All pull requests should be opened against the `master` branch.
+All pull requests should be opened against the `main` branch.
 
 We have a lot of integration systems that run automated tests to guard against mistakes. The maintainers will also review your code and may fix obvious issues for you. These systems' duty is to make you worry as little about the chores as possible. Your code contributions are more important than sticking to any procedures, although completing the checklist will surely save everyone's time.
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@
         <td>
             <a
                 href="https://github.com/pact-foundation/pact-python/actions/workflows/test.yml"><img
-                src="https://img.shields.io/github/actions/workflow/status/pact-foundation/pact-python/test.yml?branch=master&label=test"
+                src="https://img.shields.io/github/actions/workflow/status/pact-foundation/pact-python/test.yml?branch=main&label=test"
                 alt="Test Status"></a>
             <a
                 href="https://github.com/pact-foundation/pact-python/actions/workflows/build.yml"><img
-                src="https://img.shields.io/github/actions/workflow/status/pact-foundation/pact-python/build.yml?branch=master&label=build"
+                src="https://img.shields.io/github/actions/workflow/status/pact-foundation/pact-python/build.yml?branch=main&label=build"
                 alt="Build Status"></a>
             <a
                 href="https://github.com/pact-foundation/pact-python/actions/workflows/docs.yml"><img
-                src="https://img.shields.io/github/actions/workflow/status/pact-foundation/pact-python/docs.yml?branch=master&label=docs"
+                src="https://img.shields.io/github/actions/workflow/status/pact-foundation/pact-python/docs.yml?branch=main=docs"
                 alt="Build Status"></a>
         </td>
     </tr>

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -141,9 +141,9 @@ The CLI options are available as keyword arguments to the various methods of the
 
 You can see more details in the examples
 
--   [Message Provider Verifier Test](https://github.com/pact-foundation/pact-python/blob/master/examples/tests/test_03_message_provider.py)
--   [Flask Provider Verifier Test](https://github.com/pact-foundation/pact-python/blob/master/examples/tests/test_01_provider_flask.py)
--   [FastAPI Provider Verifier Test](https://github.com/pact-foundation/pact-python/blob/master/examples/tests/test_01_provider_fastapi.py)
+-   [Message Provider Verifier Test](https://github.com/pact-foundation/pact-python/blob/main/examples/tests/test_03_message_provider.py)
+-   [Flask Provider Verifier Test](https://github.com/pact-foundation/pact-python/blob/main/examples/tests/test_01_provider_flask.py)
+-   [FastAPI Provider Verifier Test](https://github.com/pact-foundation/pact-python/blob/main/examples/tests/test_01_provider_fastapi.py)
 
 ## Provider States
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -2,7 +2,7 @@
 
 Pact Python is made available through both GitHub releases and PyPI. The GitHub releases also come with a summary of changes and contributions since the last release.
 
-The entire process is automated through the [build](https://github.com/pact-foundation/pact-python/actions/workflows/build.yml?query=branch%3Amaster) GitHub Action. A description of the process is provided [below](#build-pipeline).
+The entire process is automated through the [build](https://github.com/pact-foundation/pact-python/actions/workflows/build.yml?query=branch%3Amain) GitHub Action. A description of the process is provided [below](#build-pipeline).
 
 ## Versioning
 
@@ -23,7 +23,7 @@ The version is stored in `pact/__version__.py`. This file is automatically gener
 
 ## Build Pipeline
 
-The build pipeline is defined in `.github/workflows/build.yml`. It is triggered on PRs targeting `master`, pushes to the `master` branch, and on every new tag. The pipeline is responsible for building the package (both as source distribution, and compiled wheels), creating the GitHub release, and uploading artifacts to PyPI.
+The build pipeline is defined in `.github/workflows/build.yml`. It is triggered on PRs targeting `main`, pushes to the `main` branch, and on every new tag. The pipeline is responsible for building the package (both as source distribution, and compiled wheels), creating the GitHub release, and uploading artifacts to PyPI.
 
 ### Build Steps
 
@@ -34,7 +34,7 @@ In order to reduce the build time, the pipeline builds different sets of wheels 
 | Trigger      | Platforms         | Wheels    |
 | ------------ | ----------------- | --------- |
 | Tag          | `x86_64`, `arm64` | all       |
-| `master`     | `x86_64`          | all       |
+| `main`     | `x86_64`          | all       |
 | Pull Request | `x86_64`          | `cp312-*` |
 
 ### Publish Step

--- a/docs/scripts/markdown.py
+++ b/docs/scripts/markdown.py
@@ -116,7 +116,7 @@ def process_markdown(
 
         mkdocs_gen_files.set_edit_path(
             destination,
-            f"https://github.com/pact-foundation/pact-python/edit/master/{file}",
+            f"https://github.com/pact-foundation/pact-python/edit/main/{file}",
         )
 
 

--- a/docs/scripts/python.py
+++ b/docs/scripts/python.py
@@ -203,7 +203,7 @@ def process_python(
 
         mkdocs_gen_files.set_edit_path(
             destination,
-            f"https://github.com/pact-foundation/pact-python/edit/master/{file}",
+            f"https://github.com/pact-foundation/pact-python/edit/main/{file}",
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 "Repository"    = "https://github.com/pact-foundation/pact-python"
 "Documentation" = "https://docs.pact.io"
 "Bug Tracker"   = "https://github.com/pact-foundation/pact-python/issues"
-"Changelog"     = "https://github.com/pact-foundation/pact-python/blob/master/CHANGELOG.md"
+"Changelog"     = "https://github.com/pact-foundation/pact-python/blob/main/CHANGELOG.md"
 
 [project.scripts]
 pact-verifier = "pact.cli.verify:main"


### PR DESCRIPTION
## :memo: Summary

Renamed the old `master` branch to `main` to align with new standards, this makes the corresponding changes in all files.

## :rotating_light: Breaking Changes

None, unless someone was relying on the `master` branch naming.

## :fire: Motivation

To align with new git standard.

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None