### PR TITLE
chore(ci): update runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
   build-sdist:
     name: Build source distribution
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -85,11 +85,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             archs: x86_64
-          - os: macos-13
+          - os: macos-13  # macOS 13 is the latest on x86_64
             archs: x86_64
-          - os: windows-2019
+          - os: windows-latest
             archs: AMD64
 
     steps:
@@ -151,18 +151,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             archs: aarch64
             build: manylinux
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             archs: aarch64
             build: musllinux
-          - os: macos-14
+          - os: macos-latest
             archs: arm64
             build: ''
           # TODO: Re-enable once the issues with Windows ARM64 are resolved.exclude:
           #       See: pypa/cibuildwheel#1942
-          # - os: windows-2019
+          # - os: windows-latest
           #   archs: ARM64
           #   build: ""
 
@@ -208,7 +208,7 @@ jobs:
     if: >-
       github.event_name == 'push' &&
       startsWith(github.event.ref, 'refs/tags/v')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/pact-python


### PR DESCRIPTION
## :memo: Summary

Update the CI runners to their latest versions.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

Unblock CI due to the retiring of Windows 2019 runners.

## :hammer: Test Plan

CI

## :link: Related issues/PRs

None
