### PR TITLE
chore(release): pact-python-ffi v0.5.3.0

### DIFF
--- a/pact-python-ffi/CHANGELOG.md
+++ b/pact-python-ffi/CHANGELOG.md
@@ -8,6 +8,51 @@ Note that this _only_ includes changes to the Python FFI interface. For changes 
 <!-- markdownlint-disable emph-style -->
 <!-- markdownlint-disable strong-style -->
 
+## [pact-python-ffi/0.5.3.0] _2026-04-16_
+
+### 🚀 Features
+
+-   Removed:
+    -   `create_mock_server` (use `create_mock_server_for_transport` instead)
+    -   `create_mock_server_for_pact` (use `create_mock_server_for_pact_and_transport` instead)
+    -   `verify`
+    -   `verifier_cli_args`
+-   Added:
+    -   `verifier_set_follow_redirects`
+    -   `using_plugin_with_delay`
+-   Allow iteration over all interactions
+-   Implement the Pact class
+-   Add handle to pointer conversion
+-   Add casting interaction to subtypes
+-   Add iterator over all interactions
+
+### 🐛 Bug Fixes
+
+-   Incorrect sync http deletion
+
+### 📚 Documentation
+
+-   Update changelogs
+
+### ⚙️ Miscellaneous Tasks
+
+-   Update non-compliant docstrings and types
+-   Upgrade pymdownx extensions
+-   Fix json schema url
+-   Remove ruff sub-configs
+-   Switch to versioningit
+-   Ensure pact interactions get deleted
+-   Add ruff ignores for tests
+-   Refactor ffi tests
+-   Remove versioningit, switch to static version in pyproject.toml
+-   Minor update to cliff config
+-   Replace taplo with tombi
+
+### Contributors
+
+-   @JP-Ellis
+-   @Nikhil172913832
+
 ## [pact-python-ffi/0.4.28.2] _2025-10-06_
 
 ### 📚 Documentation

--- a/pact-python-ffi/pyproject.toml
+++ b/pact-python-ffi/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pact-python-ffi"
-version = "0.4.28.2"
+version = "0.5.3.0"
 description = "Python bindings for the Pact FFI library"
 readme = "README.md"
 license = "MIT"

--- a/pact-python-ffi/pyproject.toml
+++ b/pact-python-ffi/pyproject.toml
@@ -76,7 +76,13 @@ build-backend = "hatchling.build"
     before-build = ["pip install abi3audit delvewheel"]
     environment.PACT_LIB_DIR = "C:/tmp/pact_ffi"
     repair-wheel-command = [
-      "delvewheel repair -vv --add-path \"%PACT_LIB_DIR%\" -w {dest_dir} {wheel}",
+      # ext-ms-* DLLs are no-export forwarding stubs present in System32 on all
+      # modern Windows. delvewheel 1.12.0 removed them from its no-bundle list
+      # (they have no exports so the author assumed nothing links to them), but
+      # they do appear in DLL import tables and cannot be bundled. Exclude the
+      # whole ext-ms-* family until upstream fixes ignore_regexes.
+      # See: https://github.com/adang1345/delvewheel/issues/<TBD>
+      "delvewheel repair -vv --add-path \"%PACT_LIB_DIR%\" --exclude \"ext-ms-*\" -w {dest_dir} {wheel}",
       "abi3audit --strict --report {wheel}",
     ]
 

--- a/pact-python-ffi/src/pact_ffi/__init__.py
+++ b/pact-python-ffi/src/pact_ffi/__init__.py
@@ -419,7 +419,7 @@ class InteractionHandle:
     Handle to a HTTP Interaction.
 
     [Rust
-    `InteractionHandle`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/mock_server/handles/struct.InteractionHandle.html)
+    `InteractionHandle`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/mock_server/handles/struct.InteractionHandle.html)
     """
 
     def __init__(self, ref: int) -> None:
@@ -919,7 +919,7 @@ class PactHandle:
     Handle to a Pact.
 
     [Rust
-    `PactHandle`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/mock_server/handles/struct.PactHandle.html)
+    `PactHandle`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/mock_server/handles/struct.PactHandle.html)
     """
 
     def __init__(self, ref: int) -> None:
@@ -1702,7 +1702,7 @@ class VerifierHandle:
     """
     Handle to a Verifier.
 
-    [Rust `VerifierHandle`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/verifier/handle/struct.VerifierHandle.html)
+    [Rust `VerifierHandle`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/verifier/handle/struct.VerifierHandle.html)
     """
 
     def __init__(self, ref: cffi.FFI.CData) -> None:
@@ -1738,7 +1738,7 @@ class ExpressionValueType(Enum):
     """
     Expression Value Type.
 
-    [Rust `ExpressionValueType`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/models/expressions/enum.ExpressionValueType.html)
+    [Rust `ExpressionValueType`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/models/expressions/enum.ExpressionValueType.html)
     """
 
     UNKNOWN = lib.ExpressionValueType_Unknown
@@ -1765,7 +1765,7 @@ class GeneratorCategory(Enum):
     """
     Generator Category.
 
-    [Rust `GeneratorCategory`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/models/generators/enum.GeneratorCategory.html)
+    [Rust `GeneratorCategory`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/models/generators/enum.GeneratorCategory.html)
     """
 
     METHOD = lib.GeneratorCategory_METHOD
@@ -1793,7 +1793,7 @@ class InteractionPart(Enum):
     """
     Interaction Part.
 
-    [Rust `InteractionPart`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/mock_server/handles/enum.InteractionPart.html)
+    [Rust `InteractionPart`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/mock_server/handles/enum.InteractionPart.html)
     """
 
     REQUEST = lib.InteractionPart_Request
@@ -1839,7 +1839,7 @@ class MatchingRuleCategory(Enum):
     """
     Matching Rule Category.
 
-    [Rust `MatchingRuleCategory`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/models/matching_rules/enum.MatchingRuleCategory.html)
+    [Rust `MatchingRuleCategory`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/models/matching_rules/enum.MatchingRuleCategory.html)
     """
 
     METHOD = lib.MatchingRuleCategory_METHOD
@@ -1868,7 +1868,7 @@ class PactSpecification(Enum):
     """
     Pact Specification.
 
-    [Rust `PactSpecification`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/models/pact_specification/enum.PactSpecification.html)
+    [Rust `PactSpecification`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/models/pact_specification/enum.PactSpecification.html)
     """
 
     UNKNOWN = lib.PactSpecification_Unknown
@@ -1921,7 +1921,7 @@ class StringResult:
         """
         Internal enum from Pact FFI.
 
-        [Rust `StringResult`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/mock_server/enum.StringResult.html)
+        [Rust `StringResult`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/mock_server/enum.StringResult.html)
         """
 
         FAILED = lib.StringResult_Failed
@@ -2086,7 +2086,7 @@ def version() -> str:
     """
     Return the version of the pact_ffi library.
 
-    [Rust `pactffi_version`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_version)
+    [Rust `pactffi_version`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_version)
 
     Returns:
         The version of the pact_ffi library as a string, in the form of `x.y.z`.
@@ -2106,7 +2106,7 @@ def init(log_env_var: str) -> None:
     tracing subscriber.
 
     [Rust
-    `pactffi_init`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_init)
+    `pactffi_init`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_init)
 
     Args:
         log_env_var:
@@ -2127,7 +2127,7 @@ def init_with_log_level(level: str = "INFO") -> None:
     tracing subscriber.
 
     [Rust
-    `pactffi_init_with_log_level`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_init_with_log_level)
+    `pactffi_init_with_log_level`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_init_with_log_level)
 
     Args:
         level:
@@ -2147,7 +2147,7 @@ def enable_ansi_support() -> None:
     On non-Windows platforms, this function is a no-op.
 
     [Rust
-    `pactffi_enable_ansi_support`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_enable_ansi_support)
+    `pactffi_enable_ansi_support`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_enable_ansi_support)
 
     # Safety
 
@@ -2165,7 +2165,7 @@ def log_message(
     Log using the shared core logging facility.
 
     [Rust
-    `pactffi_log_message`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_log_message)
+    `pactffi_log_message`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_log_message)
 
     This is useful for callers to have a single set of logs.
 
@@ -2195,7 +2195,7 @@ def mismatches_get_iter(mismatches: Mismatches) -> MismatchesIterator:
     Get an iterator over mismatches.
 
     [Rust
-    `pactffi_mismatches_get_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatches_get_iter)
+    `pactffi_mismatches_get_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatches_get_iter)
     """
     raise NotImplementedError
 
@@ -2204,7 +2204,7 @@ def mismatches_delete(mismatches: Mismatches) -> None:
     """
     Delete mismatches.
 
-    [Rust `pactffi_mismatches_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatches_delete)
+    [Rust `pactffi_mismatches_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatches_delete)
     """
     raise NotImplementedError
 
@@ -2213,7 +2213,7 @@ def mismatches_iter_next(iter: MismatchesIterator) -> Mismatch:
     """
     Get the next mismatch from a mismatches iterator.
 
-    [Rust `pactffi_mismatches_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatches_iter_next)
+    [Rust `pactffi_mismatches_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatches_iter_next)
 
     Returns a null pointer if no mismatches remain.
     """
@@ -2224,7 +2224,7 @@ def mismatches_iter_delete(iter: MismatchesIterator) -> None:
     """
     Delete a mismatches iterator when you're done with it.
 
-    [Rust `pactffi_mismatches_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatches_iter_delete)
+    [Rust `pactffi_mismatches_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatches_iter_delete)
     """
     raise NotImplementedError
 
@@ -2233,7 +2233,7 @@ def mismatch_to_json(mismatch: Mismatch) -> str:
     """
     Get a JSON representation of the mismatch.
 
-    [Rust `pactffi_mismatch_to_json`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatch_to_json)
+    [Rust `pactffi_mismatch_to_json`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatch_to_json)
     """
     raise NotImplementedError
 
@@ -2242,7 +2242,7 @@ def mismatch_type(mismatch: Mismatch) -> str:
     """
     Get the type of a mismatch.
 
-    [Rust `pactffi_mismatch_type`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatch_type)
+    [Rust `pactffi_mismatch_type`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatch_type)
     """
     raise NotImplementedError
 
@@ -2251,7 +2251,7 @@ def mismatch_summary(mismatch: Mismatch) -> str:
     """
     Get a summary of a mismatch.
 
-    [Rust `pactffi_mismatch_summary`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatch_summary)
+    [Rust `pactffi_mismatch_summary`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatch_summary)
     """
     raise NotImplementedError
 
@@ -2260,7 +2260,7 @@ def mismatch_description(mismatch: Mismatch) -> str:
     """
     Get a description of a mismatch.
 
-    [Rust `pactffi_mismatch_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatch_description)
+    [Rust `pactffi_mismatch_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatch_description)
     """
     raise NotImplementedError
 
@@ -2269,7 +2269,7 @@ def mismatch_ansi_description(mismatch: Mismatch) -> str:
     """
     Get an ANSI-compatible description of a mismatch.
 
-    [Rust `pactffi_mismatch_ansi_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mismatch_ansi_description)
+    [Rust `pactffi_mismatch_ansi_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mismatch_ansi_description)
     """
     raise NotImplementedError
 
@@ -2279,7 +2279,7 @@ def get_error_message(length: int = 1024) -> str | None:
     Provide the error message from `LAST_ERROR` to the calling C code.
 
     [Rust
-    `pactffi_get_error_message`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_get_error_message)
+    `pactffi_get_error_message`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_get_error_message)
 
     This function should be called after any other function in the pact_matching
     FFI indicates a failure with its own error message, if the caller wants to
@@ -2333,7 +2333,11 @@ def log_to_stdout(level_filter: LevelFilter) -> int:
     """
     Convenience function to direct all logging to stdout.
 
-    [Rust `pactffi_log_to_stdout`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_log_to_stdout)
+    This function is equivalent to using [`logger_init`] followed by the
+    [`logger_attach_sink`] with the appropriate sink specifier, and then
+    [`logger_apply`].
+
+    [Rust `pactffi_log_to_stdout`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_log_to_stdout)
     """
     raise NotImplementedError
 
@@ -2342,8 +2346,12 @@ def log_to_stderr(level_filter: LevelFilter | str = LevelFilter.ERROR) -> None:
     """
     Convenience function to direct all logging to stderr.
 
+    This function is equivalent to using [`logger_init`] followed by the
+    [`logger_attach_sink`] with the appropriate sink specifier, and then
+    [`logger_apply`].
+
     [Rust
-    `pactffi_log_to_stderr`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_log_to_stderr)
+    `pactffi_log_to_stderr`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_log_to_stderr)
 
     Args:
         level_filter:
@@ -2367,8 +2375,12 @@ def log_to_file(file_name: str, level_filter: LevelFilter) -> int:
     """
     Convenience function to direct all logging to a file.
 
