### PR TITLE
chore(ci): fix cli publish permissions

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -145,7 +145,8 @@ jobs:
       - build-wheels
 
     permissions:
-      contents: read
+      # Required for creating the release
+      contents: write
       # Required for trusted publishing
       id-token: write
 


### PR DESCRIPTION
## :memo: Summary

Previously tightened the permissions, but the `contents: write` permissions should have been kept.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

To unblock releases

## :hammer: Test Plan

CI

## :link: Related issues/PRs

- None
