### PR TITLE
chore: re-add pytest rerunfailrure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ test = [
   "pytest-asyncio~=1.0",
   "pytest-bdd~=8.0",
   "pytest-cov~=6.0",
+  "pytest-rerunfailures~=16.0",
   "pytest~=8.0",
   "requests~=2.0",
   "testcontainers~=4.0",
@@ -294,6 +295,7 @@ requires      = ["hatch-vcs", "hatchling"]
     "ignore::DeprecationWarning:tests",
   ]
   pythonpath = "."
+  reruns = 3
 
   log_date_format = "%H:%M:%S"
   log_format      = "%(asctime)s.%(msecs)03d [%(levelname)-8s] %(name)s: %(message)s"


### PR DESCRIPTION
## :memo: Summary

There are some tests which are flakey, especially when it comes to allocate ports.

## ~:rotating_light: Breaking Changes
~
<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

To have more reliable CI checks without manual retries.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
