### PR TITLE
Feat/allow more flexible arguments

### DIFF
--- a/docs/blog/posts/2024/12-30 functional arguments.md
+++ b/docs/blog/posts/2024/12-30 functional arguments.md
@@ -120,7 +120,7 @@ The new `state_handler` method replaces the `set_state` method and simplifies th
 
     1.  The `name` parameter is the name of the provider state. For example, `"a user with ID 123 exists"` or `"no users exist"`. If you instead use a mapping of provider state names to functions, this parameter is not passed to the function.
     2.  The `action` parameter is either `"setup"` or `"teardown"`. The setup action should create the provider state, and the teardown action should remove it. If you specify `teardown=False`, then the `action` parameter is _not_ passed to the callback function.
-    3.  The `params` parameter is a dictionary of additional parameters that the provider state requires. For example, instead of `"a user with ID 123 exists"`, the provider state might be `"a user with the given ID exists"` and the specific ID would be passed in the `params` dictionary. Note that `params` is always present, but may be `None` if no parameters are specified by the consumer.
+    3.  The `parameters` parameter is a dictionary of additional parameters that the provider state requires. For example, instead of `"a user with ID 123 exists"`, the provider state might be `"a user with the given ID exists"` and the specific ID would be passed in the `parameters` dictionary. Note that `parameters` is always present, but may be `None` if no parameters are specified by the consumer.
 <!-- markdownlint-enable code-block-style -->
 
 The function arguments must include the relevant keys from the [`StateHandlerArgs`][pact.v3.types.StateHandlerArgs] typed dictionary. Pact Python will then intelligently determine how to pass the arguments in to your function, whether it be through positional or keyword arguments, or through variadic arguments.