+    This function is equivalent to using [`logger_init`] followed by the
+    [`logger_attach_sink`] with the appropriate sink specifier, and then
+    [`logger_apply`].
+
     [Rust
-    `pactffi_log_to_file`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_log_to_file)
+    `pactffi_log_to_file`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_log_to_file)
 
     # Safety
 
@@ -2382,7 +2394,11 @@ def log_to_buffer(level_filter: LevelFilter | str = LevelFilter.ERROR) -> None:
     """
     Convenience function to direct all logging to a task local memory buffer.
 
-    [Rust `pactffi_log_to_buffer`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_log_to_buffer)
+    This function is equivalent to using [`logger_init`] followed by the
+    [`logger_attach_sink`] with the appropriate sink specifier, and then
+    [`logger_apply`].
+
+    [Rust `pactffi_log_to_buffer`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_log_to_buffer)
 
     Raises:
         RuntimeError:
@@ -2400,7 +2416,7 @@ def logger_init() -> None:
     """
     Initialize the FFI logger with no sinks.
 
-    [Rust `pactffi_logger_init`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_logger_init)
+    [Rust `pactffi_logger_init`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_logger_init)
 
     This initialized logger does nothing until `pactffi_logger_apply` has been called.
 
@@ -2422,7 +2438,7 @@ def logger_attach_sink(sink_specifier: str, level_filter: LevelFilter) -> int:
     Attach an additional sink to the thread-local logger.
 
     [Rust
-    `pactffi_logger_attach_sink`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_logger_attach_sink)
+    `pactffi_logger_attach_sink`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_logger_attach_sink)
 
     This logger does nothing until `pactffi_logger_apply` has been called.
 
@@ -2469,7 +2485,7 @@ def logger_apply() -> int:
     Apply the previously configured sinks and levels to the program.
 
     [Rust
-    `pactffi_logger_apply`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_logger_apply)
+    `pactffi_logger_apply`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_logger_apply)
 
     If no sinks have been setup, will set the log level to info and the target
     to standard out.
@@ -2485,7 +2501,7 @@ def fetch_log_buffer(log_id: str) -> str:
     Fetch the in-memory logger buffer contents.
 
     [Rust
-    `pactffi_fetch_log_buffer`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_fetch_log_buffer)
+    `pactffi_fetch_log_buffer`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_fetch_log_buffer)
 
     This will only have any contents if the `buffer` sink has been configured to
     log to. The contents will be allocated on the heap and will need to be freed
@@ -2511,7 +2527,7 @@ def parse_pact_json(json: str) -> Pact:
     Parses the provided JSON into a Pact model.
 
     [Rust
-    `pactffi_parse_pact_json`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_parse_pact_json)
+    `pactffi_parse_pact_json`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_parse_pact_json)
 
     The returned Pact model must be freed with the `pactffi_pact_model_delete`
     function when no longer needed.
@@ -2528,7 +2544,7 @@ def pact_model_delete(pact: Pact) -> None:
     """
     Frees the memory used by the Pact model.
 
-    [Rust `pactffi_pact_model_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_model_delete)
+    [Rust `pactffi_pact_model_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_model_delete)
     """
     lib.pactffi_pact_model_delete(pact._ptr)
 
@@ -2538,7 +2554,7 @@ def pact_model_interaction_iterator(pact: Pact) -> PactInteractionIterator:
     Returns an iterator over all the interactions in the Pact.
 
     [Rust
-    `pactffi_pact_model_interaction_iterator`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_model_interaction_iterator)
+    `pactffi_pact_model_interaction_iterator`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_model_interaction_iterator)
 
     The iterator will contain a copy of the interactions, so it will not be
     affected but mutations to the Pact model and will still function if the Pact
@@ -2560,7 +2576,7 @@ def pact_spec_version(pact: Pact) -> PactSpecification:
     """
     Returns the Pact specification enum that the Pact is for.
 
-    [Rust `pactffi_pact_spec_version`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_spec_version)
+    [Rust `pactffi_pact_spec_version`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_spec_version)
     """
     raise NotImplementedError
 
@@ -2569,7 +2585,7 @@ def pact_interaction_delete(interaction: PactInteraction) -> None:
     """
     Frees the memory used by the Pact interaction model.
 
-    [Rust `pactffi_pact_interaction_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_interaction_delete)
+    [Rust `pactffi_pact_interaction_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_interaction_delete)
     """
     lib.pactffi_pact_interaction_delete(interaction._ptr)
 
@@ -2578,7 +2594,7 @@ def async_message_new() -> AsynchronousMessage:
     """
     Get a mutable pointer to a newly-created default message on the heap.
 
-    [Rust `pactffi_async_message_new`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_new)
+    [Rust `pactffi_async_message_new`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_new)
 
     # Safety
 
@@ -2595,7 +2611,7 @@ def async_message_delete(message: AsynchronousMessage) -> None:
     """
     Destroy the `AsynchronousMessage` being pointed to.
 
-    [Rust `pactffi_async_message_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_delete)
+    [Rust `pactffi_async_message_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_delete)
     """
     lib.pactffi_async_message_delete(message._ptr)
 
@@ -2605,7 +2621,7 @@ def async_message_get_contents(message: AsynchronousMessage) -> MessageContents 
     Get the message contents of an `AsynchronousMessage` as a `MessageContents` pointer.
 
     [Rust
-    `pactffi_async_message_get_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_get_contents)
+    `pactffi_async_message_get_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_get_contents)
 
     If the message contents are missing, this function will return `None`.
     """
