### PR TITLE
fix!: replace v2 extra with compat-v2

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,10 +20,10 @@ This document outlines the key changes and migration steps for users transitioni
 
 For teams with larger codebases that need time to fully migrate to the new v3 API, a backwards compatibility module is provided at `pact.v2`. This module contains the same API as Pact Python v2.x and serves as an interim measure to assist gradual migration.
 
-To use the v2 compatibility module, you must install pact-python with the `v2` feature enabled:
+To use the v2 compatibility module, you must install pact-python with the `compat-v2` feature enabled:
 
 ```bash
-pip install pact-python[v2]
+pip install pact-python[compat-v2]
 ```
 
 All existing `pact.*` imports need to be updated to use `pact.v2.*` instead. Here are some common examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
 
   [project.optional-dependencies]
   # Dependencies required for v2 only
-  v2 = [
+  compat-v2 = [
     # Pact dependencies
     "pact-python-cli~=2.0",
     # External dependencies
@@ -239,7 +239,7 @@ requires      = ["hatch-vcs", "hatchling"]
       python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     [tool.hatch.envs.v2-test]
-    features             = ["v2"]
+    features             = ["compat-v2"]
     installer            = "uv"
     path                 = ".venv/v2-test"
     pre-install-commands = ["uv pip install --group test-v2 -e ."]
@@ -252,7 +252,7 @@ requires      = ["hatch-vcs", "hatchling"]
       python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     [tool.hatch.envs.v2-example]
-    features             = ["v2"]
+    features             = ["compat-v2"]
     installer            = "uv"
     path                 = ".venv/v2-example"
     pre-install-commands = ["uv pip install --group example-v2 -e ."]


### PR DESCRIPTION
## :memo: Summary

Rename the `v2` extra/feature to `compat-v2`. As a result, to install Pact Python with v2 compatibility, you will need to now use:

```shell
pip install 'pact-python[compat-v2]`
```

## :rotating_light: Breaking Changes

Installing Pact Python with v2 compatibility requires `pip install 'pact-python[compat-v2]'`, and the old `pip install 'pact-python[v2]'` is no longer supported.

## :fire: Motivation

The `v2` group of optional dependencies unfortunately results in an issue when Pact Python is installed using `pip`, as `pip` tries to parse the group name as if it were a version. To avoid this, the group has been renamed to `compat-v2` which should bypass the version parsing.

While this is a bug in `pip`, pip comes pre-bundled in many situations and is rarely at the latest version; so it is impractical to wait for the upstream issue to be resolved.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

Fixes: https://github.com/pact-foundation/pact-python/issues/1275
Ref: https://github.com/pypa/packaging/issues/938
