### PR TITLE
fix(v3): avoid error if there's no mismatch type

### DIFF
--- a/src/pact/v3/error.py
+++ b/src/pact/v3/error.py
@@ -128,7 +128,8 @@ class Mismatch(ABC):
         Returns:
             A new Mismatch object.
         """
-        if mismatch_type := data.pop("type"):
+        if "type" in data:
+            mismatch_type = data.pop("type")
             # Pact mismatches
             if mismatch_type in ["MissingRequest", "missing-request"]:
                 return MissingRequest(**data)
@@ -196,7 +197,7 @@ class GenericMismatch(Mismatch):
         """
         Informal string representation of the GenericMismatch.
         """
-        return f"Generic mismatch: {self.type}"
+        return f"Generic mismatch ({self.type}): {self._data}"
 
 
 class MissingRequest(Mismatch):


### PR DESCRIPTION
## :memo: Summary

Avoid an exception on unrecognised mismatch types

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

It appears that some plugins may return a mismatch without an explicit 'type' listed. The previous handling assumed this was always present, but we now properly handle the case where there is no type at all.

## :hammer: Test Plan

Will check CI first

## :link: Related issues/PRs

None