@@ -2624,7 +2640,7 @@ def async_message_generate_contents(
     contents as would be received by the consumer.
 
     [Rust
-    `pactffi_async_message_generate_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_generate_contents)
+    `pactffi_async_message_generate_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_generate_contents)
 
     If the message contents are missing, this function will return `None`.
     """
@@ -2638,7 +2654,7 @@ def async_message_get_contents_str(message: AsynchronousMessage) -> str:
     """
     Get the message contents of an `AsynchronousMessage` in string form.
 
-    [Rust `pactffi_async_message_get_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_get_contents_str)
+    [Rust `pactffi_async_message_get_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_get_contents_str)
 
     # Safety
 
@@ -2665,7 +2681,7 @@ def async_message_set_contents_str(
     Sets the contents of the message as a string.
 
     [Rust
-    `pactffi_async_message_set_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_set_contents_str)
+    `pactffi_async_message_set_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_set_contents_str)
 
     - `message` - the message to set the contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -2693,7 +2709,7 @@ def async_message_get_contents_length(message: AsynchronousMessage) -> int:
     Get the length of the contents of a `AsynchronousMessage`.
 
     [Rust
-    `pactffi_async_message_get_contents_length`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_get_contents_length)
+    `pactffi_async_message_get_contents_length`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_get_contents_length)
 
     # Safety
 
@@ -2712,7 +2728,7 @@ def async_message_get_contents_bin(message: AsynchronousMessage) -> str:
     Get the contents of an `AsynchronousMessage` as bytes.
 
     [Rust
-    `pactffi_async_message_get_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_get_contents_bin)
+    `pactffi_async_message_get_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_get_contents_bin)
 
     # Safety
 
@@ -2739,7 +2755,7 @@ def async_message_set_contents_bin(
     Sets the contents of the message as an array of bytes.
 
     [Rust
-    `pactffi_async_message_set_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_set_contents_bin)
+    `pactffi_async_message_set_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_set_contents_bin)
 
     * `message` - the message to set the contents for
     * `contents` - pointer to contents to copy from
@@ -2766,7 +2782,7 @@ def async_message_get_description(message: AsynchronousMessage) -> str:
     Get a copy of the description.
 
     [Rust
-    `pactffi_async_message_get_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_get_description)
+    `pactffi_async_message_get_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_get_description)
 
     Raises:
         RuntimeError:
@@ -2786,7 +2802,7 @@ def async_message_set_description(
     """
     Write the `description` field on the `AsynchronousMessage`.
 
-    [Rust `pactffi_async_message_set_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_set_description)
+    [Rust `pactffi_async_message_set_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_set_description)
 
     # Safety
 
@@ -2811,7 +2827,7 @@ def async_message_get_provider_state(
     Get a copy of the provider state at the given index from this message.
 
     [Rust
-    `pactffi_async_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_get_provider_state)
+    `pactffi_async_message_get_provider_state`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_get_provider_state)
 
     Raises:
         RuntimeError:
@@ -2830,7 +2846,7 @@ def async_message_get_provider_state_iter(
     """
     Get an iterator over provider states.
 
-    [Rust `pactffi_async_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_async_message_get_provider_state_iter)
+    [Rust `pactffi_async_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_async_message_get_provider_state_iter)
 
     # Safety
 
@@ -2845,7 +2861,7 @@ def consumer_get_name(consumer: Consumer) -> str:
     r"""
     Get a copy of this consumer's name.
 
-    [Rust `pactffi_consumer_get_name`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_consumer_get_name)
+    [Rust `pactffi_consumer_get_name`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_consumer_get_name)
 
     The copy must be deleted with `pactffi_string_delete`.
 
@@ -2891,7 +2907,7 @@ def pact_get_consumer(pact: Pact) -> Consumer:
     `pactffi_pact_consumer_delete` when no longer required.
 
     [Rust
-    `pactffi_pact_get_consumer`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_get_consumer)
+    `pactffi_pact_get_consumer`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_get_consumer)
 
     # Errors
 
@@ -2905,7 +2921,7 @@ def pact_consumer_delete(consumer: Consumer) -> None:
     """
     Frees the memory used by the Pact consumer.
 
-    [Rust `pactffi_pact_consumer_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_consumer_delete)
+    [Rust `pactffi_pact_consumer_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_consumer_delete)
     """
     raise NotImplementedError
 
@@ -2921,7 +2937,7 @@ def message_contents_delete(contents: MessageContents) -> None:
     Deleting a message content which is associated with an interaction
     will result in undefined behaviour.
 
-    [Rust `pactffi_message_contents_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_delete)
+    [Rust `pactffi_message_contents_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_delete)
     """
     lib.pactffi_message_contents_delete(contents._ptr)
 
@@ -2930,7 +2946,7 @@ def message_contents_get_contents_str(contents: MessageContents) -> str | None:
     """
     Get the message contents in string form.
 
-    [Rust `pactffi_message_contents_get_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_get_contents_str)
+    [Rust `pactffi_message_contents_get_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_get_contents_str)
 
     If the message has no contents or contain invalid UTF-8 characters, this
     function will return `None`.
@@ -2950,7 +2966,7 @@ def message_contents_set_contents_str(
     Sets the contents of the message as a string.
 
     [Rust
-    `pactffi_message_contents_set_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_set_contents_str)
+    `pactffi_message_contents_set_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_set_contents_str)
 
     * `contents` - the message contents to set the contents for
     * `contents_str` - pointer to contents to copy from. Must be a valid
@@ -2977,7 +2993,7 @@ def message_contents_get_contents_length(contents: MessageContents) -> int:
     """
     Get the length of the message contents.
 
-    [Rust `pactffi_message_contents_get_contents_length`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_get_contents_length)
+    [Rust `pactffi_message_contents_get_contents_length`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_get_contents_length)
 
     If the message has not contents, this function will return 0.
     """
@@ -2989,7 +3005,7 @@ def message_contents_get_contents_bin(contents: MessageContents) -> bytes | None
     Get the contents of a message as a pointer to an array of bytes.
 
     [Rust
-    `pactffi_message_contents_get_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_get_contents_bin)
+    `pactffi_message_contents_get_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_get_contents_bin)
 
     If the message has no contents, this function will return `None`.
     """
@@ -3012,7 +3028,7 @@ def message_contents_set_contents_bin(
     Sets the contents of the message as an array of bytes.
 
     [Rust
-    `pactffi_message_contents_set_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_set_contents_bin)
+    `pactffi_message_contents_set_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_set_contents_bin)
 
     * `message` - the message contents to set the contents for
     * `contents_bin` - pointer to contents to copy from
@@ -3041,7 +3057,7 @@ def message_contents_get_metadata_iter(
     Get an iterator over the metadata of a message.
 
     [Rust
-    `pactffi_message_contents_get_metadata_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_get_metadata_iter)
+    `pactffi_message_contents_get_metadata_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_get_metadata_iter)
 
     # Safety
 
@@ -3070,7 +3086,7 @@ def message_contents_get_matching_rule_iter(
     Get an iterator over the matching rules for a category of a message.
 
     [Rust
-    `pactffi_message_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_get_matching_rule_iter)
+    `pactffi_message_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_get_matching_rule_iter)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_delete` when done with it.
@@ -3112,7 +3128,7 @@ def request_contents_get_matching_rule_iter(
     r"""
     Get an iterator over the matching rules for a category of an HTTP request.
 
-    [Rust `pactffi_request_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_request_contents_get_matching_rule_iter)
+    [Rust `pactffi_request_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_request_contents_get_matching_rule_iter)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_delete` when done with it.
@@ -3149,7 +3165,7 @@ def response_contents_get_matching_rule_iter(
     r"""
     Get an iterator over the matching rules for a category of an HTTP response.
 
-    [Rust `pactffi_response_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_response_contents_get_matching_rule_iter)
+    [Rust `pactffi_response_contents_get_matching_rule_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_response_contents_get_matching_rule_iter)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_delete` when done with it.
@@ -3187,7 +3203,7 @@ def message_contents_get_generators_iter(
     Get an iterator over the generators for a category of a message.
 
     [Rust
-    `pactffi_message_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_contents_get_generators_iter)
+    `pactffi_message_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_contents_get_generators_iter)
 
     # Safety
 
@@ -3213,7 +3229,7 @@ def request_contents_get_generators_iter(
     Get an iterator over the generators for a category of an HTTP request.
 
     [Rust
-    `pactffi_request_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_request_contents_get_generators_iter)
+    `pactffi_request_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_request_contents_get_generators_iter)
 
     The returned pointer must be deleted with `pactffi_generators_iter_delete`
     when done with it.
@@ -3238,7 +3254,7 @@ def response_contents_get_generators_iter(
     Get an iterator over the generators for a category of an HTTP response.
 
     [Rust
-    `pactffi_response_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_response_contents_get_generators_iter)
+    `pactffi_response_contents_get_generators_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_response_contents_get_generators_iter)
 
     The returned pointer must be deleted with `pactffi_generators_iter_delete`
     when done with it.
@@ -3263,7 +3279,7 @@ def parse_matcher_definition(expression: str) -> MatchingRuleDefinitionResult:
     any generator.
 
     [Rust
-    `pactffi_parse_matcher_definition`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_parse_matcher_definition)
+    `pactffi_parse_matcher_definition`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_parse_matcher_definition)
 
     The following are examples of matching rule definitions:
 
@@ -3299,7 +3315,7 @@ def matcher_definition_error(definition: MatchingRuleDefinitionResult) -> str:
     using the `pactffi_string_delete` function once done with it.
 
     [Rust
-    `pactffi_matcher_definition_error`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matcher_definition_error)
+    `pactffi_matcher_definition_error`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matcher_definition_error)
     """
     raise NotImplementedError
 
@@ -3313,7 +3329,7 @@ def matcher_definition_value(definition: MatchingRuleDefinitionResult) -> str:
     the `pactffi_string_delete` function once done with it.
 
     [Rust
-    `pactffi_matcher_definition_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matcher_definition_value)
+    `pactffi_matcher_definition_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matcher_definition_value)
 
     Note that different expressions values can have types other than a string.
     Use `pactffi_matcher_definition_value_type` to get the actual type of the
@@ -3327,7 +3343,7 @@ def matcher_definition_delete(definition: MatchingRuleDefinitionResult) -> None:
     """
     Frees the memory used by the result of parsing the matching definition expression.
 
-    [Rust `pactffi_matcher_definition_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matcher_definition_delete)
+    [Rust `pactffi_matcher_definition_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matcher_definition_delete)
     """
     raise NotImplementedError
 
@@ -3340,7 +3356,7 @@ def matcher_definition_generator(definition: MatchingRuleDefinitionResult) -> Ge
     NULL pointer, otherwise returns the generator as a pointer.
 
     [Rust
-    `pactffi_matcher_definition_generator`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matcher_definition_generator)
+    `pactffi_matcher_definition_generator`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matcher_definition_generator)
 
     The generator pointer will be a valid pointer as long as
     `pactffi_matcher_definition_delete` has not been called on the definition.
@@ -3359,7 +3375,7 @@ def matcher_definition_value_type(
     If there was an error parsing the expression, it will return Unknown.
 
     [Rust
-    `pactffi_matcher_definition_value_type`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matcher_definition_value_type)
+    `pactffi_matcher_definition_value_type`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matcher_definition_value_type)
     """
     raise NotImplementedError
 
@@ -3368,7 +3384,7 @@ def matching_rule_iter_delete(iter: MatchingRuleIterator) -> None:
     """
     Free the iterator when you're done using it.
 
-    [Rust `pactffi_matching_rule_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rule_iter_delete)
+    [Rust `pactffi_matching_rule_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rule_iter_delete)
     """
     raise NotImplementedError
 
@@ -3383,7 +3399,7 @@ def matcher_definition_iter(
     `pactffi_matching_rule_iter_delete` function once done with it.
 
     [Rust
-    `pactffi_matcher_definition_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matcher_definition_iter)
+    `pactffi_matcher_definition_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matcher_definition_iter)
 
     If there was an error parsing the expression, this function will return a
     NULL pointer.
@@ -3399,7 +3415,7 @@ def matching_rule_iter_next(iter: MatchingRuleIterator) -> MatchingRuleResult:
     deleted but will be cleaned up when the iterator is deleted.
 
     [Rust
-    `pactffi_matching_rule_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rule_iter_next)
+    `pactffi_matching_rule_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rule_iter_next)
 
     Will return a NULL pointer when the iterator has advanced past the end of
     the list.
@@ -3421,7 +3437,7 @@ def matching_rule_id(rule_result: MatchingRuleResult) -> int:
     Return the ID of the matching rule.
 
     [Rust
-    `pactffi_matching_rule_id`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rule_id)
+    `pactffi_matching_rule_id`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rule_id)
 
     The ID corresponds to the following rules:
 
@@ -3467,7 +3483,7 @@ def matching_rule_value(rule_result: MatchingRuleResult) -> str:
     pointer.
 
     [Rust
-    `pactffi_matching_rule_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rule_value)
+    `pactffi_matching_rule_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rule_value)
 
     The associated values for the rules are:
 
@@ -3515,7 +3531,7 @@ def matching_rule_pointer(rule_result: MatchingRuleResult) -> MatchingRule:
     Will return a NULL pointer if the matching rule result was a reference.
 
     [Rust
-    `pactffi_matching_rule_pointer`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rule_pointer)
+    `pactffi_matching_rule_pointer`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rule_pointer)
 
     # Safety
 
@@ -3533,7 +3549,7 @@ def matching_rule_reference_name(rule_result: MatchingRuleResult) -> str:
     structure. I.e.,
 
     [Rust
-    `pactffi_matching_rule_reference_name`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rule_reference_name)
+    `pactffi_matching_rule_reference_name`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rule_reference_name)
 
     ```json
     {
@@ -3560,7 +3576,7 @@ def validate_datetime(value: str, format: str) -> None:
     Validates the date/time value against the date/time format string.
 
     [Rust
-    `pactffi_validate_datetime`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_validate_datetime)
+    `pactffi_validate_datetime`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_validate_datetime)
 
     Raises:
         ValueError:
@@ -3587,7 +3603,7 @@ def generator_to_json(generator: Generator) -> str:
     Get the JSON form of the generator.
 
     [Rust
-    `pactffi_generator_to_json`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generator_to_json)
+    `pactffi_generator_to_json`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generator_to_json)
 
     The returned string must be deleted with `pactffi_string_delete`.
 
@@ -3610,7 +3626,7 @@ def generator_generate_string(generator: Generator, context_json: str) -> str:
     function).
 
     [Rust
-    `pactffi_generator_generate_string`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generator_generate_string)
+    `pactffi_generator_generate_string`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generator_generate_string)
 
     If anything goes wrong, it will return a NULL pointer.
     """
@@ -3633,7 +3649,7 @@ def generator_generate_integer(generator: Generator, context_json: str) -> int:
     should be the values returned from the Provider State callback function).
 
     [Rust
-    `pactffi_generator_generate_integer`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generator_generate_integer)
+    `pactffi_generator_generate_integer`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generator_generate_integer)
 
     If anything goes wrong or the generator is not a type that can generate an
     integer value, it will return a zero value.
@@ -3649,7 +3665,7 @@ def generators_iter_delete(iter: GeneratorCategoryIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_generators_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generators_iter_delete)
+    `pactffi_generators_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generators_iter_delete)
     """
     lib.pactffi_generators_iter_delete(iter._ptr)
 
@@ -3659,7 +3675,7 @@ def generators_iter_next(iter: GeneratorCategoryIterator) -> GeneratorKeyValuePa
     Get the next path and generator out of the iterator, if possible.
 
     [Rust
-    `pactffi_generators_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generators_iter_next)
+    `pactffi_generators_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generators_iter_next)
 
     The returned pointer must be deleted with
     `pactffi_generator_iter_pair_delete`.
@@ -3679,7 +3695,7 @@ def generators_iter_pair_delete(pair: GeneratorKeyValuePair) -> None:
     Free a pair of key and value returned from `pactffi_generators_iter_next`.
 
     [Rust
-    `pactffi_generators_iter_pair_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generators_iter_pair_delete)
+    `pactffi_generators_iter_pair_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generators_iter_pair_delete)
     """
     lib.pactffi_generators_iter_pair_delete(pair._ptr)
 
@@ -3688,7 +3704,7 @@ def sync_http_new() -> SynchronousHttp:
     """
     Get a mutable pointer to a newly-created default interaction on the heap.
 
-    [Rust `pactffi_sync_http_new`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_new)
+    [Rust `pactffi_sync_http_new`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_new)
 
     # Safety
 
@@ -3706,7 +3722,7 @@ def sync_http_delete(interaction: SynchronousHttp) -> None:
     Destroy the `SynchronousHttp` interaction being pointed to.
 
     [Rust
-    `pactffi_sync_http_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_delete)
+    `pactffi_sync_http_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_delete)
     """
     lib.pactffi_sync_http_delete(interaction._ptr)
 
@@ -3716,7 +3732,7 @@ def sync_http_get_request(interaction: SynchronousHttp) -> HttpRequest:
     Get the request of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_request`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_request)
+    `pactffi_sync_http_get_request`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_request)
 
     # Safety
 
@@ -3736,7 +3752,7 @@ def sync_http_get_request_contents(interaction: SynchronousHttp) -> str | None:
     Get the request contents of a `SynchronousHttp` interaction in string form.
 
     [Rust
-    `pactffi_sync_http_get_request_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_request_contents)
+    `pactffi_sync_http_get_request_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_request_contents)
 
     Note that this function will return `None` if either the body is missing or
     is `null`.
@@ -3756,7 +3772,7 @@ def sync_http_set_request_contents(
     Sets the request contents of the interaction.
 
     [Rust
-    `pactffi_sync_http_set_request_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_set_request_contents)
+    `pactffi_sync_http_set_request_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_set_request_contents)
 
     - `interaction` - the interaction to set the request contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -3784,7 +3800,7 @@ def sync_http_get_request_contents_length(interaction: SynchronousHttp) -> int:
     Get the length of the request contents of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_request_contents_length`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_request_contents_length)
+    `pactffi_sync_http_get_request_contents_length`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_request_contents_length)
 
     This function will return 0 if the body is missing.
     """
@@ -3796,7 +3812,7 @@ def sync_http_get_request_contents_bin(interaction: SynchronousHttp) -> bytes | 
     Get the request contents of a `SynchronousHttp` interaction as bytes.
 
     [Rust
-    `pactffi_sync_http_get_request_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_request_contents_bin)
+    `pactffi_sync_http_get_request_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_request_contents_bin)
 
     Note that this function will return `None` if either the body is missing or
     is `null`.
@@ -3820,7 +3836,7 @@ def sync_http_set_request_contents_bin(
     Sets the request contents of the interaction as an array of bytes.
 
     [Rust
-    `pactffi_sync_http_set_request_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_set_request_contents_bin)
+    `pactffi_sync_http_set_request_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_set_request_contents_bin)
 
     - `interaction` - the interaction to set the request contents for
     - `contents` - pointer to contents to copy from
@@ -3847,7 +3863,7 @@ def sync_http_get_response(interaction: SynchronousHttp) -> HttpResponse:
     Get the response of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_response`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_response)
