### PR TITLE
docs: set mascot width and height

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 <!-- markdownlint-disable no-inline-html -->
 <div align="center">
-    <img src="https://raw.githubusercontent.com/pact-foundation/pact-python/main/mascot.svg" alt="Pact Python Mascot" height="250" align="left" hspace="20">
+    <img src="https://raw.githubusercontent.com/pact-foundation/pact-python/main/mascot.svg"
+        alt="Pact Python Mascot"
+        height="250" width="225"
+        align="left" hspace="20">
     <span>
         <b>Fast, easy and reliable testing for your APIs and microservices.</b>
     </span>


### PR DESCRIPTION
## :memo: Summary

Without both of these, either GitHub's rendering or MkDocs' sizing of the mascot is incorrect.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
