### PR TITLE
feat(cli): build abi-agnostic wheels

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  STABLE_PYTHON_VERSION: '3.13'
+  STABLE_PYTHON_VERSION: '313'
   HATCH_VERBOSE: '1'
   FORCE_COLOR: '1'
   CIBW_BUILD_FRONTEND: build
@@ -97,24 +97,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Filter targets
-        id: cibw-filter
-        shell: bash
-        # On PRs, only build the latest stable version of Python to speed up the
-        # workflow.
-        run: |
-          if [[ "${{ github.event_name}}" == "pull_request" ]] ; then
-            echo "build=cp${STABLE_PYTHON_VERSION/./}-*" >> "$GITHUB_OUTPUT"
-          else
-            echo "build=*" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create wheels
         uses: pypa/cibuildwheel@95d2f3a92fbf80abe066b09418bbf128a8923df2  # v3.0.1
         with:
           package-dir: pact-python-cli
         env:
-          CIBW_BUILD: ${{ steps.cibw-filter.outputs.build }}
+          CIBW_BUILD: cp${{ env.STABLE_PYTHON_VERSION }}-*
 
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2

--- a/pact-python-cli/pyproject.toml
+++ b/pact-python-cli/pyproject.toml
@@ -66,8 +66,7 @@ requires = [
   "hatch-vcs",
   "hatchling",
   "packaging",
-  "requests",
-  "setuptools ; python_version >= '3.12'",
+  # "setuptools ; python_version >= '3.12'",
 ]
 
 [tool.hatch]
@@ -95,29 +94,12 @@ requires = [
     [tool.hatch.build.hooks.vcs]
     version-file = "src/pact_cli/__version__.py"
 
-    [tool.hatch.build.targets.sdist]
-    include = [
-      # Source
-      "/src/pact_cli/**/*.py",
-      "/src/pact_cli/**/*.pyi",
-      "/src/pact_cli/**/py.typed",
-
-      # Metadata
-      "*.md",
-      "LICENSE",
-    ]
-
     [tool.hatch.build.targets.wheel]
-    artifacts = ["/src/pact_cli/bin/*", "/src/pact_cli/lib/*"]
-    include = [
-      # Source
-      "/src/pact_cli/**/*.py",
-      "/src/pact_cli/**/*.pyi",
-      "/src/pact_cli/**/py.typed",
-    ]
-    packages = ["/src/pact_cli"]
+    artifacts = ["src/pact_cli/bin", "src/pact_cli/lib"]
+    packages  = ["src/pact_cli"]
 
       [tool.hatch.build.targets.wheel.hooks.custom]
+      patch = "hatch_build.py"
 
   ########################################
   ## Hatch Environment Configuration
@@ -208,15 +190,14 @@ exclude = ''
 ## CI Build Wheel
 ################################################################################
 [tool.cibuildwheel]
-before-build = "rm -rvf src/pact_cli/{bin,data,lib}"
-
 # The repair tool unfortunately did not like the bundled Ruby distributable,
 # with false-positives missing libraries despite being bundled.
 repair-wheel-command = ""
 
-  [tool.cibuildwheel.windows]
-  before-build = [
-    'IF EXIST src\pact_cli\bin\ RMDIR /S /Q src\pact_cli\bin',
-    'IF EXIST src\pact_cli\data\ RMDIR /S /Q src\pact_cli\data',
-    'IF EXIST src\pact_cli\lib\ RMDIR /S /Q src\pact_cli\lib',
-  ]
+  [[tool.cibuildwheel.overrides]]
+  environment.MACOSX_DEPLOYMENT_TARGET = "10.13"
+  select                               = "*-macosx_x86_64"
+
+  [[tool.cibuildwheel.overrides]]
+  environment.MACOSX_DEPLOYMENT_TARGET = "11.0"
+  select                               = "*-macosx_arm64"


### PR DESCRIPTION
## :memo: Summary

Instead of building separate wheels for each Python version, we now build `py3-none-{platform}` wheels. These can be used by any Python 3 version, now and into the future.

The reason this works is that the Python code is pure Python and only bundles CLIs to be called through Python.

## :fire: Motivation

Reduce the burden on PyPI, and simplify packaging in cases where people want to download wheels to install offline.

## :hammer: Test Plan

CI

## :link: Related issues/PRs

Ref: #1120
Ref: #1082
