### PR TITLE
chore: fix json schema url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,12 +38,6 @@ repos:
     hooks:
       - id: biome-check
 
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: v0.9.3
-    hooks:
-      - id: taplo-format
-      - id: taplo-lint
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.3
     hooks:

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/any.json
+#:schema https://www.schemastore.org/any.json
 # git-cliff configuration file
 # https://git-cliff.org/docs/configuration
 

--- a/docs/scripts/.ruff.toml
+++ b/docs/scripts/.ruff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/ruff.json
+#:schema https://www.schemastore.org/ruff.json
 extend = "../../pyproject.toml"
 
 [lint]

--- a/examples/.ruff.toml
+++ b/examples/.ruff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/ruff.json
+#:schema https://www.schemastore.org/ruff.json
 extend = "../pyproject.toml"
 
 [lint.per-file-ignores]

--- a/examples/http/aiohttp_and_flask/pyproject.toml
+++ b/examples/http/aiohttp_and_flask/pyproject.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/pyproject.json
+#:schema https://www.schemastore.org/pyproject.json
 [project]
 name = "example-aiohttp-and-flask"
 

--- a/examples/http/requests_and_fastapi/pyproject.toml
+++ b/examples/http/requests_and_fastapi/pyproject.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/pyproject.json
+#:schema https://www.schemastore.org/pyproject.json
 [project]
 name = "example-requests-and-fastapi"
 

--- a/pact-python-cli/cliff.toml
+++ b/pact-python-cli/cliff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/any.json
+#:schema https://www.schemastore.org/any.json
 # git-cliff configuration file
 # https://git-cliff.org/docs/configuration
 

--- a/pact-python-cli/pyproject.toml
+++ b/pact-python-cli/pyproject.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/pyproject.json
+#:schema https://www.schemastore.org/pyproject.json
 [project]
 description = "Pact CLI bundle for Python"
 name        = "pact-python-cli"

--- a/pact-python-cli/tests/.ruff.toml
+++ b/pact-python-cli/tests/.ruff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/ruff.json
+#:schema https://www.schemastore.org/ruff.json
 extend = "../pyproject.toml"
 
 [lint]

--- a/pact-python-ffi/cliff.toml
+++ b/pact-python-ffi/cliff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/any.json
+#:schema https://www.schemastore.org/any.json
 # git-cliff configuration file
 # https://git-cliff.org/docs/configuration
 

--- a/pact-python-ffi/pyproject.toml
+++ b/pact-python-ffi/pyproject.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/pyproject.json
+#:schema https://www.schemastore.org/pyproject.json
 [project]
 description = "Python bindings for the Pact FFI library"
 name        = "pact-python-ffi"

--- a/pact-python-ffi/tests/.ruff.toml
+++ b/pact-python-ffi/tests/.ruff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/ruff.json
+#:schema https://www.schemastore.org/ruff.json
 extend = "../pyproject.toml"
 
 [lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/pyproject.json
+#:schema https://www.schemastore.org/pyproject.json
 [project]
 description = "Tool for creating and verifying consumer-driven contracts using the Pact framework."
 name        = "pact-python"

--- a/tests/.ruff.toml
+++ b/tests/.ruff.toml
@@ -1,4 +1,4 @@
-#:schema https://json.schemastore.org/ruff.json
+#:schema https://www.schemastore.org/ruff.json
 extend = "../pyproject.toml"
 
 [lint]


### PR DESCRIPTION
Schema Store seem to have changed the URL; and while the previous
'json' subdomain should redirect, it seems flakey and results in
failures in CI.

In addition, removing the Taplo pre-commit hook as it is no longer maintained.
