### PR TITLE
chore: don't except AssertionError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,7 +295,6 @@ addopts = [
   "--cov=pact",
   # Reruns
   "--reruns=5",
-  "--rerun-except=AssertionError",
 ]
 
 asyncio_default_fixture_loop_scope = "session"


### PR DESCRIPTION
# :memo: Summary

Remove the rerun exception for `AssertionError`

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Some flaky tests result in `AssertionError` (not just `RuntimeError`).

## :hammer: Test Plan

CI

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
