### PR TITLE
chore(v3)!: remove unnecessary underscores

### DIFF
--- a/src/pact/v3/pact.py
+++ b/src/pact/v3/pact.py
@@ -744,9 +744,9 @@ class PactServer:
 
     def __exit__(
         self,
-        _exc_type: type[BaseException] | None,
-        _exc_value: BaseException | None,
-        _traceback: TracebackType | None,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         """
         Stop the server.


### PR DESCRIPTION
## :memo: Summary

The arguments to `__exit__` are not used. When first implemented, this used the leading underscores to make that explicit; however, this is incompatible with the expected type signature of the function.

## :rotating_light: Breaking Changes

The PactServer `__exit__` arguments no longer have leading underscores. This is typically handled by Python itself and therefore is unlikely to be a change for any user, unless the end user was calling the `__exit__` method explicitly _and_ using keyword arguments.

## :fire: Motivation

Better compatibility with the expected behaviour of `__exit__`

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None
