### PR TITLE
chore: save mismatches before exiting the server

### DIFF
--- a/src/pact/pact.py
+++ b/src/pact/pact.py
@@ -640,6 +640,7 @@ class PactServer:
         self._handle: None | pact_ffi.PactServerHandle = None
         self._raises = raises
         self._verbose = verbose
+        self._mismatches: list[Mismatch] | None = None
 
     @property
     def port(self) -> int | None:
@@ -702,6 +703,9 @@ class PactServer:
             RuntimeError:
                 If the server is not running.
         """
+        if self._mismatches is not None:
+            return self._mismatches
+
         if not self._handle:
             msg = "The server is not running."
             raise RuntimeError(msg)
@@ -796,6 +800,7 @@ class PactServer:
                 logger.error(msg)
             if self._raises:
                 raise MismatchesError(*self.mismatches)
+            self._mismatches = self.mismatches
             self._handle = None
 
     def __truediv__(self, other: str | object) -> URL:


### PR DESCRIPTION
## :memo: Summary

Save the mismatches before the server exits. This allows for:

```python
with pact.serve() as srv:
    ...

srv.mismatches  # <-- this is now possible
```

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

If `pact.serve(raises=False)` is used, the user is likely to want to access any mismatches (if any); but the mismatches can only be accessed while the server is running. The user _could_ have accessed these before exit, but this is not as nice of a user experience as having them stored and ready for the end user.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
