### PR TITLE
chore(ci): add area-core label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -3,6 +3,10 @@
   description: Relating to the CLI
   color: C2E0C6
 
+- name: area:core
+  description: Relating to the core Pact Python library
+  color: C2E0C6
+
 - name: area:examples
   description: Relating to the examples
   color: C2E0C6


### PR DESCRIPTION
## :memo: Summary

Replace the old `area:v3` label with `area:core` 

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Since v3 is the new defacto default, it doesn't make sense to labelling it 'v3' and 'core' seems more reasonable.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