+    `pactffi_sync_http_get_response`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_response)
 
     # Safety
 
@@ -3867,7 +3883,7 @@ def sync_http_get_response_contents(interaction: SynchronousHttp) -> str | None:
     Get the response contents of a `SynchronousHttp` interaction in string form.
 
     [Rust
-    `pactffi_sync_http_get_response_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_response_contents)
+    `pactffi_sync_http_get_response_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_response_contents)
 
     Note that this function will return `None` if either the body is missing or
     is `null`.
@@ -3887,7 +3903,7 @@ def sync_http_set_response_contents(
     Sets the response contents of the interaction.
 
     [Rust
-    `pactffi_sync_http_set_response_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_set_response_contents)
+    `pactffi_sync_http_set_response_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_set_response_contents)
 
     - `interaction` - the interaction to set the response contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -3915,7 +3931,7 @@ def sync_http_get_response_contents_length(interaction: SynchronousHttp) -> int:
     Get the length of the response contents of a `SynchronousHttp` interaction.
 
     [Rust
-    `pactffi_sync_http_get_response_contents_length`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_response_contents_length)
+    `pactffi_sync_http_get_response_contents_length`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_response_contents_length)
 
     This function will return 0 if the body is missing.
     """
@@ -3927,7 +3943,7 @@ def sync_http_get_response_contents_bin(interaction: SynchronousHttp) -> bytes |
     Get the response contents of a `SynchronousHttp` interaction as bytes.
 
     [Rust
-    `pactffi_sync_http_get_response_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_response_contents_bin)
+    `pactffi_sync_http_get_response_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_response_contents_bin)
 
     Note that this function will return `None` if either the body is missing or
     is `null`.
@@ -3951,7 +3967,7 @@ def sync_http_set_response_contents_bin(
     Sets the response contents of the `SynchronousHttp` interaction as bytes.
 
     [Rust
-    `pactffi_sync_http_set_response_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_set_response_contents_bin)
+    `pactffi_sync_http_set_response_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_set_response_contents_bin)
 
     - `interaction` - the interaction to set the response contents for
     - `contents` - pointer to contents to copy from
@@ -3978,7 +3994,7 @@ def sync_http_get_description(interaction: SynchronousHttp) -> str:
     Get a copy of the description.
 
     [Rust
-    `pactffi_sync_http_get_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_description)
+    `pactffi_sync_http_get_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_description)
 
     Raises:
         RuntimeError:
@@ -3996,7 +4012,7 @@ def sync_http_set_description(interaction: SynchronousHttp, description: str) ->
     Write the `description` field on the `SynchronousHttp`.
 
     [Rust
-    `pactffi_sync_http_set_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_set_description)
+    `pactffi_sync_http_set_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_set_description)
 
     # Safety
 
@@ -4021,7 +4037,7 @@ def sync_http_get_provider_state(
     Get a copy of the provider state at the given index from this interaction.
 
     [Rust
-    `pactffi_sync_http_get_provider_state`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_provider_state)
+    `pactffi_sync_http_get_provider_state`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_provider_state)
 
     # Safety
 
@@ -4047,7 +4063,7 @@ def sync_http_get_provider_state_iter(
     Get an iterator over provider states.
 
     [Rust
-    `pactffi_sync_http_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_http_get_provider_state_iter)
+    `pactffi_sync_http_get_provider_state_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_http_get_provider_state_iter)
 
     # Safety
 
@@ -4070,7 +4086,7 @@ def pact_interaction_as_synchronous_http(
     """
     Cast this interaction to a `SynchronousHttp` interaction.
 
-    [Rust `pactffi_pact_interaction_as_synchronous_http`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_http)
+    [Rust `pactffi_pact_interaction_as_synchronous_http`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_http)
 
     Args:
         interaction:
@@ -4100,7 +4116,7 @@ def pact_interaction_as_asynchronous_message(
     Note that if the interaction is a V3 `Message`, it will be converted to a V4
     `AsynchronousMessage` before being returned.
 
-    [Rust `pactffi_pact_interaction_as_asynchronous_message`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_interaction_as_asynchronous_message)
+    [Rust `pactffi_pact_interaction_as_asynchronous_message`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_interaction_as_asynchronous_message)
 
     Args:
         interaction:
@@ -4127,7 +4143,7 @@ def pact_interaction_as_synchronous_message(
     """
     Cast this interaction to a `SynchronousMessage` interaction.
 
-    [Rust `pactffi_pact_interaction_as_synchronous_message`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_message)
+    [Rust `pactffi_pact_interaction_as_synchronous_message`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_interaction_as_synchronous_message)
 
     Args:
         interaction:
@@ -4153,7 +4169,7 @@ def pact_async_message_iter_next(iter: PactAsyncMessageIterator) -> Asynchronous
     Get the next asynchronous message from the iterator.
 
     [Rust
-    `pactffi_pact_async_message_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_async_message_iter_next)
+    `pactffi_pact_async_message_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_async_message_iter_next)
 
     Raises:
         StopIteration:
@@ -4170,7 +4186,7 @@ def pact_async_message_iter_delete(iter: PactAsyncMessageIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_async_message_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_async_message_iter_delete)
+    `pactffi_pact_async_message_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_async_message_iter_delete)
     """
     lib.pactffi_pact_async_message_iter_delete(iter._ptr)
 
@@ -4180,7 +4196,7 @@ def pact_sync_message_iter_next(iter: PactSyncMessageIterator) -> SynchronousMes
     Get the next synchronous request/response message from the V4 pact.
 
     [Rust
-    `pactffi_pact_sync_message_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_sync_message_iter_next)
+    `pactffi_pact_sync_message_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_sync_message_iter_next)
 
     Raises:
         StopIteration:
@@ -4197,7 +4213,7 @@ def pact_sync_message_iter_delete(iter: PactSyncMessageIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_sync_message_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_sync_message_iter_delete)
+    `pactffi_pact_sync_message_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_sync_message_iter_delete)
     """
     lib.pactffi_pact_sync_message_iter_delete(iter._ptr)
 
@@ -4207,7 +4223,7 @@ def pact_sync_http_iter_next(iter: PactSyncHttpIterator) -> SynchronousHttp:
     Get the next synchronous HTTP request/response interaction from the V4 pact.
 
     [Rust
-    `pactffi_pact_sync_http_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_sync_http_iter_next)
+    `pactffi_pact_sync_http_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_sync_http_iter_next)
 
     Raises:
         StopIteration:
@@ -4224,7 +4240,7 @@ def pact_sync_http_iter_delete(iter: PactSyncHttpIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_sync_http_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_sync_http_iter_delete)
+    `pactffi_pact_sync_http_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_sync_http_iter_delete)
     """
     lib.pactffi_pact_sync_http_iter_delete(iter._ptr)
 
@@ -4234,7 +4250,7 @@ def pact_interaction_iter_next(iter: PactInteractionIterator) -> PactInteraction
     Get the next interaction from the pact.
 
     [Rust
-    `pactffi_pact_interaction_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_interaction_iter_next)
+    `pactffi_pact_interaction_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_interaction_iter_next)
 
     Raises:
         StopIteration:
@@ -4251,7 +4267,7 @@ def pact_interaction_iter_delete(iter: PactInteractionIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_interaction_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_interaction_iter_delete)
+    `pactffi_pact_interaction_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_interaction_iter_delete)
     """
     lib.pactffi_pact_interaction_iter_delete(iter._ptr)
 
@@ -4261,7 +4277,7 @@ def pact_message_iter_next(iter: PactMessageIterator) -> PactInteraction:
     Get the next interaction from the pact.
 
     [Rust
-    `pactffi_pact_message_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_message_iter_next)
+    `pactffi_pact_message_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_message_iter_next)
 
     Raises:
         StopIteration:
