### PR TITLE
chore: make Unset falsey

### DIFF
--- a/src/pact/types.py
+++ b/src/pact/types.py
@@ -152,6 +152,20 @@ class Unset:
     having no value at all. This class is used to represent the latter.
     """
 
+    def __bool__(self) -> bool:
+        """
+        Always return `False`.
+
+        This allows the `Unset` instance to be used in boolean contexts. For
+        example:
+
+        ```python
+        def f(v: str | Unset = UNSET):
+            value = value or "default"
+        ```
+        """
+        return False
+
 
 UNSET = Unset()
 """


### PR DESCRIPTION
## :memo: Summary

Make `Unset` falsey so that it can be used in constructions like `value = value or "default"`.

## ~:rotating_light: Breaking Changes~

I do not consider `Unset` part of the public interface other than its role as a sentinel value, and in this regard, the public interface remains the same.

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
