### PR TITLE
docs: fix internal references

### DIFF
--- a/examples/plugins/proto/person_pb2_grpc.py
+++ b/examples/plugins/proto/person_pb2_grpc.py
@@ -104,7 +104,8 @@ class AddressBookServiceServicer(object):
             The response containing the person's details.
 
         Raises:
-            If the method is not implemented.
+            NotImplementedError:
+                If the method is not implemented.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,7 @@ plugins:
               ignore_init_summary: true
             docstring_section_style: spacy
             merge_init_into_class: true
-            relative_crossrefs: true
+            # relative_crossrefs: true
             scoped_crossrefs: true
             show_if_no_docstring: true
             # Signature

--- a/src/pact/__init__.py
+++ b/src/pact/__init__.py
@@ -13,13 +13,13 @@ implementations.
 
 The primary entry points for contract testing are:
 
--   [`Pact`][pact.Pact]: For consumer-side contract testing, defining expected
+-   [`Pact`][Pact]: For consumer-side contract testing, defining expected
     interactions and generating contract files.
--   [`Verifier`][pact.Verifier]: For provider-side contract verification,
+-   [`Verifier`][Verifier]: For provider-side contract verification,
     validating that a provider implementation satisfies consumer contracts.
 
-These functions are defined in [`pact.pact`][pact.pact] and
-[`pact.verifier`][pact.verifier] and re-exported for convenience.
+These functions are defined in [`pact.pact`][pact] and
+[`pact.verifier`][verifier] and re-exported for convenience.
 
 ### Matching and Generation
 

--- a/src/pact/error.py
+++ b/src/pact/error.py
@@ -77,8 +77,8 @@ class PactVerificationError(PactError):
     All of the errors that occurred during the verification of all of the
     interactions are stored in the `errors` attribute.
 
-    This is different from the [`MismatchesError`][pact.error.MismatchesError]
-    which is raised when there are mismatches detected by the mock server.
+    This is different from the [`MismatchesError`][error.MismatchesError] which
+    is raised when there are mismatches detected by the mock server.
     """
 
     def __init__(self, errors: list[InteractionVerificationError]) -> None:

--- a/src/pact/generate/__init__.py
+++ b/src/pact/generate/__init__.py
@@ -202,7 +202,7 @@ def integer(
     max: builtins.int | None = None,
 ) -> AbstractGenerator:
     """
-    Alias for [`generate.int`][pact.generate.int].
+    Alias for [`generate.int`][int].
 
     Args:
         min:
@@ -239,7 +239,7 @@ def float(precision: builtins.int | None = None) -> AbstractGenerator:
 
 def decimal(precision: builtins.int | None = None) -> AbstractGenerator:
     """
-    Alias for [`generate.float`][pact.generate.float].
+    Alias for [`generate.float`][float].
 
     Args:
         precision:
@@ -270,7 +270,7 @@ def hex(digits: builtins.int | None = None) -> AbstractGenerator:
 
 def hexadecimal(digits: builtins.int | None = None) -> AbstractGenerator:
     """
-    Alias for [`generate.hex`][pact.generate.hex].
+    Alias for [`generate.hex`][hex].
 
     Args:
         digits:
@@ -301,7 +301,7 @@ def str(size: builtins.int | None = None) -> AbstractGenerator:
 
 def string(size: builtins.int | None = None) -> AbstractGenerator:
     """
-    Alias for [`generate.str`][pact.generate.str].
+    Alias for [`generate.str`][str].
 
     Args:
         size:
@@ -448,7 +448,7 @@ def timestamp(
     disable_conversion: builtins.bool = False,
 ) -> AbstractGenerator:
     """
-    Alias for [`generate.datetime`][pact.generate.datetime].
+    Alias for [`generate.datetime`][datetime].
 
     Returns:
         Generator producing datetimes in the specified format.