--- a/examples/tests/v3/test_01_fastapi_provider.py
+++ b/examples/tests/v3/test_01_fastapi_provider.py
@@ -170,6 +170,11 @@ def provider_state_handler(
     also be used to reset the mock, or in the case were a real database is used,
     to clean up any side effects.
 
+    This example showcases how a _full_ provider state handler can be
+    implemented. The handler can also be specified through a mapping of provider
+    states to functions. See the documentation of the
+    [`state_handler`][pact.v3.Verifier.state_handler] method for more details.
+
     Args:
         action:
             One of `setup` or `teardown`. Determines whether the provider state

--- a/examples/tests/v3/test_01_fastapi_provider.py
+++ b/examples/tests/v3/test_01_fastapi_provider.py
@@ -146,7 +146,7 @@ def test_provider(server: str) -> None:
 def provider_state_handler(
     state: str,
     action: str,
-    _parameters: dict[str, Any] | None,
+    parameters: dict[str, Any] | None = None,  # noqa: ARG001
 ) -> None:
     """
     Handler for the provider state callback.
@@ -177,6 +177,10 @@ def provider_state_handler(
 
         state:
             The name of the state to set up or tear down.
+
+        parameters:
+            A dictionary of parameters to pass to the state handler. This is
+            not used in this example, but is included for completeness.
 
     Returns:
         A dictionary containing the result of the action.

--- a/src/pact/v3/types.py
+++ b/src/pact/v3/types.py
@@ -8,8 +8,7 @@ information to static type checkers like `mypy`.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any, Optional, TypedDict, Union
+from typing import Any, Literal, TypedDict, Union
 
 from typing_extensions import TypeAlias
 from yarl import URL
@@ -57,74 +56,83 @@ class Message(TypedDict):
     """
 
 
-MessageProducerFull: TypeAlias = Callable[[str, Optional[dict[str, Any]]], Message]
-"""
-Full message producer signature.
+class MessageProducerArgs(TypedDict, total=False):
+    """
+    Arguments for the message handler functions.
 
-This is the signature for a message producer that takes two arguments:
+    The message producer function must be able to accept these arguments. Pact
+    Python will inspect the function's type signature to determine how best to
+    pass the arguments in (e.g., as keyword arguments, position arguments,
+    variadic arguments, or a combination of these). Note that Pact Python will
+    prefer the use of keyword arguments if available, and therefore it is
+    recommended to allow keyword arguments for the fields below if possible.
+    """
 
-1.  The message name, as a string.
-2.  A dictionary of parameters, or `None` if no parameters are provided.
+    name: str
+    """
+    The name of the message.
 
-The function must return a `bytes` object.
-"""
+    This is used to identify the message so that the function knows which
+    message to generate. This is typically a string that describes the
+    message. For example, `"a request to create a new user"` or `"a metric event
+    for a user login"`.
 
-MessageProducerNoName: TypeAlias = Callable[[Optional[dict[str, Any]]], Message]
-"""
-Message producer signature without the name.
+    This may be omitted if the message producer functions are passed through a
+    dictionary where the key is used to identify the message.
+    """
 
-This is the signature for a message producer that takes one argument:
+    metadata: dict[str, Any] | None
+    """
+    Metadata associated with the message.
+    """
 
-1.  A dictionary of parameters, or `None` if no parameters are provided.
 
-The function must return a `bytes` object.
+class StateHandlerArgs(TypedDict, total=False):
+    """
+    Arguments for the state handler functions.
 
-This function must be provided as part of a dictionary mapping message names to
-functions.
-"""
+    The state handler function must be able to accept these arguments. Pact
+    Python will inspect the function's type signature to determine how best to
+    pass the arguments in (e.g., as keyword arguments, position arguments,
+    variadic arguments, or a combination of these). Note that Pact Python will
+    prefer the use of keyword arguments if available, and therefore it is
+    recommended to allow keyword arguments for the fields below if possible.
+    """
 
-StateHandlerFull: TypeAlias = Callable[[str, str, Optional[dict[str, Any]]], None]
-"""
-Full state handler signature.
+    state: str
+    """
+    The name of the state.
 
-This is the signature for a state handler that takes three arguments:
+    This is used to identify the state so that the function knows which state to
+    generate. This is typically a string that describes the state. For example,
+    `"user exists"`.
 
-1.  The state name, as a string.
-2.  The action (either `setup` or `teardown`), as a string.
-3.  A dictionary of parameters, or `None` if no parameters are provided.
-"""
-StateHandlerNoAction: TypeAlias = Callable[[str, Optional[dict[str, Any]]], None]
-"""
-State handler signature without the action.
+    If the function is passed through a dictionary where the key is used to
+    identify the state, this argument is not required.
+    """
 
-This is the signature for a state handler that takes two arguments:
+    action: Literal["setup", "teardown"]
+    """
+    The action to perform.
 
-1.  The state name, as a string.
-2.  A dictionary of parameters, or `None` if no parameters are provided.
-"""
-StateHandlerNoState: TypeAlias = Callable[[str, Optional[dict[str, Any]]], None]
-"""
-State handler signature without the state.
+    This is either `"setup"` or `"teardown"`, and indicates whether the state
+    should be set up or torn down.
 
-This is the signature for a state handler that takes two arguments:
+    This argument is only used if the state handler is expected to perform both
+    setup and teardown actions (i.e., if `teardown=True` is used when calling
+    [`Verifier.state_handler][pact.v3.verifier.Verifier.state_handler]`).
+    """
 
-1.  The action (either `setup` or `teardown`), as a string.
-2.  A dictionary of parameters, or `None` if no parameters are provided.
+    parameters: dict[str, Any] | None
+    """
+    Parameters required to generate the state.
 
-This function must be provided as part of a dictionary mapping state names to
-functions.
-"""
-StateHandlerNoActionNoState: TypeAlias = Callable[[Optional[dict[str, Any]]], None]
-"""
-State handler signature without the state or action.
+    This can be used to pass in any additional parameters that are required to
+    generate the state. For example, if the state requires a user ID, this can
+    be passed in here.
+    """
 
-This is the signature for a state handler that takes one argument:
 
-1.  A dictionary of parameters, or `None` if no parameters are provided.
-
-This function must be provided as part of a dictionary mapping state names to
-functions.
-"""
 StateHandlerUrl: TypeAlias = Union[str, URL]
 """
 State handler URL signature.

--- a/src/pact/v3/types.pyi
+++ b/src/pact/v3/types.pyi
@@ -4,7 +4,7 @@
 # As a result, it is safe to perform expensive imports, even if they are not
 # used or available at runtime.
 
-from collections.abc import Callable, Collection, Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -122,74 +122,15 @@ class Message(TypedDict):
     metadata: dict[str, Any] | None
     content_type: str | None
 
-MessageProducerFull: TypeAlias = Callable[[str, dict[str, Any] | None], Message]
-"""
-Full message producer signature.
+class MessageProducerArgs(TypedDict, total=False):
+    name: str
+    metadata: dict[str, Any] | None
 
-This is the signature for a message producer that takes two arguments:
+class StateHandlerArgs(TypedDict, total=False):
+    state: str
+    action: Literal["setup", "teardown"]
+    parameters: dict[str, Any] | None
 
-1.  The message name, as a string.
-2.  A dictionary of parameters, or `None` if no parameters are provided.
-
-The function must return a `bytes` object.
-"""
-
-MessageProducerNoName: TypeAlias = Callable[[dict[str, Any] | None], Message]
-"""
-Message producer signature without the name.
-
-This is the signature for a message producer that takes one argument:
-
-1.  A dictionary of parameters, or `None` if no parameters are provided.
-
-The function must return a `bytes` object.
-
-This function must be provided as part of a dictionary mapping message names to
-functions.
-"""
-
-StateHandlerFull: TypeAlias = Callable[[str, str, dict[str, Any] | None], None]
-"""
-Full state handler signature.
-
-This is the signature for a state handler that takes three arguments:
-
-1.  The state name, as a string.
-2.  The action (either `setup` or `teardown`), as a string.
-3.  A dictionary of parameters, or `None` if no parameters are provided.
-"""
-StateHandlerNoAction: TypeAlias = Callable[[str, dict[str, Any] | None], None]
-"""
-State handler signature without the action.
-
-This is the signature for a state handler that takes two arguments:
-
-1.  The state name, as a string.
-2.  A dictionary of parameters, or `None` if no parameters are provided.
-"""
-StateHandlerNoState: TypeAlias = Callable[[str, dict[str, Any] | None], None]
-"""
-State handler signature without the state.
-
-This is the signature for a state handler that takes two arguments:
-
-1.  The action (either `setup` or `teardown`), as a string.
-2.  A dictionary of parameters, or `None` if no parameters are provided.
-
-This function must be provided as part of a dictionary mapping state names to
-functions.
-"""
-StateHandlerNoActionNoState: TypeAlias = Callable[[dict[str, Any] | None], None]
-"""
-State handler signature without the state or action.
-
-This is the signature for a state handler that takes one argument:
-
-1.  A dictionary of parameters, or `None` if no parameters are provided.
-
-This function must be provided as part of a dictionary mapping state names to
-functions.
-"""
 StateHandlerUrl: TypeAlias = str | URL
 """
 State handler URL signature.

--- a/tests/v3/compatibility_suite/util/provider.py
+++ b/tests/v3/compatibility_suite/util/provider.py
@@ -894,9 +894,9 @@ def a_provider_state_callback_is_configured(
         logger.info("Configuring provider state callback")
 
         def _callback(
-            _name: str,
-            _action: str,
-            _params: dict[str, str] | None,
+            state: str,
+            action: str,
+            parameters: dict[str, str] | None,
         ) -> None:
             pass
 
@@ -1267,7 +1267,10 @@ def the_provider_state_callback_will_receive_a_setup_call(
         logger.debug("Calls: %s", provider_callback.call_args_list)
         provider_callback.assert_called()
         for calls in provider_callback.call_args_list:
-            if calls.args[0] == state and calls.args[1] == action:
+            if (
+                calls.kwargs.get("state") == state
+                and calls.kwargs.get("action") == action
+            ):
                 return
 
         msg = f"No {action} call found"
@@ -1305,8 +1308,11 @@ def the_provider_state_callback_will_receive_a_setup_call_with_parameters(
 
         provider_callback.assert_called()
         for calls in provider_callback.call_args_list:
-            if calls.args[0] == state and calls.args[1] == action:
-                assert calls.args[2] == params
+            if (
+                calls.kwargs.get("state") == state
+                and calls.kwargs.get("action") == action
+                and calls.kwargs.get("parameters") == params
+            ):
                 return
         msg = f"No {action} call found"
         raise AssertionError(msg)

--- a/tests/v3/compatibility_suite/util/provider.py
+++ b/tests/v3/compatibility_suite/util/provider.py
@@ -896,7 +896,7 @@ def a_provider_state_callback_is_configured(
         def _callback(
             state: str,
             action: str,
-            parameters: dict[str, str] | None,
+            parameters: dict[str, Any] | None,
         ) -> None:
             pass
 

--- a/tests/v3/test_util.py
+++ b/tests/v3/test_util.py
@@ -4,7 +4,7 @@ Tests of pact.v3.util functions.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pytest
 
@@ -46,39 +46,87 @@ def test_convert_python_to_java_datetime_format_with_single_quote() -> None:
     assert strftime_to_simple_date_format("%Y'%m'%d") == "yyyy''MM''dd"
 
 
+class Args(NamedTuple):
+    """
+    Named tuple to hold the arguments passed to a function.
+    """
+
+    args: dict[str, Any]
+    kwargs: dict[str, Any]
+    variadic_args: list[Any]
+    variadic_kwargs: dict[str, Any]
+
+
 def no_annotations(a, b, c, d=b"d"):  # noqa: ANN001, ANN201  # type: ignore[reportUnknownArgumentType]
-    return f"{a}:{b}:{c}:{d!r}"
+    return Args(
+        args={"a": a, "b": b, "c": c, "d": d},
+        kwargs={},
+        variadic_args=[],
+        variadic_kwargs={},
+    )
 
 
-def annotated(a: int, b: str, c: float, d: bytes = b"d") -> str:
-    return f"{a}:{b}:{c}:{d!r}"
+def annotated(a: int, b: str, c: float, d: bytes = b"d") -> Args:
+    return Args(
+        args={"a": a, "b": b, "c": c, "d": d},
+        kwargs={},
+        variadic_args=[],
+        variadic_kwargs={},
+    )
 
 
-def mixed(a: int, /, b: str, *, c: float, d: bytes = b"d") -> str:
-    return f"{a}:{b}:{c}:{d!r}"
+def mixed(a: int, /, b: str, *, c: float, d: bytes = b"d") -> Args:
+    return Args(
+        args={"a": a, "b": b, "c": c, "d": d},
+        kwargs={},
+        variadic_args=[],
+        variadic_kwargs={},
+    )
 
 
-def variadic_args(*args: Any) -> str:  # noqa: ANN401
-    return ":".join(str(arg) for arg in args)
+def variadic_args(*args: Any) -> Args:  # noqa: ANN401
+    return Args(
+        args={},
+        kwargs={},
+        variadic_args=list(args),
+        variadic_kwargs={},
+    )
 
 
-def variadic_kwargs(**kwargs: Any) -> str:  # noqa: ANN401
-    return ":".join(str(v) for v in kwargs.values())
+def variadic_kwargs(**kwargs: Any) -> Args:  # noqa: ANN401
+    return Args(
+        args={},
+        kwargs=kwargs,
+        variadic_args=[],
+        variadic_kwargs={**kwargs},
+    )
 
 
-def variadic_args_kwargs(*args: Any, **kwargs: Any) -> list[str]:  # noqa: ANN401
-    return [
-        ":".join(str(arg) for arg in args),
-        ":".join(str(v) for v in kwargs.values()),
-    ]
+def variadic_args_kwargs(*args: Any, **kwargs: Any) -> Args:  # noqa: ANN401
+    return Args(
+        args={},
+        kwargs=kwargs,
+        variadic_args=list(args),
+        variadic_kwargs={**kwargs},
+    )
 
 
-def mixed_variadic_args(a: int, *args: Any, d: bytes = b"d") -> list[str]:  # noqa: ANN401
-    return [f"{a}:{d!r}", ":".join(str(arg) for arg in args)]
+def mixed_variadic_args(a: int, *args: Any, d: bytes = b"d") -> Args:  # noqa: ANN401
+    return Args(
+        args={"a": a, "d": d},
+        kwargs={},
+        variadic_args=list(args),
+        variadic_kwargs={},
+    )
 
 
-def mixed_variadic_kwargs(a: int, d: bytes = b"d", **kwargs: Any) -> list[str]:  # noqa: ANN401
-    return [f"{a}:{d!r}", ":".join(str(v) for v in kwargs.values())]
+def mixed_variadic_kwargs(a: int, d: bytes = b"d", **kwargs: Any) -> Args:  # noqa: ANN401
+    return Args(
+        args={"a": a, "d": d},
+        kwargs=kwargs,
+        variadic_args=[],
+        variadic_kwargs={**kwargs},
+    )
 
 
 def mixed_variadic_args_kwargs(
@@ -86,119 +134,192 @@ def mixed_variadic_args_kwargs(
     *args: Any,  # noqa: ANN401
     d: bytes = b"d",
     **kwargs: Any,  # noqa: ANN401
-) -> list[str]:
-    return [
-        f"{a}:{d!r}",
-        ":".join(str(arg) for arg in args),
-        ":".join(str(v) for v in kwargs.values()),
-    ]
+) -> Args:
+    return Args(
+        args={"a": a, "d": d},
+        kwargs=kwargs,
+        variadic_args=list(args),
+        variadic_kwargs={**kwargs},
+    )
 
 
 class Foo:  # noqa: D101
     def __init__(self) -> None:  # noqa: D107
         pass
 
-    def __call__(self, a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
-        return f"{a}:{b}:{c}:{d!r}"
+    def __call__(self, a: int, b: str, c: float, d: bytes = b"d") -> Args:  # noqa: D102
+        return Args(
+            args={"a": a, "b": b, "c": c, "d": d},
+            kwargs={},
+            variadic_args=[],
+            variadic_kwargs={},
+        )
 
-    def method(self, a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
-        return f"{a}:{b}:{c}:{d!r}"
+    def method(self, a: int, b: str, c: float, d: bytes = b"d") -> Args:  # noqa: D102
+        return Args(
+            args={"a": a, "b": b, "c": c, "d": d},
+            kwargs={},
+            variadic_args=[],
+            variadic_kwargs={},
+        )
 
     @classmethod
-    def class_method(cls, a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
-        return f"{a}:{b}:{c}:{d!r}"
+    def class_method(cls, a: int, b: str, c: float, d: bytes = b"d") -> Args:  # noqa: D102
+        return Args(
+            args={"a": a, "b": b, "c": c, "d": d},
+            kwargs={},
+            variadic_args=[],
+            variadic_kwargs={},
+        )
 
     @staticmethod
-    def static_method(a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
-        return f"{a}:{b}:{c}:{d!r}"
+    def static_method(a: int, b: str, c: float, d: bytes = b"d") -> Args:  # noqa: D102
+        return Args(
+            args={"a": a, "b": b, "c": c, "d": d},
+            kwargs={},
+            variadic_args=[],
+            variadic_kwargs={},
+        )
 
 
 @pytest.mark.parametrize(
     ("func", "args", "expected"),
     [
-        (no_annotations, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14:b'd'"),
-        (no_annotations, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
-        (annotated, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14:b'd'"),
-        (annotated, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
-        (mixed, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14:b'd'"),
-        (mixed, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
-        (variadic_args, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14"),
-        (variadic_args, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
-        (variadic_kwargs, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14"),
-        (variadic_kwargs, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
-        (variadic_args_kwargs, {"a": 1, "b": "b", "c": 3.14}, ["", "1:b:3.14"]),
+        (
+            no_annotations,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"d"}, {}, [], {}),
+        ),
+        (
+            no_annotations,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"e"}, {}, [], {}),
+        ),
+        (
+            annotated,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"d"}, {}, [], {}),
+        ),
+        (
+            annotated,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"e"}, {}, [], {}),
+        ),
+        (
+            mixed,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"d"}, {}, [], {}),
+        ),
+        (
+            mixed,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"e"}, {}, [], {}),
+        ),
+        (
+            variadic_args,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({}, {}, [1, "b", 3.14], {}),
+        ),
+        (
+            variadic_args,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            Args({}, {}, [1, "b", 3.14, b"e"], {}),
+        ),
+        (
+            variadic_kwargs,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({}, {"a": 1, "b": "b", "c": 3.14}, [], {"a": 1, "b": "b", "c": 3.14}),
+        ),
+        (
+            variadic_kwargs,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            Args(
+                {},
+                {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+                [],
+                {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            ),
+        ),
+        (
+            variadic_args_kwargs,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({}, {"a": 1, "b": "b", "c": 3.14}, [], {"a": 1, "b": "b", "c": 3.14}),
+        ),
         (
             variadic_args_kwargs,
             {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
-            ["", "1:b:3.14:b'e'"],
+            Args(
+                {},
+                {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+                [],
+                {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            ),
         ),
-        (mixed_variadic_args, {"a": 1, "b": "b", "c": 3.14}, ["1:b'd'", "b:3.14"]),
+        (
+            mixed_variadic_args,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({"a": 1, "d": b"d"}, {}, ["b", 3.14], {}),
+        ),
         (
             mixed_variadic_args,
             {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
-            ["1:b'e'", "b:3.14"],
+            Args({"a": 1, "d": b"e"}, {}, ["b", 3.14], {}),
         ),
-        (mixed_variadic_kwargs, {"a": 1, "b": "b", "c": 3.14}, ["1:b'd'", "b:3.14"]),
+        (
+            mixed_variadic_kwargs,
+            {"a": 1, "b": "b", "c": 3.14},
+            Args({"a": 1, "d": b"d"}, {"b": "b", "c": 3.14}, [], {"b": "b", "c": 3.14}),
+        ),
         (
             mixed_variadic_kwargs,
             {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
-            ["1:b'e'", "b:3.14"],
+            Args({"a": 1, "d": b"e"}, {"b": "b", "c": 3.14}, [], {"b": "b", "c": 3.14}),
         ),
         (
             mixed_variadic_args_kwargs,
             {"a": 1, "b": "b", "c": 3.14},
-            ["1:b'd'", "", "b:3.14"],
+            Args({"a": 1, "d": b"d"}, {"b": "b", "c": 3.14}, [], {"b": "b", "c": 3.14}),
         ),
         (
             mixed_variadic_args_kwargs,
             {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
-            ["1:b'e'", "", "b:3.14"],
-        ),
-        (
-            mixed_variadic_args_kwargs,
-            {"a": 1, "b": "b", "c": 3.14, "e": "f"},
-            ["1:b'd'", "", "b:3.14:f"],
-        ),
-        (
-            mixed_variadic_args_kwargs,
-            {"a": 1, "b": "b", "c": 3.14, "e": "f", "d": b"e"},
-            ["1:b'e'", "", "b:3.14:f"],
+            Args({"a": 1, "d": b"e"}, {"b": "b", "c": 3.14}, [], {"b": "b", "c": 3.14}),
         ),
         (
             Foo(),
             {"a": 1, "b": "b", "c": 3.14},
-            "1:b:3.14:b'd'",
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"d"}, {}, [], {}),
         ),
         (
             Foo(),
             {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
-            "1:b:3.14:b'e'",
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"e"}, {}, [], {}),
         ),
         (
             Foo().class_method,
             {"a": 1, "b": "b", "c": 3.14},
-            "1:b:3.14:b'd'",
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"d"}, {}, [], {}),
         ),
         (
             Foo().class_method,
             {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
-            "1:b:3.14:b'e'",
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"e"}, {}, [], {}),
         ),
         (
             Foo().static_method,
             {"a": 1, "b": "b", "c": 3.14},
-            "1:b:3.14:b'd'",
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"d"}, {}, [], {}),
         ),
         (
             Foo().static_method,
             {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
-            "1:b:3.14:b'e'",
+            Args({"a": 1, "b": "b", "c": 3.14, "d": b"e"}, {}, [], {}),
         ),
     ],  # type: ignore[reportUnknownArgumentType]
 )
 def test_apply_expected(
-    func: Callable[..., Any],
+    func: Callable[..., Args],
     args: dict[str, Any],
-    expected: str | list[str],
+    expected: Args,
 ) -> None:
     assert apply_args(func, args) == expected

--- a/tests/v3/test_util.py
+++ b/tests/v3/test_util.py
@@ -2,9 +2,16 @@
 Tests of pact.v3.util functions.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import pytest
 
-from pact.v3._util import strftime_to_simple_date_format
+from pact.v3._util import apply_args, strftime_to_simple_date_format
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def test_convert_python_to_java_datetime_format_basic() -> None:
@@ -37,3 +44,161 @@ def test_convert_python_to_java_datetime_format_with_escape_characters() -> None
 
 def test_convert_python_to_java_datetime_format_with_single_quote() -> None:
     assert strftime_to_simple_date_format("%Y'%m'%d") == "yyyy''MM''dd"
+
+
+def no_annotations(a, b, c, d=b"d"):  # noqa: ANN001, ANN201  # type: ignore[reportUnknownArgumentType]
+    return f"{a}:{b}:{c}:{d!r}"
+
+
+def annotated(a: int, b: str, c: float, d: bytes = b"d") -> str:
+    return f"{a}:{b}:{c}:{d!r}"
+
+
+def mixed(a: int, /, b: str, *, c: float, d: bytes = b"d") -> str:
+    return f"{a}:{b}:{c}:{d!r}"
+
+
+def variadic_args(*args: Any) -> str:  # noqa: ANN401
+    return ":".join(str(arg) for arg in args)
+
+
+def variadic_kwargs(**kwargs: Any) -> str:  # noqa: ANN401
+    return ":".join(str(v) for v in kwargs.values())
+
+
+def variadic_args_kwargs(*args: Any, **kwargs: Any) -> list[str]:  # noqa: ANN401
+    return [
+        ":".join(str(arg) for arg in args),
+        ":".join(str(v) for v in kwargs.values()),
+    ]
+
+
+def mixed_variadic_args(a: int, *args: Any, d: bytes = b"d") -> list[str]:  # noqa: ANN401
+    return [f"{a}:{d!r}", ":".join(str(arg) for arg in args)]
+
+
+def mixed_variadic_kwargs(a: int, d: bytes = b"d", **kwargs: Any) -> list[str]:  # noqa: ANN401
+    return [f"{a}:{d!r}", ":".join(str(v) for v in kwargs.values())]
+
+
+def mixed_variadic_args_kwargs(
+    a: int,
+    *args: Any,  # noqa: ANN401
+    d: bytes = b"d",
+    **kwargs: Any,  # noqa: ANN401
+) -> list[str]:
+    return [
+        f"{a}:{d!r}",
+        ":".join(str(arg) for arg in args),
+        ":".join(str(v) for v in kwargs.values()),
+    ]
+
+
+class Foo:  # noqa: D101
+    def __init__(self) -> None:  # noqa: D107
+        pass
+
+    def __call__(self, a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
+        return f"{a}:{b}:{c}:{d!r}"
+
+    def method(self, a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
+        return f"{a}:{b}:{c}:{d!r}"
+
+    @classmethod
+    def class_method(cls, a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
+        return f"{a}:{b}:{c}:{d!r}"
+
+    @staticmethod
+    def static_method(a: int, b: str, c: float, d: bytes = b"d") -> str:  # noqa: D102
+        return f"{a}:{b}:{c}:{d!r}"
+
+
+@pytest.mark.parametrize(
+    ("func", "args", "expected"),
+    [
+        (no_annotations, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14:b'd'"),
+        (no_annotations, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
+        (annotated, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14:b'd'"),
+        (annotated, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
+        (mixed, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14:b'd'"),
+        (mixed, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
+        (variadic_args, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14"),
+        (variadic_args, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
+        (variadic_kwargs, {"a": 1, "b": "b", "c": 3.14}, "1:b:3.14"),
+        (variadic_kwargs, {"a": 1, "b": "b", "c": 3.14, "d": b"e"}, "1:b:3.14:b'e'"),
+        (variadic_args_kwargs, {"a": 1, "b": "b", "c": 3.14}, ["", "1:b:3.14"]),
+        (
+            variadic_args_kwargs,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            ["", "1:b:3.14:b'e'"],
+        ),
+        (mixed_variadic_args, {"a": 1, "b": "b", "c": 3.14}, ["1:b'd'", "b:3.14"]),
+        (
+            mixed_variadic_args,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            ["1:b'e'", "b:3.14"],
+        ),
+        (mixed_variadic_kwargs, {"a": 1, "b": "b", "c": 3.14}, ["1:b'd'", "b:3.14"]),
+        (
+            mixed_variadic_kwargs,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            ["1:b'e'", "b:3.14"],
+        ),
+        (
+            mixed_variadic_args_kwargs,
+            {"a": 1, "b": "b", "c": 3.14},
+            ["1:b'd'", "", "b:3.14"],
+        ),
+        (
+            mixed_variadic_args_kwargs,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            ["1:b'e'", "", "b:3.14"],
+        ),
+        (
+            mixed_variadic_args_kwargs,
+            {"a": 1, "b": "b", "c": 3.14, "e": "f"},
+            ["1:b'd'", "", "b:3.14:f"],
+        ),
+        (
+            mixed_variadic_args_kwargs,
+            {"a": 1, "b": "b", "c": 3.14, "e": "f", "d": b"e"},
+            ["1:b'e'", "", "b:3.14:f"],
+        ),
+        (
+            Foo(),
+            {"a": 1, "b": "b", "c": 3.14},
+            "1:b:3.14:b'd'",
+        ),
+        (
+            Foo(),
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            "1:b:3.14:b'e'",
+        ),
+        (
+            Foo().class_method,
+            {"a": 1, "b": "b", "c": 3.14},
+            "1:b:3.14:b'd'",
+        ),
+        (
+            Foo().class_method,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            "1:b:3.14:b'e'",
+        ),
+        (
+            Foo().static_method,
+            {"a": 1, "b": "b", "c": 3.14},
+            "1:b:3.14:b'd'",
+        ),
+        (
+            Foo().static_method,
+            {"a": 1, "b": "b", "c": 3.14, "d": b"e"},
+            "1:b:3.14:b'e'",
+        ),
+    ],  # type: ignore[reportUnknownArgumentType]
+)
+def test_apply_expected(
+    func: Callable[..., Any],
+    args: dict[str, Any],
+    expected: str | list[str],
+) -> None:
+    assert apply_args(func, args) == expected


### PR DESCRIPTION
## :memo: Summary

Changes the handling of functional arguments to be much more flexible, allowing for default arguments.

## :rotating_light: Breaking Changes

Previously, the functional arguments used strictly position arguments and did not care about the name of the arguments. It also performed checks on the number of parameters (irrespective of the presence of default arguments).

The new behaviour allows for default arguments and variadic arguments (`*args`, `**kwargs`), and is a lot more lenient as to the order of arguments. HOWEVER, the arguments are matched by name as defined in the `MessageProducerArgs` and `StateHandlerArgs` typed dictionaries.

Specifically, this means that if you previously used `params` as a positional argument, you must rename it to `parameters`.

## :fire: Motivation

To allow more flexible support of functional arguments, including allowing default arguments, and relax ordering requirements.

## :hammer: Test Plan

Tests have been updated to make use of the new feature.

## :link: Related issues/PRs

- Resolves #994 