### PR TITLE
chore: rerun flaky tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ example = [
   "protobuf~=6.0",
   "pydantic~=2.0",
   "pytest-cov~=7.0",
+  "pytest-rerunfailures~=16.0",
   "pytest~=9.0",
   "testcontainers~=4.0",
   "uvicorn[standard]~=0.0",
@@ -134,6 +135,7 @@ example-v2 = [
   "fastapi~=0.0",
   "flask[async]~=3.0",
   "pytest-cov~=7.0",
+  "pytest-rerunfailures~=16.0",
   "pytest~=9.0",
   "testcontainers~=4.0",
   "uvicorn[standard]~=0.0",
@@ -143,6 +145,7 @@ test-v2 = [
   "httpx~=0.0",
   "mock~=5.0",
   "pytest-cov~=7.0",
+  "pytest-rerunfailures~=16.0",
   "pytest~=9.0",
   "uvicorn[standard]~=0.0",
 ]
@@ -290,6 +293,9 @@ addopts = [
   "--cov-config=pyproject.toml",
   "--cov-report=xml",
   "--cov=pact",
+  # Reruns
+  "--reruns=5",
+  "--rerun-except=AssertionError",
 ]
 
 asyncio_default_fixture_loop_scope = "session"


### PR DESCRIPTION
## :memo: Summary

There are a number of tests which can be flaky due to internal connections.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Ideally, the tests shouldn't be flaky, and while some improvements have been made to have tests _less_ flaky, they still can be flaky (especially on Linux for some reason).

## :hammer: Test Plan

Time will tell.

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
