### PR TITLE
chore(ci): fix labels workflow permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - .github/labels.yml
 
+permissions:
+  issues: write
+
 jobs:
   sync-labels:
     name: Synchronise labels


### PR DESCRIPTION
## :memo: Summary

Add the `issues: write` permission, which should allow the workflow to actually update the labels.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

The workflow was not working.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
