### PR TITLE
docs: remove redundant header from blog post

### DIFF
--- a/docs/blog/posts/2025/12-04 pact-python-v3-release.md
+++ b/docs/blog/posts/2025/12-04 pact-python-v3-release.md
@@ -107,7 +107,6 @@ pact = Pact('my-web-front-end', 'my-backend-service')
     .with_header('Accept', 'application/json')
     .with_query_parameter('include', 'profile')
     .will_respond_with(200)
-    .with_header('Content-Type', 'application/json')
     .with_body({'id': 123, 'name': 'Alice'}, content_type='application/json')
 )
 


### PR DESCRIPTION
## :memo: Summary

There was some redundancy with the content type being specified twice, when it isn't really required.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
