### PR TITLE
chore(ci): re-enable 3.14 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,6 @@ jobs:
         run: hatch run test.py${{ matrix.python-version }}:test --junit-xml=junit.xml
 
       - name: Run tests (v2)
-        # Temporary workaround until Pydantic 3.12 is released with Python 3.14 support
-        if: matrix.python-version != '3.14'
         run: hatch run v2-test.py${{ matrix.python-version }}:test --junit-xml=v2-junit.xml
 
       - name: Run tests (CLI)
@@ -143,9 +141,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
-          # Temporarily excluded until Pydantic 3.12 is released with Python
-          # 3.14 support
-          # - '3.14'
+          - '3.14'
 
     steps:
       - name: Checkout code
@@ -169,6 +165,7 @@ jobs:
 
           while IFS= read -r -d $'\0' file <&3; do
             cd "$(dirname "$file")"
+            echo "Running example in $(pwd)"
             uv run --python ${{ matrix.python-version }} --group test pytest --junit-xml=junit.xml
           done 3< <(find "$(pwd)/examples" -name pyproject.toml -print0)
 


### PR DESCRIPTION
## :memo: Summary

Re-enable 3.14 tests in CI.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

These were temporarily disabled while waiting for Pydantic to catch up.


## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
