### PR TITLE
Revert "chore(deps): update softprops/action-gh-release action to v2.2.0"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
 
       - name: Generate release
         id: release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048  # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974  # v2.1.0
         with:
           files: wheels/*
           body_path: ${{ runner.temp }}/changelog


### PR DESCRIPTION
This reverts commit 15f61caeb9dfa829b4548895b2deb1c9dda54f82.

There's a bug in softprops 'action-gh-release' action which appears when uploading larger assets. Reverting to an earlier version until fix is merged.

Ref: softprops/action-gh-release#562
Ref: softprops/action-gh-release#556
