### PR TITLE
feat!: simplify `given`

### DIFF
--- a/examples/plugins/protobuf/test_consumer.py
+++ b/examples/plugins/protobuf/test_consumer.py
@@ -77,7 +77,7 @@ def test_get_person_by_id(pact: Pact) -> None:
 
     (
         pact.upon_receiving("a request to get person by ID")
-        .given("person with the given ID exists", parameters={"user_id": 1})
+        .given("person with the given ID exists", user_id=1)
         .with_request("GET", "/person/1")
         .will_respond_with(200)
         .with_header("Content-Type", "application/x-protobuf")
@@ -120,7 +120,7 @@ def test_get_nonexistent_person(pact: Pact) -> None:
     """
     (
         pact.upon_receiving("a request to get non-existent person")
-        .given("person with the given ID does not exist", parameters={"user_id": 999})
+        .given("person with the given ID does not exist", user_id=999)
         .with_request("GET", "/person/999")
         .will_respond_with(404)
         .with_header("Content-Type", "application/json")

--- a/tests/compatibility_suite/test_v3_consumer.py
+++ b/tests/compatibility_suite/test_v3_consumer.py
@@ -99,7 +99,7 @@ def a_provider_state_is_specified_with_the_following_data(
             elif value.replace(".", "", 1).isdigit():
                 row[key] = float(value)
 
-    pact_interaction.interaction.given(state, parameters=data[0])
+    pact_interaction.interaction.given(state, data[0])
 
 
 ################################################################################

--- a/tests/compatibility_suite/test_v3_message_consumer.py
+++ b/tests/compatibility_suite/test_v3_message_consumer.py
@@ -162,7 +162,7 @@ def a_provider_state_for_the_message_is_specified_with_the_following_data(
     table = parse_horizontal_table(datatable)
     logger.debug("Specifying provider state '%s' with data: %s", state, table)
     parameters = {k: ast.literal_eval(v) for k, v in table[0].items()}
-    pact_interaction.interaction.given(state, parameters=parameters)
+    pact_interaction.interaction.given(state, parameters)
 
 
 @given("a message is defined")

--- a/tests/compatibility_suite/util/interaction_definition.py
+++ b/tests/compatibility_suite/util/interaction_definition.py
@@ -517,8 +517,8 @@ class InteractionDefinition:
 
         for state in self.states or []:
             if state.parameters:
-                logger.info("given(%r, parameters=%r)", state.name, state.parameters)
-                interaction.given(state.name, parameters=state.parameters)
+                logger.info("given(%r, %r)", state.name, state.parameters)
+                interaction.given(state.name, state.parameters)
             else:
                 logger.info("given(%r)", state.name)
                 interaction.given(state.name)

--- a/tests/test_http_interaction.py
+++ b/tests/test_http_interaction.py
@@ -446,14 +446,14 @@ async def test_given(pact: Pact) -> None:
     )
     (
         pact.upon_receiving("a basic request given a user exists (1)")
-        .given("a user exists", name="id", value="123")
-        .given("a user exists", name="name", value="John")
+        .given("a user exists", id=123)
+        .given("a user exists", name="John")
         .with_request("GET", "/user1")
         .will_respond_with(201)
     )
     (
         pact.upon_receiving("a basic request given a user exists (2)")
-        .given("a user exists", parameters={"id": "123", "name": "John"})
+        .given("a user exists", {"id": "123", "name": "John"})
         .with_request("GET", "/user2")
         .will_respond_with(202)
     )
@@ -590,7 +590,7 @@ async def test_pact_server_verbose(
         .will_respond_with(200)
     )
     with (
-        caplog.at_level(logging.WARNING, logger="pact.v3.pact"),
+        caplog.at_level(logging.WARNING, logger="pact.pact"),
         pact.serve(raises=False, verbose=True) as srv,
     ):
         async with aiohttp.ClientSession(srv.url) as session:

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -153,7 +153,7 @@ def test_matchers() -> None:
     pact = Pact("consumer", "provider").with_specification("V4")
     (
         pact.upon_receiving("a request")
-        .given("a state", parameters={"providerStateArgument": "providerStateValue"})
+        .given("a state", {"providerStateArgument": "providerStateValue"})
         .with_request("GET", match.regex("/path/to/100", regex=r"/path/to/\d{1,4}"))
         .with_query_parameter(
             "asOf",


### PR DESCRIPTION
## :memo: Summary

Instead of having the overloaded function:

- `given(state, *, key, value)`
- `given(state, *, parameters)`

The `given` function's new signature is:

- `given(state, parameters, /, **kwargs)`

In this form, the `state` and (optional) `parameters` must _always_ be positional, and all keyword arguments get used as parameters. This allows for the `parameters` key to be used in the kwargs.

## :rotating_light: Breaking Changes

The signature of `Interaction.given` has been updated. The following changes are required:

- Change `given("state", key="user_id", value=123)` to `given("state", user_id=123)`. This can take an arbitrary number of keyword arguments. If the key is not a valid Python keyword argument, use the dictionary input below.

- Change `given("state", parameters={"user_id": 123})` to `given("state", {"user_id": 123})`.

## :fire: Motivation

This simplifies the passing in of parameters to the provider state. Specifically, it avoids repeated calls to `given` (which merges the key-value pairs together).

## :hammer: Test Plan

Tests have been updated accordingly.

## :link: Related issues/PRs

