### PR TITLE
chore(ci): fix publish step

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -154,12 +154,27 @@ jobs:
         id: release-changelog
         working-directory: pact-python-cli
         run: |
-          git cliff \
+          if ! git cliff \
             --current \
             --strip header \
-            --output ${{ runner.temp }}/release-changelog.md
+            --output ${{ runner.temp }}/release-changelog.md; then
+            {
+              echo "> [!WARNING]"
+              echo ">"
+              echo "> No changelog generated. To be filled in."
+            } > ${{ runner.temp }}/release-changelog.md
+          fi
 
-          echo -e "\n\n## Pull Requests\n\n" >> ${{ runner.temp }}/release-changelog.md
+          {
+            echo ""
+            echo "<details>"
+            echo "<summary>"
+            echo ""
+            echo "## Pull Requests"
+            echo ""
+            echo "</summary>"
+            echo ""
+          } >> ${{ runner.temp }}/release-changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/build-ffi.yml
+++ b/.github/workflows/build-ffi.yml
@@ -155,12 +155,27 @@ jobs:
         id: release-changelog
         working-directory: pact-python-ffi
         run: |
-          git cliff \
+          if ! git cliff \
             --current \
             --strip header \
-            --output ${{ runner.temp }}/release-changelog.md
+            --output ${{ runner.temp }}/release-changelog.md ; then
+            {
+              echo "> [!WARNING]"
+              echo ">"
+              echo "> No changelog generated. To be filled in."
+            } > ${{ runner.temp }}/release-changelog.md
+          fi
 
-          echo -e "\n\n## Pull Requests\n\n" >> ${{ runner.temp }}/release-changelog.md
+          {
+            echo ""
+            echo "<details>"
+            echo "<summary>"
+            echo ""
+            echo "## Pull Requests"
+            echo ""
+            echo "</summary>"
+            echo ""
+          } >> ${{ runner.temp }}/release-changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,12 +121,27 @@ jobs:
       - name: Generate release changelog
         id: release-changelog
         run: |
-          git cliff \
+          if ! git cliff \
             --current \
             --strip header \
-            --output ${{ runner.temp }}/release-changelog.md
+            --output ${{ runner.temp }}/release-changelog.md; then
+            {
+              echo "> [!WARNING]"
+              echo ">"
+              echo "> No changelog generated. To be filled in."
+            } > ${{ runner.temp }}/release-changelog.md
+          fi
 
-          echo -e "\n\n## Pull Requests\n\n" >> ${{ runner.temp }}/release-changelog.md
+          {
+            echo ""
+            echo "<details>"
+            echo "<summary>"
+            echo ""
+            echo "## Pull Requests"
+            echo ""
+            echo "</summary>"
+            echo ""
+          } >> ${{ runner.temp }}/release-changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
## :memo: Summary

Insert a fallback if the release-specific change log cannot be generated.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

There was an issue with releasing Pact Python 3.0.1 and Pact Python FFI 0.4.28.2 whereby the release changelog could not be generated (despite the rest of the changelog being generated fine).

This inserts a placeholder to be filled in, as opposed to failing the release entirely.

Ref: https://github.com/pact-foundation/pact-python/actions/runs/18270656326/job/52012475672

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
