### PR TITLE
chore: reduce noise from taiki-e/install-action

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,10 @@
     {
       "groupName": "Ruff",
       "matchPackageNames": ["astral-sh/ruff-pre-commit", "ruff"]
+    },
+    {
+      "matchPackageNames": ["taiki-e/install-action"],
+      "schedule": "before 4am on monday"
     }
   ]
 }


### PR DESCRIPTION
## :memo: Summary

Reduce noise from the `taiki-e/install-action` dependency by having weekly updates only.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

The `taiki-e/install-action` has _very_ frequent updates (due to updating the packages it knows about). This can result in sometimes multiple updates a day.

Having a weekly update should be plenty sufficient.

## :hammer: Test Plan

Renovate will validate the config. No other testing required.

## :link: Related issues/PRs

None
