### PR TITLE
chore: remove logger from hatch_build

### DIFF
--- a/pact-python-cli/hatch_build.py
+++ b/pact-python-cli/hatch_build.py
@@ -6,7 +6,6 @@ This hook is responsible for downloading and packaging the Pact CLI.
 
 from __future__ import annotations
 
-import logging
 import os
 import shutil
 import sys
@@ -20,8 +19,6 @@ from typing import Any
 from hatchling.builders.config import BuilderConfig
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from packaging.tags import sys_tags
-
-logger = logging.getLogger(__name__)
 
 PKG_DIR = Path(__file__).parent.resolve() / "src" / "pact_cli"
 PACT_CLI_URL = "https://github.com/pact-foundation/pact-standalone/releases/download/v{version}/pact-{version}-{os}-{machine}.{ext}"


### PR DESCRIPTION
## :memo: Summary

Remove an unused logger within the `hatch_build.py` build script.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
