### PR TITLE
feat(v3): add will_respond_with for sync

### DIFF
--- a/src/pact/v3/interaction/_sync_message_interaction.py
+++ b/src/pact/v3/interaction/_sync_message_interaction.py
@@ -4,6 +4,8 @@ Synchronous message interaction.
 
 from __future__ import annotations
 
+from typing_extensions import Self
+
 import pact.v3.ffi
 from pact.v3.interaction._base import Interaction
 
@@ -59,3 +61,36 @@ class SyncMessageInteraction(Interaction):
     @property
     def _interaction_part(self) -> pact.v3.ffi.InteractionPart:
         return self.__interaction_part
+
+    def will_respond_with(self) -> Self:
+        """
+        Begin the response part of the interaction.
+
+        This method is a convenience method to separate the request and response
+        parts of the interaction. This function is analogous to the
+        [`will_respond_with()`][pact.v3.pact.HttpInteraction.will_respond_with]
+        method of the [`HttpInteraction`][pact.v3.pact.HttpInteraction] class,
+        albeit more generic for synchronous message interactions.
+
+        For example, the following two snippets are
+        equivalent:
+
+        ```python
+        Pact(...).upon_receiving("A sync request", interaction="Sync")
+            .with_body("request body", part="Request")
+            .with_body("response body", part="Response")
+        ```
+
+        ```python
+        Pact(...).upon_receiving("A sync request", interaction="Sync")
+            .with_body("request body")
+            .will_respond_with()
+            .with_body("response body")
+        ```
+
+        Returns:
+            The current instance of the interaction.
+
+        """
+        self.__interaction_part = pact.v3.ffi.InteractionPart.RESPONSE
+        return self


### PR DESCRIPTION
## :memo: Summary

Add `will_respond_with` method for synchronous interactions.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

HTTP interactions have a `will_respond_with` method which sets the response HTTP status code, and is used by the API to separate the request portion from the response.

While synchronous message interactions don't have a HTTP status code, an equivalent method is still useful within the API as it provides a way to separate the request and response logically, as opposed to required explicit stipulations every time.

## :hammer: Test Plan

None for now, but the plan is to add a gRPC example which will feature this.

## :link: Related issues/PRs

None