### PR TITLE
chore(deps): fix optional dependencies

### DIFF
--- a/pact-python-ffi/pyproject.toml
+++ b/pact-python-ffi/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = ["cffi~=1.0"]
     "pact-python-ffi[devel-types]",
     "ruff==0.12.7",
   ]
-  devel-test = ["pytest-cov~=6.0", "pytest-mock~=3.0", "pytest~=8.0"]
-  devel-types = ["mypy==1.17.1"]
+  devel-test = ["pytest-cov~=6.0", "pytest~=8.0"]
+  devel-types = ["mypy==1.17.1", "typing-extensions~=4.0"]
 
 ################################################################################
 ## Build System


### PR DESCRIPTION
## :memo: Summary

- The `pytest-mock` is not used in testing
- The `typing-extensions` was missing

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
