### PR TITLE
chore: fix argument to main test function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ requires      = ["hatch-vcs", "hatchling"]
       example            = "pytest --ignore=examples/v2 examples/ {args}"
       format             = "ruff format {args}"
       lint               = "ruff check --output-format=full --show-fixes {args}"
-      test               = "pytest --ignore=tests/v2 tests/ {args}"
+      test               = "pytest --ignore=tests/v2 {args:tests/}"
       typecheck          = ["typecheck-examples", "typecheck-src", "typecheck-tests"]
       typecheck-examples = "mypy examples/ {args}"
       typecheck-src      = "mypy src/ {args}"


### PR DESCRIPTION
## :memo: Summary

When trying to run tests with `hatch run test path/to/test.py::test_fo`, hatch keeps the first `tests/` argument, which ends up including all of the tests anyway.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
