### PR TITLE
fix: use correct datetime default format

### DIFF
--- a/src/pact/match/__init__.py
+++ b/src/pact/match/__init__.py
@@ -730,7 +730,7 @@ def datetime(
             value=value,
             format=format,
         )
-    format = format or "%Y-%m-%dT%H:%M:%S.%f%z"
+    format = format or "%Y-%m-%dT%H:%M:%S%z"
     if isinstance(value, dt.datetime):
         value = value.strftime(format)
     format = strftime_to_simple_date_format(format)


### PR DESCRIPTION
## :memo: Summary

There was a mismatch between the documented default and the actual default in practice.

## :rotating_light: Breaking Changes

If you relied on the previous default (undocumented) behaviour, prefer specifying the format explicitly now: `match.datetime(regex="%Y-%m-%dT%H:%M:%S.%f%z")`.

## :fire: Motivation

To align the actual behaviour with the documented behaviour.

## :hammer: Test Plan


## :link: Related issues/PRs