@@ -4278,7 +4294,7 @@ def pact_message_iter_delete(iter: PactMessageIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_pact_message_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_message_iter_delete)
+    `pactffi_pact_message_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_message_iter_delete)
     """
     lib.pactffi_pact_message_iter_delete(iter._ptr)
 
@@ -4288,7 +4304,7 @@ def matching_rule_to_json(rule: MatchingRule) -> str:
     Get the JSON form of the matching rule.
 
     [Rust
-    `pactffi_matching_rule_to_json`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rule_to_json)
+    `pactffi_matching_rule_to_json`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rule_to_json)
 
     The returned string must be deleted with `pactffi_string_delete`.
 
@@ -4305,7 +4321,7 @@ def matching_rules_iter_delete(iter: MatchingRuleCategoryIterator) -> None:
     Free the iterator when you're done using it.
 
     [Rust
-    `pactffi_matching_rules_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rules_iter_delete)
+    `pactffi_matching_rules_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rules_iter_delete)
     """
     lib.pactffi_matching_rules_iter_delete(iter._ptr)
 
@@ -4317,7 +4333,7 @@ def matching_rules_iter_next(
     Get the next path and matching rule out of the iterator, if possible.
 
     [Rust
-    `pactffi_matching_rules_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rules_iter_next)
+    `pactffi_matching_rules_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rules_iter_next)
 
     The returned pointer must be deleted with
     `pactffi_matching_rules_iter_pair_delete`.
@@ -4339,7 +4355,7 @@ def matching_rules_iter_pair_delete(pair: MatchingRuleKeyValuePair) -> None:
     Free a pair of key and value returned from `message_metadata_iter_next`.
 
     [Rust
-    `pactffi_matching_rules_iter_pair_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matching_rules_iter_pair_delete)
+    `pactffi_matching_rules_iter_pair_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matching_rules_iter_pair_delete)
     """
     lib.pactffi_matching_rules_iter_pair_delete(pair._ptr)
 
@@ -4349,7 +4365,7 @@ def provider_state_iter_next(iter: ProviderStateIterator) -> ProviderState:
     Get the next value from the iterator.
 
     [Rust
-    `pactffi_provider_state_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_iter_next)
+    `pactffi_provider_state_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_iter_next)
 
     # Safety
 
@@ -4370,7 +4386,7 @@ def provider_state_iter_delete(iter: ProviderStateIterator) -> None:
     Delete the iterator.
 
     [Rust
-    `pactffi_provider_state_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_iter_delete)
+    `pactffi_provider_state_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_iter_delete)
     """
     lib.pactffi_provider_state_iter_delete(iter._ptr)
 
@@ -4380,7 +4396,7 @@ def message_metadata_iter_next(iter: MessageMetadataIterator) -> MessageMetadata
     Get the next key and value out of the iterator, if possible.
 
     [Rust
-    `pactffi_message_metadata_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_metadata_iter_next)
+    `pactffi_message_metadata_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_metadata_iter_next)
 
     The returned pointer must be deleted with
     `pactffi_message_metadata_pair_delete`.
@@ -4406,7 +4422,7 @@ def message_metadata_iter_delete(iter: MessageMetadataIterator) -> None:
     Free the metadata iterator when you're done using it.
 
     [Rust
-    `pactffi_message_metadata_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_metadata_iter_delete)
+    `pactffi_message_metadata_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_metadata_iter_delete)
     """
     lib.pactffi_message_metadata_iter_delete(iter._ptr)
 
@@ -4416,7 +4432,7 @@ def message_metadata_pair_delete(pair: MessageMetadataPair) -> None:
     Free a pair of key and value returned from `message_metadata_iter_next`.
 
     [Rust
-    `pactffi_message_metadata_pair_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_message_metadata_pair_delete)
+    `pactffi_message_metadata_pair_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_message_metadata_pair_delete)
     """
     lib.pactffi_message_metadata_pair_delete(pair._ptr)
 
@@ -4426,7 +4442,7 @@ def provider_get_name(provider: Provider) -> str:
     Get a copy of this provider's name.
 
     [Rust
-    `pactffi_provider_get_name`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_get_name)
+    `pactffi_provider_get_name`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_get_name)
 
     The copy must be deleted with `pactffi_string_delete`.
 
@@ -4472,7 +4488,7 @@ def pact_get_provider(pact: Pact) -> Provider:
     `pactffi_pact_provider_delete` when no longer required.
 
     [Rust
-    `pactffi_pact_get_provider`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_get_provider)
+    `pactffi_pact_get_provider`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_get_provider)
 
     # Errors
 
@@ -4487,7 +4503,7 @@ def pact_provider_delete(provider: Provider) -> None:
     Frees the memory used by the Pact provider.
 
     [Rust
-    `pactffi_pact_provider_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_provider_delete)
+    `pactffi_pact_provider_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_provider_delete)
     """
     raise NotImplementedError
 
@@ -4497,7 +4513,7 @@ def provider_state_get_name(provider_state: ProviderState) -> str | None:
     Get the name of the provider state as a string.
 
     [Rust
-    `pactffi_provider_state_get_name`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_get_name)
+    `pactffi_provider_state_get_name`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_get_name)
 
     Raises:
         RuntimeError:
@@ -4517,7 +4533,7 @@ def provider_state_get_param_iter(
     Get an iterator over the params of a provider state.
 
     [Rust
-    `pactffi_provider_state_get_param_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_get_param_iter)
+    `pactffi_provider_state_get_param_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_get_param_iter)
 
     # Safety
 
@@ -4545,7 +4561,7 @@ def provider_state_param_iter_next(
     Get the next key and value out of the iterator, if possible.
 
     [Rust
-    `pactffi_provider_state_param_iter_next`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_param_iter_next)
+    `pactffi_provider_state_param_iter_next`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_param_iter_next)
 
     # Safety
 
@@ -4566,7 +4582,7 @@ def provider_state_delete(provider_state: ProviderState) -> None:
     Free the provider state when you're done using it.
 
     [Rust
-    `pactffi_provider_state_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_delete)
+    `pactffi_provider_state_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_delete)
     """
     raise NotImplementedError
 
@@ -4576,7 +4592,7 @@ def provider_state_param_iter_delete(iter: ProviderStateParamIterator) -> None:
     Free the provider state param iterator when you're done using it.
 
     [Rust
-    `pactffi_provider_state_param_iter_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_param_iter_delete)
+    `pactffi_provider_state_param_iter_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_param_iter_delete)
     """
     lib.pactffi_provider_state_param_iter_delete(iter._ptr)
 
@@ -4586,7 +4602,7 @@ def provider_state_param_pair_delete(pair: ProviderStateParamPair) -> None:
     Free a pair of key and value.
 
     [Rust
-    `pactffi_provider_state_param_pair_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_provider_state_param_pair_delete)
+    `pactffi_provider_state_param_pair_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_provider_state_param_pair_delete)
     """
     lib.pactffi_provider_state_param_pair_delete(pair._ptr)
 
@@ -4596,7 +4612,7 @@ def sync_message_new() -> SynchronousMessage:
     Get a mutable pointer to a newly-created default message on the heap.
 
     [Rust
-    `pactffi_sync_message_new`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_new)
+    `pactffi_sync_message_new`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_new)
 
     # Safety
 
@@ -4614,7 +4630,7 @@ def sync_message_delete(message: SynchronousMessage) -> None:
     Destroy the `Message` being pointed to.
 
     [Rust
-    `pactffi_sync_message_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_delete)
+    `pactffi_sync_message_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_delete)
     """
     lib.pactffi_sync_message_delete(message._ptr)
 
@@ -4624,7 +4640,7 @@ def sync_message_get_request_contents_str(message: SynchronousMessage) -> str:
     Get the request contents of a `SynchronousMessage` in string form.
 
     [Rust
-    `pactffi_sync_message_get_request_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_request_contents_str)
+    `pactffi_sync_message_get_request_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_request_contents_str)
 
     # Safety
 
@@ -4651,7 +4667,7 @@ def sync_message_set_request_contents_str(
     Sets the request contents of the message.
 
     [Rust
-    `pactffi_sync_message_set_request_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_set_request_contents_str)
+    `pactffi_sync_message_set_request_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_set_request_contents_str)
 
     - `message` - the message to set the request contents for
     - `contents` - pointer to contents to copy from. Must be a valid
@@ -4679,7 +4695,7 @@ def sync_message_get_request_contents_length(message: SynchronousMessage) -> int
     Get the length of the request contents of a `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_get_request_contents_length`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_request_contents_length)
+    `pactffi_sync_message_get_request_contents_length`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_request_contents_length)
 
     # Safety
 
@@ -4698,7 +4714,7 @@ def sync_message_get_request_contents_bin(message: SynchronousMessage) -> bytes:
     Get the request contents of a `SynchronousMessage` as a bytes.
 
     [Rust
-    `pactffi_sync_message_get_request_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_request_contents_bin)
+    `pactffi_sync_message_get_request_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_request_contents_bin)
 
     # Safety
 
@@ -4725,7 +4741,7 @@ def sync_message_set_request_contents_bin(
     Sets the request contents of the message as an array of bytes.
 
     [Rust
-    `pactffi_sync_message_set_request_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_set_request_contents_bin)
+    `pactffi_sync_message_set_request_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_set_request_contents_bin)
 
     * `message` - the message to set the request contents for
     * `contents` - pointer to contents to copy from
@@ -4752,7 +4768,7 @@ def sync_message_get_request_contents(message: SynchronousMessage) -> MessageCon
     Get the request contents of an `SynchronousMessage` as a `MessageContents`.
 
     [Rust
-    `pactffi_sync_message_get_request_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_request_contents)
+    `pactffi_sync_message_get_request_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_request_contents)
 
     # Safety
 
@@ -4779,7 +4795,7 @@ def sync_message_generate_request_contents(
     contents as would be received by the consumer.
 
     [Rust
-    `pactffi_sync_message_generate_request_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_generate_request_contents)
+    `pactffi_sync_message_generate_request_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_generate_request_contents)
 
     Raises:
         RuntimeError:
@@ -4797,7 +4813,7 @@ def sync_message_get_number_responses(message: SynchronousMessage) -> int:
     Get the number of response messages in the `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_get_number_responses`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_number_responses)
+    `pactffi_sync_message_get_number_responses`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_number_responses)
 
     If the message is null, this function will return 0.
     """
@@ -4812,7 +4828,7 @@ def sync_message_get_response_contents_str(
     Get the response contents of a `SynchronousMessage` in string form.
 
     [Rust
-    `pactffi_sync_message_get_response_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_response_contents_str)
+    `pactffi_sync_message_get_response_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_response_contents_str)
 
     # Safety
 
@@ -4845,7 +4861,7 @@ def sync_message_set_response_contents_str(
     with default values.
 
     [Rust
-    `pactffi_sync_message_set_response_contents_str`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_set_response_contents_str)
+    `pactffi_sync_message_set_response_contents_str`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_set_response_contents_str)
 
     * `message` - the message to set the response contents for
     * `index` - index of the response to set. 0 is the first response.
@@ -4877,7 +4893,7 @@ def sync_message_get_response_contents_length(
     Get the length of the response contents of a `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_get_response_contents_length`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_response_contents_length)
+    `pactffi_sync_message_get_response_contents_length`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_response_contents_length)
 
     # Safety
 
@@ -4899,7 +4915,7 @@ def sync_message_get_response_contents_bin(
     Get the response contents of a `SynchronousMessage` as bytes.
 
     [Rust
-    `pactffi_sync_message_get_response_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_response_contents_bin)
+    `pactffi_sync_message_get_response_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_response_contents_bin)
 
     # Safety
 
@@ -4930,7 +4946,7 @@ def sync_message_set_response_contents_bin(
     responses will be padded with default values.
 
     [Rust
-    `pactffi_sync_message_set_response_contents_bin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_set_response_contents_bin)
+    `pactffi_sync_message_set_response_contents_bin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_set_response_contents_bin)
 
     * `message` - the message to set the response contents for
     * `index` - index of the response to set. 0 is the first response
@@ -4961,7 +4977,7 @@ def sync_message_get_response_contents(
     Get the response contents of an `SynchronousMessage` as a `MessageContents`.
 
     [Rust
-    `pactffi_sync_message_get_response_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_response_contents)
+    `pactffi_sync_message_get_response_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_response_contents)
 
     # Safety
 
@@ -4990,7 +5006,7 @@ def sync_message_generate_response_contents(
     received by the consumer.
 
     [Rust
-    `pactffi_sync_message_generate_response_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_generate_response_contents)
+    `pactffi_sync_message_generate_response_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_generate_response_contents)
 
     Raises:
         RuntimeError:
@@ -5008,7 +5024,7 @@ def sync_message_get_description(message: SynchronousMessage) -> str:
     Get a copy of the description.
 
     [Rust
-    `pactffi_sync_message_get_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_description)
+    `pactffi_sync_message_get_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_description)
 
     Raises:
         RuntimeError:
@@ -5026,7 +5042,7 @@ def sync_message_set_description(message: SynchronousMessage, description: str) 
     Write the `description` field on the `SynchronousMessage`.
 
     [Rust
-    `pactffi_sync_message_set_description`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_set_description)
+    `pactffi_sync_message_set_description`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_set_description)
 
     # Safety
 
@@ -5051,7 +5067,7 @@ def sync_message_get_provider_state(
     Get a copy of the provider state at the given index from this message.
 
     [Rust
-    `pactffi_sync_message_get_provider_state`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_provider_state)
+    `pactffi_sync_message_get_provider_state`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_provider_state)
 
     # Safety
 
@@ -5077,7 +5093,7 @@ def sync_message_get_provider_state_iter(
     Get an iterator over provider states.
 
     [Rust
-    `pactffi_sync_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_sync_message_get_provider_state_iter)
+    `pactffi_sync_message_get_provider_state_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_sync_message_get_provider_state_iter)
 
     # Safety
 
@@ -5099,50 +5115,9 @@ def string_delete(string: OwnedString) -> None:
     Delete a string previously returned by this FFI.
 
     [Rust
-    `pactffi_string_delete`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_string_delete)
+    `pactffi_string_delete`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_string_delete)
     """
     lib.pactffi_string_delete(string._ptr)
-
-
-def create_mock_server(pact_str: str, addr_str: str, *, tls: bool) -> int:
-    """
-    [DEPRECATED] External interface to create a HTTP mock server.
-
-    A pointer to the pact JSON as a NULL-terminated C string is passed in, as
-    well as the port for the mock server to run on. A value of 0 for the port
-    will result in a port being allocated by the operating system. The port of
-    the mock server is returned.
-
-    [Rust
-    `pactffi_create_mock_server`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_create_mock_server)
-
-    * `pact_str` - Pact JSON
-    * `addr_str` - Address to bind to in the form name:port (i.e. 127.0.0.1:80)
-    * `tls` - boolean flag to indicate of the mock server should use TLS (using
-      a self-signed certificate)
-
-    This function is deprecated and replaced with
-    `pactffi_create_mock_server_for_transport`.
-
-    # Errors
-
-    Errors are returned as negative values.
-
-    | Error | Description |
-    |-------|-------------|
-    | -1 | A null pointer was received |
-    | -2 | The pact JSON could not be parsed |
-    | -3 | The mock server could not be started |
-    | -4 | The method panicked |
-    | -5 | The address is not valid |
-    | -6 | Could not create the TLS configuration with the self-signed certificate |
-    """
-    warnings.warn(
-        "This function is deprecated, use create_mock_server_for_transport instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    raise NotImplementedError
 
 
 def get_tls_ca_certificate() -> OwnedString:
@@ -5150,57 +5125,16 @@ def get_tls_ca_certificate() -> OwnedString:
     Fetch the CA Certificate used to generate the self-signed certificate.
 
     [Rust
-    `pactffi_get_tls_ca_certificate`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_get_tls_ca_certificate)
+    `pactffi_get_tls_ca_certificate`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_get_tls_ca_certificate)
 
     **NOTE:** The string for the result is allocated on the heap, and will have
-    to be freed by the caller using pactffi_string_delete.
+    to be freed by the caller using [`string_delete`][pact_ffi.string_delete].
 
     # Errors
 
     An empty string indicates an error reading the pem file.
     """
     return OwnedString(lib.pactffi_get_tls_ca_certificate())
-
-
-def create_mock_server_for_pact(pact: PactHandle, addr_str: str, *, tls: bool) -> int:
-    """
-    [DEPRECATED] External interface to create a HTTP mock server.
-
-    A Pact handle is passed in, as well as the port for the mock server to run
-    on. A value of 0 for the port will result in a port being allocated by the
-    operating system. The port of the mock server is returned.
-
-    [Rust
-    `pactffi_create_mock_server_for_pact`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_create_mock_server_for_pact)
-
-    * `pact` - Handle to a Pact model created with created with
-      `pactffi_new_pact`.
-    * `addr_str` - Address to bind to in the form name:port (i.e. 127.0.0.1:0).
-      Must be a valid UTF-8 NULL-terminated string.
-    * `tls` - boolean flag to indicate of the mock server should use TLS (using
-      a self-signed certificate)
-
-    This function is deprecated and replaced with
-    `pactffi_create_mock_server_for_transport`.
-
-    # Errors
-
-    Errors are returned as negative values.
-
-    | Error | Description |
-    |-------|-------------|
-    | -1 | An invalid handle was received. Handles should be created with `pactffi_new_pact` |
-    | -3 | The mock server could not be started |
-    | -4 | The method panicked |
-    | -5 | The address is not valid |
-    | -6 | Could not create the TLS configuration with the self-signed certificate |
-    """  # noqa: E501
-    warnings.warn(
-        "This function is deprecated, use create_mock_server_for_transport instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    raise NotImplementedError
 
 
 def create_mock_server_for_transport(
@@ -5214,7 +5148,7 @@ def create_mock_server_for_transport(
     Create a mock server for the provided Pact handle and transport.
 
     [Rust
-    `pactffi_create_mock_server_for_transport`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_create_mock_server_for_transport)
+    `pactffi_create_mock_server_for_transport`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_create_mock_server_for_transport)
 
     Args:
         pact:
@@ -5276,7 +5210,7 @@ def mock_server_matched(mock_server_handle: PactServerHandle) -> bool:
     if any request has not been successfully matched, or the method panics.
 
     [Rust
-    `pactffi_mock_server_matched`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mock_server_matched)
+    `pactffi_mock_server_matched`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mock_server_matched)
     """
     return lib.pactffi_mock_server_matched(mock_server_handle._ref)
 
@@ -5288,7 +5222,7 @@ def mock_server_mismatches(
     External interface to get all the mismatches from a mock server.
 
     [Rust
-    `pactffi_mock_server_mismatches`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mock_server_mismatches)
+    `pactffi_mock_server_mismatches`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mock_server_mismatches)
 
     # Errors
 
@@ -5315,7 +5249,7 @@ def cleanup_mock_server(mock_server_handle: PactServerHandle) -> None:
     and cleanup any memory allocated for it.
 
     [Rust
-    `pactffi_cleanup_mock_server`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_cleanup_mock_server)
+    `pactffi_cleanup_mock_server`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_cleanup_mock_server)
 
     Args:
         mock_server_handle:
@@ -5344,7 +5278,7 @@ def write_pact_file(
     directory to write the file to is passed as the second parameter.
 
     [Rust
-    `pactffi_write_pact_file`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_write_pact_file)
+    `pactffi_write_pact_file`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_write_pact_file)
 
     Args:
         mock_server_handle:
@@ -5396,7 +5330,7 @@ def mock_server_logs(mock_server_handle: PactServerHandle) -> str:
     started.
 
     [Rust
-    `pactffi_mock_server_logs`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_mock_server_logs)
+    `pactffi_mock_server_logs`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_mock_server_logs)
 
     Raises:
         RuntimeError:
@@ -5420,7 +5354,7 @@ def generate_datetime_string(format: str) -> StringResult:
     string needs to be freed with the `pactffi_string_delete` function
 
     [Rust
-    `pactffi_generate_datetime_string`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generate_datetime_string)
+    `pactffi_generate_datetime_string`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generate_datetime_string)
 
     # Safety
 
@@ -5437,7 +5371,7 @@ def check_regex(regex: str, example: str) -> bool:
     Checks that the example string matches the given regex.
 
     [Rust
-    `pactffi_check_regex`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_check_regex)
+    `pactffi_check_regex`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_check_regex)
 
     # Safety
 
@@ -5456,7 +5390,7 @@ def generate_regex_value(regex: str) -> StringResult:
     `pactffi_string_delete` function.
 
     [Rust
-    `pactffi_generate_regex_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_generate_regex_value)
+    `pactffi_generate_regex_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_generate_regex_value)
 
     # Safety
 
@@ -5471,7 +5405,7 @@ def free_string(s: str) -> None:
     [DEPRECATED] Frees the memory allocated to a string by another function.
 
     [Rust
-    `pactffi_free_string`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_free_string)
+    `pactffi_free_string`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_free_string)
 
     This function is deprecated. Use `pactffi_string_delete` instead.
 
@@ -5493,7 +5427,7 @@ def new_pact(consumer_name: str, provider_name: str) -> PactHandle:
     Creates a new Pact model and returns a handle to it.
 
     [Rust
-    `pactffi_new_pact`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_new_pact)
+    `pactffi_new_pact`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_new_pact)
 
     Args:
         consumer_name:
@@ -5546,7 +5480,7 @@ def new_interaction(pact: PactHandle, description: str) -> InteractionHandle:
     will result in that interaction being replaced with the new one.
 
     [Rust
-    `pactffi_new_interaction`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_new_interaction)
+    `pactffi_new_interaction`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_new_interaction)
 
     Args:
         pact:
@@ -5574,7 +5508,7 @@ def new_message_interaction(pact: PactHandle, description: str) -> InteractionHa
     will result in that interaction being replaced with the new one.
 
     [Rust
-    `pactffi_new_message_interaction`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_new_message_interaction)
+    `pactffi_new_message_interaction`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_new_message_interaction)
 
     Args:
         pact:
@@ -5605,7 +5539,7 @@ def new_sync_message_interaction(
     will result in that interaction being replaced with the new one.
 
     [Rust
-    `pactffi_new_sync_message_interaction`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_new_sync_message_interaction)
+    `pactffi_new_sync_message_interaction`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_new_sync_message_interaction)
 
     Args:
         pact:
@@ -5630,7 +5564,7 @@ def upon_receiving(interaction: InteractionHandle, description: str) -> None:
     Sets the description for the Interaction.
 
     [Rust
-    `pactffi_upon_receiving`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_upon_receiving)
+    `pactffi_upon_receiving`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_upon_receiving)
 
     This function
 
@@ -5671,7 +5605,7 @@ def given(interaction: InteractionHandle, description: str) -> None:
     Adds a provider state to the Interaction.
 
     [Rust
-    `pactffi_given`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_given)
+    `pactffi_given`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_given)
 
     Args:
         interaction:
@@ -5698,7 +5632,7 @@ def interaction_test_name(interaction: InteractionHandle, test_name: str) -> Non
     used with V4 interactions.
 
     [Rust
-    `pactffi_interaction_test_name`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_interaction_test_name)
+    `pactffi_interaction_test_name`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_interaction_test_name)
 
     Args:
         interaction:
@@ -5745,7 +5679,7 @@ def given_with_param(
     be parsed as JSON.
 
     [Rust
-    `pactffi_given_with_param`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_given_with_param)
+    `pactffi_given_with_param`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_given_with_param)
 
     Args:
         interaction:
@@ -5787,7 +5721,7 @@ def given_with_params(
     with a `value` key.
 
     [Rust
-    `pactffi_given_with_params`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_given_with_params)
+    `pactffi_given_with_params`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_given_with_params)
 
     Args:
         interaction:
@@ -5826,7 +5760,7 @@ def with_request(interaction: InteractionHandle, method: str, path: str) -> None
     Configures the request for the Interaction.
 
     [Rust
-    `pactffi_with_request`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_request)
+    `pactffi_with_request`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_request)
 
     Args:
         interaction:
@@ -5840,7 +5774,7 @@ def with_request(interaction: InteractionHandle, method: str, path: str) -> None
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md)
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md)
             which allows regex patterns. For examples:
 
             ```json
