### PR TITLE
feat: add consumer_version method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "pact-python-ffi~=0.4.0",
   # External dependencies
   "yarl~=1.0",
+  "typing-extensions~=4.0 ; python_version < '3.13'",
 ]
 
   [project.urls]


### PR DESCRIPTION
## :memo: Summary

Add a new properly typed and documented `consumer_version` method to the broker selector builder class. This now allows for calls like:

```python
verifier = (
    Verifier(...)
    .broker_source(..., selector=True)
    .consumer_version(deployed_or_released=True)
    .consumer_version(branch="main")
    .build()
)
```

For more information on selectors, so the new [method docs](https://pact-foundation.github.io/pact-python/api/verifier/#pact.verifier.BrokerSelectorBuilder.consumer_version) and the [Pact docs](https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors).

## :rotating_light: Breaking Changes

The old `consumer_versions` method would replace any previous calls to it. This has been changed so that successive calls extend the selectors.

I doubt anyone would rely on this behaviour, and therefore will not produce a major version tag; however, I am documenting this here in case you relied on this behaviour.

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

The old `consumer_versions` method required used to pass in a JSON-serialised dictionary, which was untyped. This made it difficult for people to discover information about consumer version selectors.

## :hammer: Test Plan

Unit tests updated.

## :link: Related issues/PRs

- Fixes #731 
