### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,15 @@
 ################################################################################
-## Pact Python Specific
+## Project Specific
 ################################################################################
-src/pact/data
 
 # Test outputs
 examples/tests/pacts
 
 # Version is determined from the VCS
 src/pact/__version__.py
+
+# Wheels from CIBuildWheel
+wheelhouse/
 
 ################################################################################
 ## Standard Templates


### PR DESCRIPTION
## :memo: Summary

Ignore the `wheelhouse/` directories.

## ~:rotating_light: Breaking Changes~

## :fire: Motivation

The `wheelhouse/` directory is used by default by CIBuildWheel, and the wheels should not be committed.

## :hammer: Test Plan

None

## :link: Related issues/PRs

None