### PR TITLE
feat!: default to v4 specification

### DIFF
--- a/src/pact/pact.py
+++ b/src/pact/pact.py
@@ -154,6 +154,10 @@ class Pact:
             provider,
         )
 
+        # Default to the latest version of the Pact specification, which
+        # can be changed later if required.
+        self.with_specification("V4")
+
     def __str__(self) -> str:
         """
         Informal string representation of the Pact.
@@ -204,6 +208,9 @@ class Pact:
 
         The Pact specification version indicates the features which are
         supported by the Pact, and certain default behaviours.
+
+        If this method is not called, then the Pact will use version 4 of the
+        specification by default.
 
         Args:
             version:


### PR DESCRIPTION
## :memo: Summary

Change the default Pact specification from V3 to V4.

## :rotating_light: Breaking Changes

Pact instances default to version 4 of the Pact specification (previously used version 3). This should be mostly backwards compatible, but can be reverted by using `with_specification("V3")`.

## :fire: Motivation

Version 4 of the Pact specification has been available for a while now, and this will help with its adoption.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
