### PR TITLE
chore(ci): upgrade macos-12 to macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         include:
           - os: ubuntu-20.04
             archs: x86_64
-          - os: macos-12
+          - os: macos-13
             archs: x86_64
           - os: windows-2019
             archs: AMD64


### PR DESCRIPTION
## :memo: Summary

GitHub is deprecating macOS 12 runners soon.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Ensure CI keeps working

## :hammer: Test Plan

CI

## :link: Related issues/PRs

- actions/runner-images#10721