### PR TITLE
chore: drop cffi dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
   # Pact dependencies
   "pact-python-ffi~=0.4.0",
   # External dependencies
-  "cffi~=2.0",
   "yarl~=1.0",
 ]
 
@@ -118,7 +117,6 @@ test = [
 ]
 types = [
   "mypy==1.18.2",
-  "types-cffi~=1.0",
   "types-grpcio~=1.0",
   "types-protobuf~=6.0",
   "types-requests~=2.0",


### PR DESCRIPTION
## :memo: Summary

Drop the `cffi` package from Pact Python dependencies.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Since the FFI has been moved into its own standalone `pact-python-ffi` package, the core Pact Python library has no need for `cffi`.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