@@ -5875,7 +5809,7 @@ def with_query_parameter_v2(
     Configures a query parameter for the Interaction.
 
     [Rust
-    `pactffi_with_query_parameter_v2`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_query_parameter_v2)
+    `pactffi_with_query_parameter_v2`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_query_parameter_v2)
 
     To setup a query parameter with multiple values, you can either call this
     function multiple times with a different index value:
@@ -5912,7 +5846,7 @@ def with_query_parameter_v2(
     )
     ```
 
-    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md)
+    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md)
 
     If you want the matching rules to apply to all values (and not just the one
     with the given index), make sure to set the value to be an array.
@@ -5964,7 +5898,7 @@ def with_query_parameter_v2(
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md).
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError:
@@ -5986,7 +5920,7 @@ def with_specification(pact: PactHandle, version: PactSpecification) -> None:
     Sets the specification version for a given Pact model.
 
     [Rust
-    `pactffi_with_specification`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_specification)
+    `pactffi_with_specification`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_specification)
 
     Args:
         pact:
@@ -6010,7 +5944,7 @@ def handle_get_pact_spec_version(handle: PactHandle) -> PactSpecification:
     Fetches the Pact specification version for the given Pact model.
 
     [Rust
-    `pactffi_handle_get_pact_spec_version`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_handle_get_pact_spec_version)
+    `pactffi_handle_get_pact_spec_version`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_handle_get_pact_spec_version)
 
     Args:
         handle:
@@ -6036,7 +5970,7 @@ def with_pact_metadata(
     the mock server for it has already started) or the namespace is readonly.
 
     [Rust
-    `pactffi_with_pact_metadata`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_pact_metadata)
+    `pactffi_with_pact_metadata`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_pact_metadata)
 
     Args:
         pact:
@@ -6102,7 +6036,7 @@ def with_metadata(
     ```
 
     See
-    [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md)
+    [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md)
 
     # Note
 
