### PR TITLE
chore(v3)!: make util module private

### DIFF
--- a/examples/tests/v3/provider_server.py
+++ b/examples/tests/v3/provider_server.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, NoReturn
 
 import requests
 
-from pact.v3.util import _find_free_port
+from pact.v3._util import find_free_port
 
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
@@ -120,7 +120,7 @@ class Provider:
         """
         Start the provider.
         """
-        url = URL(f"http://localhost:{_find_free_port()}")
+        url = URL(f"http://localhost:{find_free_port()}")
         sys.stderr.write(f"Starting provider on {url}\n")
 
         self.app.run(

--- a/examples/tests/v3/provider_server.py
+++ b/examples/tests/v3/provider_server.py
@@ -7,17 +7,18 @@ from __future__ import annotations
 import logging
 import re
 import signal
-import socket
 import subprocess
 import sys
 import time
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 from importlib import import_module
 from pathlib import Path
 from threading import Thread
 from typing import TYPE_CHECKING, NoReturn
 
 import requests
+
+from pact.v3.util import _find_free_port
 
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
@@ -115,27 +116,11 @@ class Provider:
                 self.state_provider_function(flask.request.args["state"])
             return "Provider state set", 200
 
-    def _find_free_port(self) -> int:
-        """
-        Find a free port.
-
-        This is used to find a free port to host the API on when running locally. It
-        is allocated, and then released immediately so that it can be used by the
-        API.
-
-        Returns:
-            The port number.
-        """
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            s.bind(("", 0))
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            return s.getsockname()[1]
-
     def run(self) -> None:
         """
         Start the provider.
         """
-        url = URL(f"http://localhost:{self._find_free_port()}")
+        url = URL(f"http://localhost:{_find_free_port()}")
         sys.stderr.write(f"Starting provider on {url}\n")
 
         self.app.run(

--- a/src/pact/v3/_util.py
+++ b/src/pact/v3/_util.py
@@ -3,8 +3,8 @@ Utility functions for Pact.
 
 This module defines a number of utility functions that are used in specific
 contexts within the Pact library. These functions are not intended to be
-used directly by consumers of the library, but are still made available for
-reference.
+used directly by consumers of the library and as such, may change without
+notice.
 """
 
 import socket
@@ -84,7 +84,7 @@ def strftime_to_simple_date_format(python_format: str) -> str:
             if escaped:
                 result += "'"
                 escaped = False
-            result += _format_code_to_java_format(c)
+            result += format_code_to_java_format(c)
             # Increment another time to skip the second character of the
             # Python format code.
             idx += 1
@@ -108,7 +108,7 @@ def strftime_to_simple_date_format(python_format: str) -> str:
     return result
 
 
-def _format_code_to_java_format(code: str) -> str:
+def format_code_to_java_format(code: str) -> str:
     """
     Convert a single Python format code to a Java SimpleDateFormat format.
 
@@ -144,7 +144,7 @@ def _format_code_to_java_format(code: str) -> str:
     raise ValueError(msg)
 
 
-def _find_free_port() -> int:
+def find_free_port() -> int:
     """
     Find a free port.
 

--- a/src/pact/v3/generate/__init__.py
+++ b/src/pact/v3/generate/__init__.py
@@ -8,11 +8,11 @@ import builtins
 import warnings
 from typing import TYPE_CHECKING, Literal
 
+from pact.v3._util import strftime_to_simple_date_format
 from pact.v3.generate.generator import (
     Generator,
     GenericGenerator,
 )
-from pact.v3.util import strftime_to_simple_date_format
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/src/pact/v3/match/__init__.py
+++ b/src/pact/v3/match/__init__.py
@@ -51,6 +51,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from pact.v3 import generate
+from pact.v3._util import strftime_to_simple_date_format
 from pact.v3.match.matcher import (
     ArrayContainsMatcher,
     EachKeyMatcher,
@@ -59,7 +60,6 @@ from pact.v3.match.matcher import (
     Matcher,
 )
 from pact.v3.types import UNSET, Matchable, Unset
-from pact.v3.util import strftime_to_simple_date_format
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/src/pact/v3/pact.py
+++ b/src/pact/v3/pact.py
@@ -84,6 +84,7 @@ from pact.v3.error import (
 from pact.v3.interaction._async_message_interaction import AsyncMessageInteraction
 from pact.v3.interaction._http_interaction import HttpInteraction
 from pact.v3.interaction._sync_message_interaction import SyncMessageInteraction
+from pact.v3.util import _find_free_port
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -565,7 +566,7 @@ class PactServer:
         self,
         pact_handle: pact.v3.ffi.PactHandle,
         host: str = "localhost",
-        port: int = 0,
+        port: int | None = None,
         transport: str = "HTTP",
         transport_config: str | None = None,
         *,
@@ -583,8 +584,8 @@ class PactServer:
                 Hostname of IP for the mock server.
 
             port:
-                Port to bind the mock server to. The value of `0` will select a
-                random available port.
+                Port to bind the mock server to. The value of `None` will select
+                a random available port.
 
             transport:
                 Transport to use for the mock server.
@@ -602,7 +603,7 @@ class PactServer:
                 independently of `raises`.
         """
         self._host = host
-        self._port = port
+        self._port = port or _find_free_port()
         self._transport = transport
         self._transport_config = transport_config
         self._pact_handle = pact_handle
@@ -611,16 +612,16 @@ class PactServer:
         self._verbose = verbose
 
     @property
-    def port(self) -> int:
+    def port(self) -> int | None:
         """
         Port on which the server is running.
 
-        If the server is not running, then this will be `0`.
+        If the server is not running, then this will be `None`.
         """
         # Unlike the other properties, this value might be different to what was
         # passed in to the constructor as the server can be started on a random
         # port.
-        return self._handle.port if self._handle else 0
+        return self._handle.port if self._handle else None
 
     @property
     def host(self) -> str:

--- a/src/pact/v3/pact.py
+++ b/src/pact/v3/pact.py
@@ -75,6 +75,7 @@ from typing import (
 from yarl import URL
 
 import pact.v3.ffi
+from pact.v3._util import find_free_port
 from pact.v3.error import (
     InteractionVerificationError,
     Mismatch,
@@ -84,7 +85,6 @@ from pact.v3.error import (
 from pact.v3.interaction._async_message_interaction import AsyncMessageInteraction
 from pact.v3.interaction._http_interaction import HttpInteraction
 from pact.v3.interaction._sync_message_interaction import SyncMessageInteraction
-from pact.v3.util import _find_free_port
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -603,7 +603,7 @@ class PactServer:
                 independently of `raises`.
         """
         self._host = host
-        self._port = port or _find_free_port()
+        self._port = port or find_free_port()
         self._transport = transport
         self._transport_config = transport_config
         self._pact_handle = pact_handle

--- a/src/pact/v3/util.py
+++ b/src/pact/v3/util.py
@@ -7,7 +7,9 @@ used directly by consumers of the library, but are still made available for
 reference.
 """
 
+import socket
 import warnings
+from contextlib import closing
 
 _PYTHON_FORMAT_TO_JAVA_DATETIME = {
     "a": "EEE",
@@ -140,3 +142,20 @@ def _format_code_to_java_format(code: str) -> str:
 
     msg = f"Unsupported Python format code `%{code}`"
     raise ValueError(msg)
+
+
+def _find_free_port() -> int:
+    """
+    Find a free port.
+
+    This is used to find a free port to host the API on when running locally. It
+    is allocated, and then released immediately so that it can be used by the
+    API.
+
+    Returns:
+        The port number.
+    """
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]

--- a/tests/v3/compatibility_suite/util/provider.py
+++ b/tests/v3/compatibility_suite/util/provider.py
@@ -19,10 +19,11 @@ from pathlib import Path
 
 import pytest
 
+from pact.v3.util import _find_free_port
+
 sys.path.append(str(Path(__file__).parent.parent.parent.parent.parent))
 
 
-import contextlib
 import copy
 import json
 import logging
@@ -31,7 +32,6 @@ import pickle
 import re
 import shutil
 import signal
-import socket
 import subprocess
 import time
 import warnings
@@ -105,23 +105,6 @@ def next_version() -> str:
     version = version_var.get()
     version_var.set(str(int(version) + 1))
     return version
-
-
-def _find_free_port() -> int:
-    """
-    Find a free port.
-
-    This is used to find a free port to host the API on when running locally. It
-    is allocated, and then released immediately so that it can be used by the
-    API.
-
-    Returns:
-        The port number.
-    """
-    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
 
 
 def _setup_logging(log_level: int) -> None:

--- a/tests/v3/compatibility_suite/util/provider.py
+++ b/tests/v3/compatibility_suite/util/provider.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from pact.v3.util import _find_free_port
+from pact.v3._util import find_free_port
 
 sys.path.append(str(Path(__file__).parent.parent.parent.parent.parent))
 
@@ -307,7 +307,7 @@ class Provider:
         """
         Start the provider.
         """
-        url = URL(f"http://localhost:{_find_free_port()}")
+        url = URL(f"http://localhost:{find_free_port()}")
         sys.stderr.write(f"Starting provider on {url}\n")
         for endpoint in self.app.url_map.iter_rules():
             sys.stderr.write(f"  * {endpoint}\n")

--- a/tests/v3/test_pact.py
+++ b/tests/v3/test_pact.py
@@ -44,6 +44,7 @@ def test_empty_provider() -> None:
 
 def test_serve(pact: Pact) -> None:
     with pact.serve() as srv:
+        assert srv.port is not None
         assert srv.port > 0
         assert srv.host == "localhost"
         assert str(srv).startswith("http://localhost")

--- a/tests/v3/test_util.py
+++ b/tests/v3/test_util.py
@@ -4,7 +4,7 @@ Tests of pact.v3.util functions.
 
 import pytest
 
-from pact.v3.util import strftime_to_simple_date_format
+from pact.v3._util import strftime_to_simple_date_format
 
 
 def test_convert_python_to_java_datetime_format_basic() -> None:


### PR DESCRIPTION
## :memo: Summary

The `pact.v3.util` module contains useful utility functions used internally, but otherwise should not be used by Pact Python end-users. As a result, I am making it private now.

## :rotating_light: Breaking Changes

- `pact.v3.util` is renamed to `pact.v3._util`
- Functions within said module have had their leading underscores removed

Furthermore, as `pact.v3._util` is now a private module, breaking changes to private functions will _not_ be considered breaking changes to the Pact Python library.

## :fire: Motivation

Simplify the ongoing maintenance of the utility functions without burdening ourselves with backward compatibility.

## :hammer: Test Plan

Regular CI

## :link: Related issues/PRs

None