### PR TITLE
fix(cli)!: remove 32-bit wheels

### DIFF
--- a/pact-python-cli/hatch_build.py
+++ b/pact-python-cli/hatch_build.py
@@ -186,8 +186,6 @@ class PactCliBuildHook(BuildHookInterface[BuilderConfig]):
             machine = "arm64"
         elif platform.endswith(("x86_64", "amd64")):
             machine = "x86_64"
-        elif platform.endswith(("i386", "i686", "x86", "win32")):
-            machine = "x86"
         else:
             raise UnsupportedPlatformError(platform)
 

--- a/pact-python-cli/pyproject.toml
+++ b/pact-python-cli/pyproject.toml
@@ -189,6 +189,9 @@ exclude = ''
 # with false-positives missing libraries despite being bundled.
 repair-wheel-command = ""
 
+  [tool.cibuildwheel.windows]
+  archs = ["auto64"]
+
   [[tool.cibuildwheel.overrides]]
   environment.MACOSX_DEPLOYMENT_TARGET = "10.13"
   select                               = "*-macosx_x86_64"


### PR DESCRIPTION
## :memo: Summary

Remove 32-bit CLI wheels for Windows

## :rotating_light: Breaking Changes

32-bit wheels for Windows are no longer available.

## :fire: Motivation

The upstream Pact CLI has dropped support for 32-bit Windows, hence the removal here.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