@@ -6151,7 +6085,7 @@ def with_header_v2(
     r"""
     Configures a header for the Interaction.
 
-    [Rust `pactffi_with_header_v2`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_header_v2)
+    [Rust `pactffi_with_header_v2`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_header_v2)
 
     To setup a header with multiple values, you can either call this
     function multiple times with a different index value:
@@ -6189,7 +6123,7 @@ def with_header_v2(
     )
     ```
 
-    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md)
+    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md)
 
     Args:
         interaction:
@@ -6211,7 +6145,7 @@ def with_header_v2(
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md).
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError:
@@ -6243,7 +6177,7 @@ def set_header(
     and generators can not be configured with it.
 
     [Rust
-    `pactffi_set_header`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_set_header)
+    `pactffi_set_header`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_set_header)
 
     If matching rules are required to be set, use `pactffi_with_header_v2`.
 
@@ -6281,7 +6215,7 @@ def response_status(interaction: InteractionHandle, status: int) -> None:
     Configures the response for the Interaction.
 
     [Rust
-    `pactffi_response_status`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_response_status)
+    `pactffi_response_status`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_response_status)
 
     Args:
         interaction:
@@ -6305,7 +6239,7 @@ def response_status_v2(interaction: InteractionHandle, status: str) -> None:
     Configures the response for the Interaction.
 
     [Rust
-    `pactffi_response_status_v2`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_response_status_v2)
+    `pactffi_response_status_v2`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_response_status_v2)
 
     To include matching rules for the status (only statusCode or integer really
     makes sense to use), include the matching rule JSON format with the value as
@@ -6324,7 +6258,7 @@ def response_status_v2(interaction: InteractionHandle, status: str) -> None:
     )
     ```
 
-    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md)
+    See [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md)
 
     Args:
         interaction:
@@ -6335,7 +6269,7 @@ def response_status_v2(interaction: InteractionHandle, status: str) -> None:
 
             This may be a simple string in which case it will be used as-is, or
             it may be a [JSON matching
-            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md).
+            rule](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError:
@@ -6359,7 +6293,7 @@ def with_body(
     Adds the body for the interaction.
 
     [Rust
-    `pactffi_with_body`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_body)
+    `pactffi_with_body`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_body)
 
     Returns false if the interaction or Pact can't be modified (i.e. the mock
     server for it has already started)
@@ -6394,7 +6328,7 @@ def with_body(
         body:
             The body contents. For JSON payloads, matching rules can be embedded
             in the body. See
-            [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.4.28/rust/pact_ffi/IntegrationJson.md).
+            [IntegrationJson.md](https://github.com/pact-foundation/pact-reference/blob/libpact_ffi-v0.5.3/rust/pact_ffi/IntegrationJson.md).
 
     Raises:
         RuntimeError:
@@ -6421,7 +6355,7 @@ def with_binary_body(
     Adds the body for the interaction.
 
     [Rust
-    `pactffi_with_binary_body`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_binary_body)
+    `pactffi_with_binary_body`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_binary_body)
 
     For HTTP and async message interactions, this will overwrite the body. With
     asynchronous messages, the part parameter will be ignored. With synchronous
@@ -6481,7 +6415,7 @@ def with_binary_file(
     already started)
 
     [Rust
-    `pactffi_with_binary_file`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_binary_file)
+    `pactffi_with_binary_file`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_binary_file)
 
     For HTTP and async message interactions, this will overwrite the body. With
     asynchronous messages, the part parameter will be ignored. With synchronous
@@ -6528,7 +6462,7 @@ def with_matching_rules(
     Add matching rules to the interaction.
 
     [Rust
-    `pactffi_with_matching_rules`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_matching_rules)
+    `pactffi_with_matching_rules`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_matching_rules)
 
     This function can be called multiple times, in which case the matching
     rules will be merged.
@@ -6566,7 +6500,7 @@ def with_generators(
     Add generators to the interaction.
 
     [Rust
-    `pactffi_with_generators`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_generators)
+    `pactffi_with_generators`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_generators)
 
     This function can be called multiple times, in which case the generators
     will be combined (provide they don't clash).
@@ -6614,7 +6548,7 @@ def with_multipart_file_v2(  # noqa: PLR0913
     already started) or an error occurs.
 
     [Rust
-    `pactffi_with_multipart_file_v2`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_multipart_file_v2)
+    `pactffi_with_multipart_file_v2`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_multipart_file_v2)
 
     This function can be called multiple times. In that case, each subsequent
     call will be appended to the existing multipart body as a new part.
@@ -6668,7 +6602,7 @@ def with_multipart_file(
     already started) or an error occurs.
 
     [Rust
-    `pactffi_with_multipart_file`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_with_multipart_file)
+    `pactffi_with_multipart_file`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_with_multipart_file)
 
     * `interaction` - Interaction handle to set the body for.
     * `part` - Request or response part.
@@ -6705,7 +6639,7 @@ def set_key(interaction: InteractionHandle, key: str | None) -> None:
     Sets the key attribute for the interaction.
 
     [Rust
-    `pactffi_set_key`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_set_key)
+    `pactffi_set_key`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_set_key)
 
     Args:
         interaction:
@@ -6733,7 +6667,7 @@ def set_pending(interaction: InteractionHandle, *, pending: bool) -> None:
     Mark the interaction as pending.
 
     [Rust
-    `pactffi_set_pending`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_set_pending)
+    `pactffi_set_pending`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_set_pending)
 
     Args:
         interaction:
@@ -6757,7 +6691,7 @@ def set_comment(interaction: InteractionHandle, key: str, value: str | None) -> 
     Add a comment to the interaction.
 
     [Rust
-    `pactffi_set_comment`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_set_comment)
+    `pactffi_set_comment`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_set_comment)
 
     Args:
         interaction:
@@ -6791,7 +6725,7 @@ def add_text_comment(interaction: InteractionHandle, comment: str) -> None:
     Add a text comment to the interaction.
 
     [Rust
-    `pactffi_add_text_comment`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_add_text_comment)
+    `pactffi_add_text_comment`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_add_text_comment)
 
     Args:
         interaction:
@@ -6821,7 +6755,7 @@ def pact_handle_get_async_message_iter(pact: PactHandle) -> PactAsyncMessageIter
     `pactffi_pact_sync_message_iter_delete`.
 
     [Rust
-    `pactffi_pact_handle_get_sync_message_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_handle_get_sync_message_iter)
+    `pactffi_pact_handle_get_sync_message_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_handle_get_sync_message_iter)
 
     # Safety
 
@@ -6847,7 +6781,7 @@ def pact_handle_get_sync_message_iter(pact: PactHandle) -> PactSyncMessageIterat
     `pactffi_pact_sync_message_iter_delete`.
 
     [Rust
-    `pactffi_pact_handle_get_sync_message_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_handle_get_sync_message_iter)
+    `pactffi_pact_handle_get_sync_message_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_handle_get_sync_message_iter)
 
     # Safety
 
@@ -6873,7 +6807,7 @@ def pact_handle_get_sync_http_iter(pact: PactHandle) -> PactSyncHttpIterator:
     `pactffi_pact_sync_http_iter_delete`.
 
     [Rust
-    `pactffi_pact_handle_get_sync_http_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_handle_get_sync_http_iter)
+    `pactffi_pact_handle_get_sync_http_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_handle_get_sync_http_iter)
 
     # Safety
 
@@ -6897,7 +6831,7 @@ def pact_handle_get_message_iter(pact: PactHandle) -> PactMessageIterator:
     `pactffi_pact_message_iter_delete`.
 
     [Rust
-    `pactffi_pact_handle_get_message_iter`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_handle_get_message_iter)
+    `pactffi_pact_handle_get_message_iter`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_handle_get_message_iter)
 
     # Safety
 
@@ -6925,7 +6859,7 @@ def pact_handle_write_file(
     External interface to write out the pact file.
 
     [Rust
-    `pactffi_pact_handle_write_file`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_pact_handle_write_file)
+    `pactffi_pact_handle_write_file`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_pact_handle_write_file)
 
     This function should be called if all the consumer tests have passed.
 
@@ -6969,7 +6903,7 @@ def free_pact_handle(pact: PactHandle) -> None:
     Delete a Pact handle and free the resources used by it.
 
     [Rust
-    `pactffi_free_pact_handle`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_free_pact_handle)
+    `pactffi_free_pact_handle`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_free_pact_handle)
 
     Raises:
         RuntimeError:
@@ -6985,32 +6919,6 @@ def free_pact_handle(pact: PactHandle) -> None:
     raise RuntimeError(msg)
 
 
-def verify(args: str) -> int:
-    """
-    External interface to verifier a provider.
-
-    [Rust `pactffi_verify`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verify)
-
-    * `args` - the same as the CLI interface, except newline delimited
-
-    # Errors
-
-    Errors are returned as non-zero numeric values.
-
-    | Error | Description |
-    |-------|-------------|
-    | 1 | The verification process failed, see output for errors |
-    | 2 | A null pointer was received |
-    | 3 | The method panicked |
-    | 4 | Invalid arguments were provided to the verification process |
-
-    # Safety
-
-    Exported functions are inherently unsafe. Deal.
-    """
-    raise NotImplementedError
-
-
 def verifier_new_for_application() -> VerifierHandle:
     """
     Get a Handle to a newly created verifier.
@@ -7021,7 +6929,7 @@ def verifier_new_for_application() -> VerifierHandle:
     to set the required values and enable it.
 
     [Rust
-    `pactffi_verifier_new_for_application`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_new_for_application)
+    `pactffi_verifier_new_for_application`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_new_for_application)
     """
     result: cffi.FFI.CData = lib.pactffi_verifier_new_for_application(
         b"pact-python",
@@ -7034,7 +6942,7 @@ def verifier_shutdown(handle: VerifierHandle) -> None:
     """
     Shutdown the verifier and release all resources.
 
-    [Rust `pactffi_verifier_shutdown`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_shutdown)
+    [Rust `pactffi_verifier_shutdown`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_shutdown)
     """
     lib.pactffi_verifier_shutdown(handle._ref)
 
@@ -7051,7 +6959,7 @@ def verifier_set_provider_info(  # noqa: PLR0913
     Set the provider details for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_provider_info`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_provider_info)
+    `pactffi_verifier_set_provider_info`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_provider_info)
 
     Args:
         handle:
@@ -7097,7 +7005,7 @@ def verifier_add_provider_transport(
     Adds a new transport for the given provider.
 
     [Rust
-    `pactffi_verifier_add_provider_transport`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_add_provider_transport)
+    `pactffi_verifier_add_provider_transport`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_add_provider_transport)
 
     Args:
         handle:
@@ -7138,7 +7046,7 @@ def verifier_set_filter_info(
     Set the filters for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_filter_info`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_filter_info)
+    `pactffi_verifier_set_filter_info`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_filter_info)
 
     Set filters to narrow down the interactions to verify.
 
@@ -7174,7 +7082,7 @@ def verifier_set_provider_state(
     Set the provider state URL for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_provider_state`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_provider_state)
+    `pactffi_verifier_set_provider_state`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_provider_state)
 
     Args:
         handle:
@@ -7209,7 +7117,7 @@ def verifier_set_verification_options(
     Set the options used by the verifier when calling the provider.
 
     [Rust
-    `pactffi_verifier_set_verification_options`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_verification_options)
+    `pactffi_verifier_set_verification_options`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_verification_options)
 
     Args:
         handle:
@@ -7244,7 +7152,7 @@ def verifier_set_coloured_output(
     Enables or disables coloured output using ANSI escape codes.
 
     [Rust
-    `pactffi_verifier_set_coloured_output`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_coloured_output)
+    `pactffi_verifier_set_coloured_output`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_coloured_output)
 
     By default, coloured output is enabled.
 
@@ -7273,7 +7181,7 @@ def verifier_set_no_pacts_is_error(handle: VerifierHandle, *, enabled: bool) -> 
     Enables or disables if no pacts are found to verify results in an error.
 
     [Rust
-    `pactffi_verifier_set_no_pacts_is_error`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_no_pacts_is_error)
+    `pactffi_verifier_set_no_pacts_is_error`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_no_pacts_is_error)
 
     Args:
         handle:
@@ -7306,7 +7214,7 @@ def verifier_set_publish_options(
     Set the options used when publishing verification results to the Broker.
 
     [Rust
-    `pactffi_verifier_set_publish_options`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_publish_options)
+    `pactffi_verifier_set_publish_options`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_publish_options)
 
     Args:
         handle:
@@ -7349,7 +7257,7 @@ def verifier_set_consumer_filters(
     Set the consumer filters for the Pact verifier.
 
     [Rust
-    `pactffi_verifier_set_consumer_filters`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_set_consumer_filters)
+    `pactffi_verifier_set_consumer_filters`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_consumer_filters)
     """
     lib.pactffi_verifier_set_consumer_filters(
         handle._ref,
@@ -7367,7 +7275,7 @@ def verifier_add_custom_header(
     Adds a custom header to be added to the requests made to the provider.
 
     [Rust
-    `pactffi_verifier_add_custom_header`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_add_custom_header)
+    `pactffi_verifier_add_custom_header`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_add_custom_header)
     """
     lib.pactffi_verifier_add_custom_header(
         handle._ref,
@@ -7376,12 +7284,37 @@ def verifier_add_custom_header(
     )
 
 
+def verifier_set_follow_redirects(
+    handle: VerifierHandle,
+    *,
+    follow: bool,
+) -> None:
+    """
+    Sets whether redirects should be automatically followed.
+
+    [Rust
+    `pactffi_verifier_set_follow_redirects`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_set_follow_redirects)
+
+    Args:
+        handle:
+            The verifier handle to update.
+
+        follow:
+            If `True`, redirects will be automatically followed when making
+            requests to the provider.
+    """
+    lib.pactffi_verifier_set_follow_redirects(
+        handle._ref,
+        1 if follow else 0,
+    )
+
+
 def verifier_add_file_source(handle: VerifierHandle, file: str) -> None:
     """
     Adds a Pact file as a source to verify.
 
     [Rust
-    `pactffi_verifier_add_file_source`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_add_file_source)
+    `pactffi_verifier_add_file_source`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_add_file_source)
     """
     lib.pactffi_verifier_add_file_source(handle._ref, file.encode("utf-8"))
 
@@ -7393,7 +7326,7 @@ def verifier_add_directory_source(handle: VerifierHandle, directory: str) -> Non
     All pacts from the directory that match the provider name will be verified.
 
     [Rust
-    `pactffi_verifier_add_directory_source`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_add_directory_source)
+    `pactffi_verifier_add_directory_source`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_add_directory_source)
 
     # Safety
 
@@ -7415,7 +7348,7 @@ def verifier_url_source(
     Adds a URL as a source to verify.
 
     [Rust
-    `pactffi_verifier_url_source`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_url_source)
+    `pactffi_verifier_url_source`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_url_source)
 
     Args:
         handle:
@@ -7455,7 +7388,7 @@ def verifier_broker_source(
     Adds a Pact broker as a source to verify.
 
     [Rust
-    `pactffi_verifier_broker_source`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_broker_source)
+    `pactffi_verifier_broker_source`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_broker_source)
 
     This will fetch all the pact files from the broker that match the provider
     name.
@@ -7503,7 +7436,7 @@ def verifier_broker_source_with_selectors(  # noqa: PLR0913
     Adds a Pact broker as a source to verify.
 
     [Rust
-    `pactffi_verifier_broker_source_with_selectors`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_broker_source_with_selectors)
+    `pactffi_verifier_broker_source_with_selectors`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_broker_source_with_selectors)
 
     This will fetch all the pact files from the broker that match the provider
     name and the consumer version selectors (See [Consumer Version
@@ -7582,7 +7515,8 @@ def verifier_execute(handle: VerifierHandle) -> None:
     """
     Runs the verification.
 
-    (https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_execute)
+    [Rust
+    `pactffi_verifier_execute`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_execute)
 
     Raises:
         RuntimeError:
