### PR TITLE
fix: use correct matching rule serialisation

### DIFF
--- a/src/pact/interaction/_base.py
+++ b/src/pact/interaction/_base.py
@@ -16,7 +16,7 @@ import json
 from typing import TYPE_CHECKING, Any, Literal
 
 import pact_ffi
-from pact.match.matcher import IntegrationJSONEncoder
+from pact.match.matcher import IntegrationJSONEncoder, MatchingRuleJSONEncoder
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -556,7 +556,7 @@ class Interaction(abc.ABC):
                 response.
         """
         if isinstance(rules, dict):
-            rules = json.dumps(rules)
+            rules = json.dumps(rules, cls=MatchingRuleJSONEncoder)
 
         pact_ffi.with_matching_rules(
             self._handle,

--- a/src/pact/match/matcher.py
+++ b/src/pact/match/matcher.py
@@ -424,8 +424,12 @@ class MatchingRuleJSONEncoder(JSONEncoder):
         Returns:
             The encoded object.
         """
-        if isinstance(o, AbstractMatcher):
+        if isinstance(o, AndMatcher):
             return o.to_matching_rule()
+        if isinstance(o, AbstractMatcher):
+            # We need to convert all matchers in AndMatchers (even if there is
+            # only one).
+            return AndMatcher(o).to_matching_rule()
         return super().default(o)
 
 


### PR DESCRIPTION
## :memo: Summary

The serialisation used internally for `with_matching_rules` used the default JSON encoder. This now has been fixed and allows for matchers to be used directly.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

Will be tested in an upcoming PR.

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
