### PR TITLE
chore(docs): use normalized project url keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,11 @@ dependencies = [
 ]
 
   [project.urls]
-  "Bug Tracker"   = "https://github.com/pact-foundation/pact-python/issues"
-  "Changelog"     = "https://github.com/pact-foundation/pact-python/blob/main/CHANGELOG.md"
-  "Documentation" = "https://docs.pact.io"
-  "Homepage"      = "https://pact.io"
-  "Repository"    = "https://github.com/pact-foundation/pact-python"
+  changelog     = "https://github.com/pact-foundation/pact-python/blob/main/CHANGELOG.md"
+  documentation = "https://pact-foundation.github.io/pact-python/"
+  homepage      = "https://pact.io"
+  issues        = "https://github.com/pact-foundation/pact-python/issues"
+  source        = "https://github.com/pact-foundation/pact-python"
 
   [project.scripts]
   pact-verifier = "pact.v2.cli.verify:main"


### PR DESCRIPTION
## :memo: Summary

While they are, for the most part, equivalent, I prefer to avoid using the quotes and use the normalised keys as documented in <https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels>.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