@@ -7594,71 +7528,12 @@ def verifier_execute(handle: VerifierHandle) -> None:
         raise RuntimeError(msg)
 
 
-def verifier_cli_args() -> str:
-    """
-    External interface to retrieve the CLI options and arguments.
-
-    This available when calling the CLI interface, returning them as a JSON
-    string.
-
-    [Rust
-    `pactffi_verifier_cli_args`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_cli_args)
-
-    The purpose is to then be able to use in other languages which wrap the FFI
-    library, to implement the same CLI functionality automatically without
-    manual maintenance of arguments, help descriptions etc.
-
-    # Example structure
-
-    ```json
-    {
-      "options": [
-        {
-          "long": "scheme",
-          "help": "Provider URI scheme (defaults to http)",
-          "possible_values": [
-            "http",
-            "https"
-          ],
-          "default_value": "http"
-          "multiple": false,
-        },
-        {
-          "long": "file",
-          "short": "f",
-          "help": "Pact file to verify (can be repeated)",
-          "multiple": true
-        },
-        {
-          "long": "user",
-          "help": "Username to use when fetching pacts from URLS",
-          "multiple": false,
-          "env": "PACT_BROKER_USERNAME"
-        }
-      ],
-      "flags": [
-        {
-          "long": "disable-ssl-verification",
-          "help": "Disables validation of SSL certificates",
-          "multiple": false
-        }
-      ]
-    }
-    ```
-
-    # Safety
-
-    Exported functions are inherently unsafe.
-    """
-    raise NotImplementedError
-
-
 def verifier_logs(handle: VerifierHandle) -> OwnedString:
     """
     Extracts the logs for the verification run.
 
     [Rust
-    `pactffi_verifier_logs`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_logs)
+    `pactffi_verifier_logs`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_logs)
 
     This needs the memory buffer log sink to be setup before the verification is
     executed. The returned string will need to be freed with the `free_string`
@@ -7680,7 +7555,7 @@ def verifier_logs_for_provider(provider_name: str) -> OwnedString:
     Extracts the logs for the verification run for the provider name.
 
     [Rust
-    `pactffi_verifier_logs_for_provider`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_logs_for_provider)
+    `pactffi_verifier_logs_for_provider`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_logs_for_provider)
 
     This needs the memory buffer log sink to be setup before the verification is
     executed. The returned string will need to be freed with the `free_string`
@@ -7702,7 +7577,7 @@ def verifier_output(handle: VerifierHandle, strip_ansi: int) -> OwnedString:
     Extracts the standard output for the verification run.
 
     [Rust
-    `pactffi_verifier_output`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_output)
+    `pactffi_verifier_output`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_output)
 
     Args:
         handle:
@@ -7729,7 +7604,7 @@ def verifier_json(handle: VerifierHandle) -> OwnedString:
     Extracts the verification result as a JSON document.
 
     [Rust
-    `pactffi_verifier_json`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_verifier_json)
+    `pactffi_verifier_json`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_verifier_json)
 
     Raises:
         RuntimeError:
@@ -7740,6 +7615,61 @@ def verifier_json(handle: VerifierHandle) -> OwnedString:
         msg = f"Failed to get JSON for {handle}."
         raise RuntimeError(msg)
     return OwnedString(ptr)
+
+
+def using_plugin_with_delay(
+    pact: PactHandle,
+    plugin_name: str,
+    plugin_version: str | None,
+    completion_delay: int,
+) -> None:
+    """
+    Add a plugin to be used by the test.
+
+    The plugin needs to be installed correctly for this function to work.
+
+    Note that plugins run as separate processes, so will need to be cleaned up
+    afterwards by calling [`cleanup_plugins`][pact_ffi.cleanup_plugins]
+    otherwise you will have plugin processes left running.
+
+    [Rust `pactffi_using_plugin_with_delay`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_using_plugin_with_delay)
+
+    Args:
+        pact:
+            Handle to a Pact model.
+
+        plugin_name:
+            Name of the plugin to use.
+
+        plugin_version:
+            Version of the plugin to use. If `None`, the latest version will be
+            used.
+
+        completion_delay:
+            An arbitrary delay specified in milliseconds to add before the
+            function returns to allow asynchronous tasks to complete.
+
+    Raises:
+        RuntimeError:
+            If the plugin could not be loaded.
+    """
+    ret = lib.pactffi_using_plugin_with_delay(
+        pact._ref,
+        plugin_name.encode("utf-8"),
+        plugin_version.encode("utf-8") if plugin_version else ffi.NULL,
+        completion_delay,
+    )
+    if ret == 0:
+        return
+    if ret == 1:
+        msg = f"A general panic was caught: {get_error_message()}"
+    elif ret == 2:  # noqa: PLR2004
+        msg = f"Failed to load the plugin {plugin_name}."
+    elif ret == 3:  # noqa: PLR2004
+        msg = f"The Pact handle {pact} is invalid."
+    else:
+        msg = f"There was an unknown error loading the plugin {plugin_name}."
+    raise RuntimeError(msg)
 
 
 def using_plugin(
@@ -7757,7 +7687,7 @@ def using_plugin(
     otherwise you will have plugin processes left running.
 
     [Rust
-    `pactffi_using_plugin`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_using_plugin)
+    `pactffi_using_plugin`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_using_plugin)
 
     Args:
         pact:
@@ -7800,7 +7730,7 @@ def cleanup_plugins(pact: PactHandle) -> None:
     zero).
 
     [Rust
-    `pactffi_cleanup_plugins`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_cleanup_plugins)
+    `pactffi_cleanup_plugins`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_cleanup_plugins)
     """
     lib.pactffi_cleanup_plugins(pact._ref)
 
@@ -7819,7 +7749,7 @@ def interaction_contents(
     format of the JSON contents.
 
     [Rust
-    `pactffi_interaction_contents`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_interaction_contents)
+    `pactffi_interaction_contents`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_interaction_contents)
 
     Args:
         interaction:
@@ -7849,15 +7779,15 @@ def interaction_contents(
         return
     if ret == 1:
         msg = f"A general panic was caught: {get_error_message()}"
-    if ret == 2:  # noqa: PLR2004
+    elif ret == 2:  # noqa: PLR2004
         msg = "The mock server has already been started."
-    if ret == 3:  # noqa: PLR2004
+    elif ret == 3:  # noqa: PLR2004
         msg = f"The interaction handle {interaction} is invalid."
-    if ret == 4:  # noqa: PLR2004
+    elif ret == 4:  # noqa: PLR2004
         msg = f"The content type {content_type} is not valid."
-    if ret == 5:  # noqa: PLR2004
+    elif ret == 5:  # noqa: PLR2004
         msg = "The content is not valid JSON."
-    if ret == 6:  # noqa: PLR2004
+    elif ret == 6:  # noqa: PLR2004
         msg = f"The plugin returned an error: {get_error_message()}"
     else:
         msg = f"There was an unknown error configuring the interaction: {ret}"
@@ -7879,7 +7809,7 @@ def matches_string_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_string_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matches_string_value)
+    `pactffi_matches_string_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matches_string_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get as a NULL terminated string
@@ -7910,7 +7840,7 @@ def matches_u64_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_u64_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matches_u64_value)
+    `pactffi_matches_u64_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matches_u64_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -7940,7 +7870,7 @@ def matches_i64_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_i64_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matches_i64_value)
+    `pactffi_matches_i64_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matches_i64_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -7970,7 +7900,7 @@ def matches_f64_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_f64_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matches_f64_value)
+    `pactffi_matches_f64_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matches_f64_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -8000,7 +7930,7 @@ def matches_bool_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_bool_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matches_bool_value)
+    `pactffi_matches_bool_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matches_bool_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get, 0 == false and 1 == true
@@ -8032,7 +7962,7 @@ def matches_binary_value(  # noqa: PLR0913
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_binary_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matches_binary_value)
+    `pactffi_matches_binary_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matches_binary_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get
@@ -8067,7 +7997,7 @@ def matches_json_value(
     function once it is no longer required.
 
     [Rust
-    `pactffi_matches_json_value`](https://docs.rs/pact_ffi/0.4.28/pact_ffi/?search=pactffi_matches_json_value)
+    `pactffi_matches_json_value`](https://docs.rs/pact_ffi/0.5.3/pact_ffi/?search=pactffi_matches_json_value)
 
     * matching_rule - pointer to a matching rule
     * expected_value - value we expect to get as a NULL terminated string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,13 +179,6 @@ build-backend = "hatchling.build"
       extra-dependencies = ["hatchling", "packaging"]
       dependency-groups = ["dev"]
 
-        [tool.hatch.envs.default.workspace]
-        parallel = true
-        members = [
-          { path = "pact-python-cli", group = "dev" },
-          { path = "pact-python-ffi", group = "dev" },
-        ]
-
         [tool.hatch.envs.default.scripts]
         all = ["example", "format", "lint", "test", "typecheck"]
         docs = "mkdocs serve {args}"
@@ -336,3 +329,11 @@ build-backend = "hatchling.build"
 
     [tool.typos.files]
     extend-exclude = ["*.svg"]
+
+  [tool.uv]
+    [tool.uv.sources]
+    pact-python-cli = { workspace = true }
+    pact-python-ffi = { workspace = true }
+
+    [tool.uv.workspace]
+    members = ["pact-python-cli", "pact-python-ffi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">=3.10"
 # - A minor version address vulnerability which directly impacts Pact Python
 dependencies = [
   # Pact dependencies
-  "pact-python-ffi~=0.4.0",
+  "pact-python-ffi~=0.5.0",
   "typing-extensions~=4.0 ; python_version < '3.13'",
   # External dependencies
   "yarl~=1.0",

--- a/src/pact/pact.py
+++ b/src/pact/pact.py
@@ -222,7 +222,12 @@ class Pact:
         pact_ffi.with_specification(self._handle, version)
         return self
 
-    def using_plugin(self, name: str, version: str | None = None) -> Self:
+    def using_plugin(
+        self,
+        name: str,
+        version: str | None = None,
+        delay: int | None = None,
+    ) -> Self:
         """
         Add a plugin to be used by the test.
 
@@ -234,8 +239,15 @@ class Pact:
 
             version:
                 Version of the plugin. This is optional and can be `None`.
+
+            delay:
+                An arbitrary delay in milliseconds to add before the function
+                returns to allow asynchronous tasks to complete.
         """
-        pact_ffi.using_plugin(self._handle, name, version)
+        if delay is not None:
+            pact_ffi.using_plugin_with_delay(self._handle, name, version, delay)
+        else:
+            pact_ffi.using_plugin(self._handle, name, version)
         return self
 
     def with_metadata(

--- a/src/pact/verifier.py
+++ b/src/pact/verifier.py
@@ -943,6 +943,20 @@ class Verifier:
             self.add_custom_header(name, value)
         return self
 
+    def follow_redirects(self, follow: bool) -> Self:  # noqa: FBT001
+        """
+        Set whether redirects should be followed.
+
+        By default, the Pact verifier does follow redirects, testing the final
+        non-redirect response (mimicking the default behaviour of most HTTP
+        clients).
+
+        In some cases, it may be desirable to test the redirect response itself,
+        in which case this method can be used to disable following redirects.
+        """
+        pact_ffi.verifier_set_follow_redirects(self._handle, follow=follow)
+        return self
+
     @overload
     def add_source(
         self,

--- a/tests/interaction/test_http_interaction.py
+++ b/tests/interaction/test_http_interaction.py
@@ -28,7 +28,6 @@ ALL_HTTP_METHODS = [
     "HEAD",
     "OPTIONS",
     "TRACE",
-    "CONNECT",
 ]
 
 


### PR DESCRIPTION
## [pact-python-ffi/0.5.3.0] _2026-04-16_

### 🚀 Features

-   Allow iteration over all interactions
-   Implement the Pact class
-   Add handle to pointer conversion
-   Add casting interaction to subtypes
-   Add iterator over all interactions

### 🐛 Bug Fixes

-   Incorrect sync http deletion

### 📚 Documentation

-   Update changelogs

### ⚙️ Miscellaneous Tasks

-   Update non-compliant docstrings and types
-   Upgrade pymdownx extensions
-   Fix json schema url
-   Remove ruff sub-configs
-   Switch to versioningit
-   Ensure pact interactions get deleted
-   Add ruff ignores for tests
-   Refactor ffi tests
-   Remove versioningit, switch to static version in pyproject.toml
-   Minor update to cliff config
-   Replace taplo with tombi

### Contributors

-   @JP-Ellis
-   @Nikhil172913832

<!-- generated by git-cliff on 2026-04-16-->
