### PR TITLE
feat: add content type matcher

### DIFF
--- a/src/pact/match/__init__.py
+++ b/src/pact/match/__init__.py
@@ -968,6 +968,24 @@ def type(
     return GenericMatcher("type", value, min=min, max=max, generator=generator)
 
 
+def content_type(content_type: builtins.str) -> AbstractMatcher[Any]:
+    """
+    Match a value by content type.
+
+    Unlike other matchers, this matcher does not take a `value` argument, as it
+    is typically used to match binary data (e.g., images, files) where the
+    actual content is impractical to specify.
+
+    Args:
+        content_type:
+            Content type to match (e.g., "image/jpeg", "application/pdf").
+
+    Returns:
+        Matcher for the given content type.
+    """
+    return GenericMatcher("contentType", value=content_type)
+
+
 def like(
     value: _T,
     /,


### PR DESCRIPTION
## :memo: Summary

This matcher validates the body by content type only, typically through the magic bytes.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

This is typically used when validating binary data (e.g., images, PDFs, etc.) where the binary data is typically rather opaque.

## :hammer: Test Plan

None in this PR, but incorporated into another a test within another (upcoming) PR.

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
