### PR TITLE
chore: prefer prek over pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - format
       - lint
       - typecheck
-      - pre-commit
+      - prek
 
     steps:
       - name: Failed
@@ -276,36 +276,32 @@ jobs:
         working-directory: pact-python-cli
         run: hatch run typecheck
 
-  pre-commit:
-    name: Pre-commit
+  prek:
+    name: Prek (pre-commit)
 
     runs-on: ubuntu-latest
 
-    env:
-      PRE_COMMIT_HOME: ${{ github.workspace }}/.pre-commit
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-      - name: Cache pre-commit
+      - name: Cache prek
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
         with:
           path: |
-            ${{ env.PRE_COMMIT_HOME }}
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            $HOME/.cache/prek
+          key: ${{ runner.os }}-prek-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.6.1
         with:
           enable-cache: true
-          cache-suffix: pre-commit
+          cache-suffix: prek
           cache-dependency-glob: ''
 
-      - name: Install pre-commit
-        run: uv tool install pre-commit
+      - name: Install prek
+        run: uv tool install prek
+      - name: Install hatch
+        run: uv tool install hatch
 
-      - name: Run pre-commit
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - name: Run prek
+        run: prek run --show-diff-on-failure --color=always --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ---
 default_install_hook_types:
-  - commit-msg
   - pre-commit
   - pre-push
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,10 +113,10 @@ You can also try using the new [github.dev](https://github.dev/pact-foundation/p
 
 Don't worry too much about styles in general—the maintainers will help you fix them as they review your code.
 
-To help catch a lot of simple formatting or linting issues, you can run `hatch run lint` to run the linter and `hatch run format` to format your code. This process can also be automated by installing [`pre-commit`](https://pre-commit.com/) hooks:
+To help catch a lot of simple formatting or linting issues, you can run `hatch run lint` to run the linter and `hatch run format` to format your code. This process can also be automated by installing [`prek`](https://prek.j178.dev/) to manage pre-commit hooks:
 
 ```sh
-pre-commit install
+prek install
 ```
 
 ## Pull Requests


### PR DESCRIPTION
## :memo: Summary

Switch from pre-commit to [prek](https://prek.j178.dev/).

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Prek is an alternative to `pre-commit` which is implemented in Rust and has a large number of improvements (most of all, the main developer behind it is actually open to suggestions).

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