@@ -468,7 +468,7 @@ def bool() -> AbstractGenerator:
 
 def boolean() -> AbstractGenerator:
     """
-    Alias for [`generate.bool`][pact.generate.bool].
+    Alias for [`generate.bool`][bool].
 
     Returns:
         Generator producing random boolean values.

--- a/src/pact/generate/generator.py
+++ b/src/pact/generate/generator.py
@@ -37,7 +37,7 @@ class AbstractGenerator(ABC):
         Convert the generator to an integration JSON object.
 
         See
-        [`AbstractGenerator.to_integration_json`][pact.generate.generator.AbstractGenerator.to_integration_json]
+        [`AbstractGenerator.to_integration_json`][AbstractGenerator.to_integration_json]
         for more information.
         """
 
@@ -102,7 +102,7 @@ class GenericGenerator(AbstractGenerator):
         Convert the generator to an integration JSON object.
 
         See
-        [`AbstractGenerator.to_integration_json`][pact.generate.generator.AbstractGenerator.to_integration_json]
+        [`AbstractGenerator.to_integration_json`][AbstractGenerator.to_integration_json]
         for more information.
         """
         return {
@@ -115,7 +115,7 @@ class GenericGenerator(AbstractGenerator):
         Convert the generator to a generator JSON object.
 
         See
-        [`AbstractGenerator.to_generator_json`][pact.generate.generator.AbstractGenerator.to_generator_json]
+        [`AbstractGenerator.to_generator_json`][AbstractGenerator.to_generator_json]
         for more information.
         """
         return {

--- a/src/pact/interaction/__init__.py
+++ b/src/pact/interaction/__init__.py
@@ -2,7 +2,7 @@
 Interaction module.
 
 This module defines the classes that are used to define individual interactions
-within a [`Pact`][pact.pact.Pact] between a consumer and a provider. These
+within a [`Pact`][pact.Pact] between a consumer and a provider. These
 interactions can be of different types, such as HTTP requests, synchronous
 messages, or asynchronous messages.
 

--- a/src/pact/interaction/_base.py
+++ b/src/pact/interaction/_base.py
@@ -34,9 +34,9 @@ class Interaction(abc.ABC):
     provider. The concrete subclasses define the type of interaction, and
     include:
 
-    -  [`HttpInteraction`][pact.interaction.HttpInteraction]
-    -  [`AsyncMessageInteraction`][pact.interaction.AsyncMessageInteraction]
-    -  [`SyncMessageInteraction`][pact.interaction.SyncMessageInteraction]
+    -  [`HttpInteraction`][HttpInteraction]
+    -  [`AsyncMessageInteraction`][AsyncMessageInteraction]
+    -  [`SyncMessageInteraction`][SyncMessageInteraction]
 
     # Interaction Part
 
@@ -244,8 +244,7 @@ class Interaction(abc.ABC):
         Adds a binary body to the request or response.
 
         Note that for HTTP interactions, this function will overwrite the body
-        if it has been set using
-        [`with_body`][pact.interaction.Interaction.with_body].
+        if it has been set using [`with_body`][with_body].
 
         Args:
             body:
@@ -295,8 +294,8 @@ class Interaction(abc.ABC):
         The values must be serializable to JSON using [`json.dumps`][json.dumps]
         and may contain matchers and generators. If you wish to use a valid
         JSON-encoded string as a metadata value, prefer the
-        [`set_metadata`][pact.interaction.Interaction.set_metadata] method as
-        this does not perform any additional parsing of the string.
+        [`set_metadata`][set_metadata] method as this does not perform any
+        additional parsing of the string.
 
         Args:
             metadata:
@@ -340,10 +339,9 @@ class Interaction(abc.ABC):
         """
         Add metadata for the interaction.
 
-        This function behaves exactly like
-        [`with_metadata`][pact.interaction.Interaction.with_metadata] but does
-        not perform any parsing of the value strings. The strings must be valid
-        JSON-encoded strings.
+        This function behaves exactly like [`with_metadata`][with_metadata] but
+        does not perform any parsing of the value strings. The strings must be
+        valid JSON-encoded strings.
 
         The value of `None` will remove the metadata key from the interaction.
         This is distinct from using an empty string or a string containing the
@@ -452,7 +450,8 @@ class Interaction(abc.ABC):
         # Warning
 
         This function will overwrite any existing comment with the same key. In
-        particular, the `text` key is used by `add_text_comment`.
+        particular, the `text` key is used by
+        [`add_text_comment`][add_text_comment].
         """
         if isinstance(value, str) or value is None:
             pact_ffi.set_comment(self._handle, key, value)
@@ -475,7 +474,7 @@ class Interaction(abc.ABC):
 
         Internally, the comments are appended to an array under the `text`
         comment key. Care should be taken to ensure that conflicts are not
-        introduced by [`set_comment`][pact.interaction.Interaction.set_comment].
+        introduced by [`set_comment`][set_comment].
         """
         pact_ffi.add_text_comment(self._handle, comment)
         return self

--- a/src/pact/interaction/_http_interaction.py
+++ b/src/pact/interaction/_http_interaction.py
@@ -32,8 +32,7 @@ class HttpInteraction(Interaction):
     HTTP interaction. As many elements are shared between the request and
     response, this class provides a common interface for both. The functions
     intelligently determine whether the element should be added to the request
-    or the response based on whether
-    [`will_respond_with`][pact.interaction.HttpInteraction.will_respond_with]
+    or the response based on whether [`will_respond_with`][will_respond_with]
     has been called.
 
     For example, the following two interactions are equivalent:
@@ -165,9 +164,8 @@ class HttpInteraction(Interaction):
 
                 If `None`, then the function intelligently determines whether
                 the header should be added to the request or the response, based
-                on whether the
-                [`will_respond_with`][pact.interaction.HttpInteraction.will_respond_with]
-                method has been called.
+                on whether the [`will_respond_with`][will_respond_with] method
+                has been called.
         """
         interaction_part = self._parse_interaction_part(part)
         name_lower = name.lower()
@@ -204,10 +202,10 @@ class HttpInteraction(Interaction):
         -   Passing in an iterable of key-value tuples.
 
         -   Make multiple calls to this function or
-            [`with_header`][pact.interaction.HttpInteraction.with_header].
+            [`with_header`][with_header].
 
         See
-        [`with_header`][pact.interaction.HttpInteraction.with_header]
+        [`with_header`][with_header]
         for more information.
 
         Args:
@@ -220,9 +218,8 @@ class HttpInteraction(Interaction):
 
                 If `None`, then the function intelligently determines whether
                 the header should be added to the request or the response, based
-                on whether the
-                [`will_respond_with`][pact.interaction.HttpInteraction.will_respond_with]
-                method has been called.
+                on whether the [`will_respond_with`][will_respond_with] method
+                has been called.
         """
         if isinstance(headers, dict):
             headers = headers.items()
@@ -239,10 +236,9 @@ class HttpInteraction(Interaction):
         r"""
         Add a header to the request.
 
-        Unlike
-        [`with_header`][pact.interaction.HttpInteraction.with_header], this
-        function does no additional processing of the header value. This is
-        useful for headers that contain a JSON object.
+        Unlike [`with_header`][with_header], this function does no additional
+        processing of the header value. This is useful for headers that contain
+        a JSON object.
 
         Args:
             name:
@@ -257,9 +253,8 @@ class HttpInteraction(Interaction):
 
                 If `None`, then the function intelligently determines whether
                 the header should be added to the request or the response, based
-                on whether the
-                [`will_respond_with`][pact.interaction.HttpInteraction.will_respond_with]
-                method has been called.
+                on whether the [`will_respond_with`][will_respond_with] method
+                has been called.
         """
         pact_ffi.set_header(
             self._handle,
@@ -287,10 +282,9 @@ class HttpInteraction(Interaction):
         -   Passing in an iterable of key-value tuples.
 
         -   Make multiple calls to this function or
-            [`with_header`][pact.interaction.HttpInteraction.with_header].
+            [`with_header`][with_header].
 
-        See [`set_header`][pact.interaction.HttpInteraction.set_header] for
-        more information.
+        See [`set_header`][set_header] for more information.
 
         Args:
             headers:
@@ -302,8 +296,7 @@ class HttpInteraction(Interaction):
 
                 If `None`, then the function intelligently determines whether
                 the headers should be added to the request or the response,
-                based on whether the
-                [`will_respond_with`][pact.interaction.HttpInteraction.will_respond_with]
+                based on whether the [`will_respond_with`][will_respond_with]
                 method has been called.
         """
         if isinstance(headers, dict):
@@ -372,11 +365,9 @@ class HttpInteraction(Interaction):
         -   Passing in an iterable of key-value tuples.
 
         -   Make multiple calls to this function or
-            [`with_query_parameter`][pact.interaction.HttpInteraction.with_query_parameter].
+            [`with_query_parameter`][with_query_parameter].
 
-        See
-        [`with_query_parameter`][pact.interaction.HttpInteraction.with_query_parameter]
-        for more information.
+        See [`with_query_parameter`][with_query_parameter] for more information.
 
         Args:
             parameters:
@@ -393,9 +384,8 @@ class HttpInteraction(Interaction):
         Set the response status.
 
         Ideally, this function is called once all of the request information has
-        been set. This allows functions such as
-        [`with_header`][pact.interaction.HttpInteraction.with_header]
-        to intelligently determine whether this is a request or response header.
+        been set. This allows functions such as [`with_header`][with_header] to
+        intelligently determine whether this is a request or response header.
 
         Alternatively, the `part` argument can be used to explicitly specify
         whether the header should be added to the request or the response.

--- a/src/pact/interaction/_sync_message_interaction.py
+++ b/src/pact/interaction/_sync_message_interaction.py
@@ -18,7 +18,7 @@ class SyncMessageInteraction(Interaction):
     A synchronous message interaction.
 
     This class defines a synchronous message interaction between a consumer and
-    a provider. As with [`HttpInteraction`][pact.pact.HttpInteraction], it
+    a provider. As with [`HttpInteraction`][HttpInteraction], it
     defines a specific request that the consumer makes to the provider, and the
     response that the provider should return.
     """
@@ -29,8 +29,8 @@ class SyncMessageInteraction(Interaction):
 
         This function should not be called directly. Instead, an
         AsyncMessageInteraction should be created using the
-        [`upon_receiving`][pact.Pact.upon_receiving] method of a
-        [`Pact`][pact.Pact] instance using the `"Sync"` interaction type.
+        [`upon_receiving`][Pact.upon_receiving] method of a
+        [`Pact`][Pact] instance using the `"Sync"` interaction type.
 
         Args:
             pact_handle:
@@ -67,9 +67,8 @@ class SyncMessageInteraction(Interaction):
 
         This method is a convenience method to separate the request and response
         parts of the interaction. This function is analogous to the
-        [`will_respond_with()`][pact.pact.HttpInteraction.will_respond_with]
-        method of the [`HttpInteraction`][pact.pact.HttpInteraction] class,
-        albeit more generic for synchronous message interactions.
+        [`HttpInteraction.will_respond_with()`][HttpInteraction.will_respond_with]
+        method, albeit more generic for synchronous message interactions.
 
         For example, the following two snippets are equivalent:
 

--- a/src/pact/match/__init__.py
+++ b/src/pact/match/__init__.py
@@ -383,7 +383,7 @@ def integer(
     max: builtins.int | None = None,
 ) -> AbstractMatcher[builtins.int]:
     """
-    Alias for [`match.int`][pact.match.int].
+    Alias for [`match.int`][int].
     """
     return int(value, min=min, max=max)
 
@@ -428,7 +428,7 @@ def decimal(
     precision: builtins.int | None = None,
 ) -> AbstractMatcher[_NumberT]:
     """
-    Alias for [`match.float`][pact.match.float].
+    Alias for [`match.float`][float].
     """
     return float(value, precision=precision)
 
@@ -592,7 +592,7 @@ def string(
     generator: AbstractGenerator | None = None,
 ) -> AbstractMatcher[builtins.str]:
     """
-    Alias for [`match.str`][pact.match.str].
+    Alias for [`match.str`][str].
     """
     return str(value, size=size, generator=generator)
 
@@ -709,7 +709,7 @@ def bool(value: builtins.bool | Unset = UNSET, /) -> AbstractMatcher[builtins.bo
 
 def boolean(value: builtins.bool | Unset = UNSET, /) -> AbstractMatcher[builtins.bool]:
     """
-    Alias for [`match.bool`][pact.match.bool].
+    Alias for [`match.bool`][bool].
     """
     return bool(value)
 
@@ -915,7 +915,7 @@ def timestamp(
     disable_conversion: builtins.bool = False,
 ) -> AbstractMatcher[builtins.str]:
     """
-    Alias for [`match.datetime`][pact.match.datetime].
+    Alias for [`match.datetime`][datetime].
     """
     return datetime(value, format, disable_conversion=disable_conversion)
 
@@ -929,7 +929,7 @@ def none() -> AbstractMatcher[None]:
 
 def null() -> AbstractMatcher[None]:
     """
-    Alias for [`match.none`][pact.match.none].
+    Alias for [`match.none`][none].
     """
     return none()
 
@@ -996,7 +996,7 @@ def like(
     generator: AbstractGenerator | None = None,
 ) -> AbstractMatcher[_T]:
     """
-    Alias for [`match.type`][pact.match.type].
+    Alias for [`match.type`][type].
     """
     return type(value, min=min, max=max, generator=generator)
 

--- a/src/pact/match/matcher.py
+++ b/src/pact/match/matcher.py
@@ -176,7 +176,7 @@ class GenericMatcher(AbstractMatcher[_T_co]):
         Convert the matcher to an integration JSON object.
 
         See
-        [`AbstractMatcher.to_integration_json`][pact.match.matcher.AbstractMatcher.to_integration_json]
+        [`AbstractMatcher.to_integration_json`][AbstractMatcher.to_integration_json]
         for more information.
         """
         return {
@@ -195,7 +195,7 @@ class GenericMatcher(AbstractMatcher[_T_co]):
         Convert the matcher to a matching rule.
 
         See
-        [`AbstractMatcher.to_matching_rule`][pact.match.matcher.AbstractMatcher.to_matching_rule]
+        [`AbstractMatcher.to_matching_rule`][AbstractMatcher.to_matching_rule]
         for more information.
         """
         return {
@@ -230,7 +230,7 @@ class ArrayContainsMatcher(AbstractMatcher[Sequence[_T_co]]):
         Convert the matcher to an integration JSON object.
 
         See
-        [`AbstractMatcher.to_integration_json`][pact.match.matcher.AbstractMatcher.to_integration_json]
+        [`AbstractMatcher.to_integration_json`][AbstractMatcher.to_integration_json]
         for more information.
         """
         return self._matcher.to_integration_json()
@@ -240,7 +240,7 @@ class ArrayContainsMatcher(AbstractMatcher[Sequence[_T_co]]):
         Convert the matcher to a matching rule.
 
         See
-        [`AbstractMatcher.to_matching_rule`][pact.match.matcher.AbstractMatcher.to_matching_rule]
+        [`AbstractMatcher.to_matching_rule`][AbstractMatcher.to_matching_rule]
         for more information.
         """
         return self._matcher.to_matching_rule()
@@ -279,7 +279,7 @@ class EachKeyMatcher(AbstractMatcher[Mapping[_T, Matchable]]):
         Convert the matcher to an integration JSON object.
 
         See
-        [`AbstractMatcher.to_integration_json`][pact.match.matcher.AbstractMatcher.to_integration_json]
+        [`AbstractMatcher.to_integration_json`][AbstractMatcher.to_integration_json]
         for more information.
         """
         return self._matcher.to_integration_json()
@@ -289,7 +289,7 @@ class EachKeyMatcher(AbstractMatcher[Mapping[_T, Matchable]]):
         Convert the matcher to a matching rule.
 
         See
-        [`AbstractMatcher.to_matching_rule`][pact.match.matcher.AbstractMatcher.to_matching_rule]
+        [`AbstractMatcher.to_matching_rule`][AbstractMatcher.to_matching_rule]
         for more information.
         """
         return self._matcher.to_matching_rule()
@@ -328,7 +328,7 @@ class EachValueMatcher(AbstractMatcher[Mapping[Matchable, _T_co]]):
         Convert the matcher to an integration JSON object.
 
         See
-        [`AbstractMatcher.to_integration_json`][pact.match.matcher.AbstractMatcher.to_integration_json]
+        [`AbstractMatcher.to_integration_json`][AbstractMatcher.to_integration_json]
         for more information.
         """
         return self._matcher.to_integration_json()
@@ -338,7 +338,7 @@ class EachValueMatcher(AbstractMatcher[Mapping[Matchable, _T_co]]):
         Convert the matcher to a matching rule.
 
         See
-        [`AbstractMatcher.to_matching_rule`][pact.match.matcher.AbstractMatcher.to_matching_rule]
+        [`AbstractMatcher.to_matching_rule`][AbstractMatcher.to_matching_rule]
         for more information.
         """
         return self._matcher.to_matching_rule()
@@ -387,7 +387,7 @@ class AndMatcher(AbstractMatcher[_T_co]):
         Convert the matcher to an integration JSON object.
 
         See
-        [`AbstractMatcher.to_integration_json`][pact.match.matcher.AbstractMatcher.to_integration_json]
+        [`AbstractMatcher.to_integration_json`][AbstractMatcher.to_integration_json]
         for more information.
         """
         return {"pact:matcher:type": [m.to_integration_json() for m in self._matchers]}
@@ -397,7 +397,7 @@ class AndMatcher(AbstractMatcher[_T_co]):
         Convert the matcher to a matching rule.
 
         See
-        [`AbstractMatcher.to_matching_rule`][pact.match.matcher.AbstractMatcher.to_matching_rule]
+        [`AbstractMatcher.to_matching_rule`][AbstractMatcher.to_matching_rule]
         for more information.
         """
         return {

--- a/src/pact/pact.py
+++ b/src/pact/pact.py
@@ -112,8 +112,8 @@ class Pact:
     to the Pact.
 
     Each interaction between the consumer and the provider is defined through
-    the [`upon_receiving`][pact.pact.Pact.upon_receiving] method, which
-    returns a sub-class of [`Interaction`][pact.interaction.Interaction].
+    the [`upon_receiving`][Pact.upon_receiving] method, which
+    returns a sub-class of [`Interaction`][interaction.Interaction].
     """
 
     def __init__(
@@ -479,7 +479,7 @@ class Pact:
 
         Returns:
             `None` if raises is True and no errors occurred, otherwise a list of
-            [`InteractionVerificationError`][pact.error.InteractionVerificationError].
+            [`InteractionVerificationError`][error.InteractionVerificationError].
 
         Raises:
             TypeError:
@@ -569,7 +569,7 @@ class PactServer:
     stopping the mock server when the block is exited.
 
     Note that the server should not be started directly, but rather through the
-    [`serve`][pact.Pact.serve] method of a [`Pact`][pact.Pact]:
+    [`Pact.serve`][Pact.serve] method:
 
     ```python
     pact = Pact("consumer", "provider")
@@ -578,9 +578,9 @@ class PactServer:
         ...
     ```
 
-    The URL for the server can be accessed through its
-    [`url`][pact.pact.PactServer.url] attribute, which will be required in
-    order to point the consumer client to the mock server:
+    The URL for the server can be accessed through its [`url`][PactServer.url]
+    attribute, which will be required in order to point the consumer client to
+    the mock server:
 
     ```python
     pact = Pact("consumer", "provider")

--- a/src/pact/verifier.py
+++ b/src/pact/verifier.py
@@ -355,12 +355,12 @@ class Verifier:
         1.  A fully fledged function that will be called for all messages. This
             is the most powerful option as it allows for full control over the
             message generation. The function's signature must be compatible with
-            the [`MessageProducerArgs`][pact.types.MessageProducerArgs] type.
+            the [`MessageProducerArgs`][types.MessageProducerArgs] type.
 
         2.  A dictionary mapping message names to either (a) producer functions,
-            (b) [`Message`][pact.types.Message] dictionaries, or (c) raw
-            bytes. If using a producer function, it must be compatible with the
-            [`MessageProducerArgs`][pact.types.MessageProducerArgs] type.
+            (b) [`Message`][types.Message] dictionaries, or (c) raw bytes. If
+            using a producer function, it must be compatible with the
+            [`MessageProducerArgs`][types.MessageProducerArgs] type.
 
         ## Implementation
 
@@ -558,8 +558,8 @@ class Verifier:
         in Python.
 
         The function signature must be compatible with the
-        [`StateHandlerArgs`][pact.types.StateHandlerArgs]. If the function
-        has additional arguments, these must either have default values, or be
+        [`StateHandlerArgs`][types.StateHandlerArgs]. If the function has
+        additional arguments, these must either have default values, or be
         filled by using the [`partial`][functools.partial] function.
 
         Pact also uses a special state denoted with the empty string `""`. This
@@ -879,7 +879,7 @@ class Verifier:
                 Name of the branch used for verification.
 
                 The first time a branch is set here or through
-                [`provider_branch`][pact.verifier.BrokerSelectorBuilder.provider_branch],
+                [`provider_branch`][BrokerSelectorBuilder.provider_branch],
                 the value will be saved and use as a default for both.
         """
         if not self._branch and branch:
@@ -1189,12 +1189,11 @@ class Verifier:
 
         By default, or if `selector=False`, this function returns the verifier
         instance to allow for method chaining. If `selector=True` is given, this
-        function returns a
-        [`BrokerSelectorBuilder`][pact.verifier.BrokerSelectorBuilder] instance
-        which allows for further configuration of the broker source in a fluent
-        interface. The [`build()`][pact.verifier.BrokerSelectorBuilder.build]
-        call is then used to finalise the broker source and return the verifier
-        instance for further configuration.
+        function returns a [`BrokerSelectorBuilder`][BrokerSelectorBuilder]
+        instance which allows for further configuration of the broker source in
+        a fluent interface. The [`build()`][BrokerSelectorBuilder.build] call is
+        then used to finalise the broker source and return the verifier instance
+        for further configuration.
 
         Args:
             url:
@@ -1216,10 +1215,10 @@ class Verifier:
 
             selector:
                 Whether to return a
-                [BrokerSelectorBuilder][pact.verifier.BrokerSelectorBuilder]
-                instance. The builder instance allows for further configuration
-                of the broker source and must be finalised with a call to
-                [`build()`][pact.verifier.BrokerSelectorBuilder.build].
+                [BrokerSelectorBuilder][BrokerSelectorBuilder] instance. The
+                builder instance allows for further configuration of the broker
+                source and must be finalised with a call to
+                [`build()`][BrokerSelectorBuilder.build].
 
             use_env:
                 Whether to read missing values from the environment variables.
@@ -1441,8 +1440,8 @@ class BrokerSelectorBuilder:
         Set the provider branch.
 
         The first time a branch is set here or through
-        [`set_publish_options`][pact.verifier.Verifier.set_publish_options], the
-        value will be saved and use as a default for both.
+        [`set_publish_options`][Verifier.set_publish_options], the value will be
+        saved and use as a default for both.
         """
         self._provider_branch = branch
         if not self._verifier._branch:  # type: ignore  # noqa: PGH003, SLF001


### PR DESCRIPTION
## :memo: Summary

Fix and update internal references so that they use the shorter relative reference.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

An update to MkDocstrings means we can use scoped references.

## :hammer: Test Plan

CI

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
