### PR TITLE
chore: hide import from traceback

### DIFF
--- a/src/pact/generate/__init__.py
+++ b/src/pact/generate/__init__.py
@@ -72,6 +72,7 @@ def __import__(  # noqa: N807
     warn users when they import functions directly from this module. This is
     done to avoid shadowing built-in types and functions.
     """
+    __tracebackhide__ = True
     if name == "pact.generate" and len(set(fromlist) - {"Matcher"}) > 0:
         warnings.warn(
             "Avoid `from pact.generate import <func>`. "

--- a/src/pact/match/__init__.py
+++ b/src/pact/match/__init__.py
@@ -130,6 +130,7 @@ def __import__(  # noqa: N807
     users when they import functions directly from this module. This is done to
     avoid shadowing built-in types and functions.
     """
+    __tracebackhide__ = True
     if name == "pact.match" and len(set(fromlist) - {"Matcher"}) > 0:
         warnings.warn(
             "Avoid `from pact.match import <func>`. "


### PR DESCRIPTION
## :memo: Summary

The `__import__` redefinition only inspects the import and prints a warning and otherwise does not interfere with the import process.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
