### PR TITLE
chore(release): pact-python-cli v2.6.0.0

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -53,8 +53,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
 
 env:
-  # Bump to 3.11 to access tomllib, otherwise, we would use the oldest supported Python version
-  STABLE_PYTHON_VERSION: '311'
+  STABLE_PYTHON_VERSION: '310'
   HATCH_VERBOSE: '1'
   FORCE_COLOR: '1'
   CIBW_BUILD_FRONTEND: build
@@ -100,7 +99,8 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
+        # Bump to 3.11 to access tomllib
+        run: uv python install 311
 
       - name: Update release PR
         run: uv run python scripts/release.py prepare cli
@@ -126,7 +126,8 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
+        # Bump to 3.11 to access tomllib
+        run: uv python install 311
 
       - name: Create and push release tag
         run: uv run python scripts/release.py tag cli

--- a/.github/workflows/release-ffi.yml
+++ b/.github/workflows/release-ffi.yml
@@ -54,8 +54,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
 
 env:
-  # Bump to 3.11 to access tomllib, otherwise, we would use the oldest supported Python version
-  STABLE_PYTHON_VERSION: '311'
+  STABLE_PYTHON_VERSION: '310'
   HATCH_VERBOSE: '1'
   FORCE_COLOR: '1'
   CIBW_BUILD_FRONTEND: build
@@ -101,7 +100,8 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
+        # Bump to 3.11 to access tomllib
+        run: uv python install 311
 
       - name: Update release PR
         run: uv run python scripts/release.py prepare ffi
@@ -127,7 +127,8 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
       - name: Install Python
-        run: uv python install ${{ env.STABLE_PYTHON_VERSION }}
+        # Bump to 3.11 to access tomllib
+        run: uv python install 311
 
       - name: Create and push release tag
         run: uv run python scripts/release.py tag ffi

--- a/pact-python-cli/CHANGELOG.md
+++ b/pact-python-cli/CHANGELOG.md
@@ -8,6 +8,27 @@ Note that this _only_ includes changes to the Python re-packaging of the Pact CL
 <!-- markdownlint-disable emph-style -->
 <!-- markdownlint-disable strong-style -->
 
+## [pact-python-cli/2.6.0.0] _2026-04-16_
+
+### 🐛 Bug Fixes
+
+-   Bundle both ruby and rust CLIs
+
+### 📚 Documentation
+
+-   Update changelog for pact-python-cli/2.5.7.0
+
+### ⚙️ Miscellaneous Tasks
+
+-   Remove versioningit, switch to static version in pyproject.toml
+-   Minor update to cliff config
+-   Replace taplo with tombi
+-   Allow windows arm cli builds to proceed
+
+### Contributors
+
+-   @JP-Ellis
+
 ## [pact-python-cli/2.5.7.0] _2025-12-10_
 
 ### 🚀 Features

--- a/pact-python-cli/pyproject.toml
+++ b/pact-python-cli/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pact-python-cli"
-version = "2.5.7.0"
+version = "2.6.0.0"
 description = "Pact CLI bundle for Python"
 readme = "README.md"
 license = "MIT"

--- a/pact-python-cli/src/pact_cli/__init__.py
+++ b/pact-python-cli/src/pact_cli/__init__.py
@@ -131,18 +131,15 @@ def _exec() -> None:
                 flush=True,
             )
 
-    if not _USE_SYSTEM_BINS:
-        executable = _find_executable(command)
-    else:
-        # To avoid finding the same executable, we have to process the PATH
-        # variable and remove the current executable's directory.
-        script_dir = Path(sys.argv[0]).parent.resolve()
-        os.environ["PATH"] = os.pathsep.join(
-            p
-            for p in os.getenv("PATH", "").split(os.pathsep)
-            if Path(p).resolve() != script_dir
-        )
-        executable = _find_executable(command)
+    # To avoid finding the same executable, remove the current entry point's
+    # directory from PATH before searching.
+    script_dir = Path(sys.argv[0]).parent.resolve()
+    os.environ["PATH"] = os.pathsep.join(
+        p
+        for p in os.getenv("PATH", "").split(os.pathsep)
+        if Path(p).resolve() != script_dir
+    )
+    executable = _find_executable(command)
 
     if not executable:
         print(f"Command '{command}' not found.", file=sys.stderr)  # noqa: T201


### PR DESCRIPTION
## [pact-python-cli/2.6.0.0] _2026-04-16_

### 🐛 Bug Fixes

-   Bundle both ruby and rust CLIs

### 📚 Documentation

-   Update changelog for pact-python-cli/2.5.7.0

### ⚙️ Miscellaneous Tasks

-   Remove versioningit, switch to static version in pyproject.toml
-   Minor update to cliff config
-   Replace taplo with tombi
-   Allow windows arm cli builds to proceed

### Contributors

-   @JP-Ellis

<!-- generated by git-cliff on 2026-04-16-->
