### PR TITLE
chore(ci): update ubuntu runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
   build-sdist:
     name: Build source distribution
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             archs: x86_64
           - os: macos-13
             archs: x86_64
@@ -151,10 +151,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             archs: aarch64
             build: manylinux
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             archs: aarch64
             build: musllinux
           - os: macos-14
@@ -208,7 +208,7 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       startsWith(github.event.ref, 'refs/tags/v')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment:
       name: pypi
       url: https://pypi.org/p/pact-python


### PR DESCRIPTION
## :memo: Summary

Update the Ubuntu runners to 22.04 due to GitHub sunsetting the 20.04 runners.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

To ensure that our CI workflows keep working.

## :hammer: Test Plan

As part of CI.

## :link: Related issues/PRs

None
