### PR TITLE
chore: allow windows arm cli builds to proceed

### DIFF
--- a/pact-python-cli/hatch_build.py
+++ b/pact-python-cli/hatch_build.py
@@ -124,13 +124,24 @@ class PactCliBuildHook(BuildHookInterface[BuilderConfig]):
             raise ValueError(msg)
 
         try:
-            build_data["force_include"] = self._install_ruby_cli(cli_version)
-            self._install_rust_cli()
+            force_include = self._install_ruby_cli(cli_version)
+        except UnsupportedPlatformError as err:
+            # The Ruby standalone is deprecated and not available on all
+            # platforms (e.g. Windows ARM). Warn and continue rather than
+            # failing the build.
+            self.app.display_warning(
+                f"Pact Ruby standalone CLI not available for {err.platform}; skipping."
+            )
+            force_include = {}
+
+        try:
+            force_include = {**force_include, **self._install_rust_cli()}
         except UnsupportedPlatformError as err:
             msg = f"Pact CLI is not available for {err.platform}."
             self.app.display_error(msg)
             raise
 
+        build_data["force_include"] = force_include
         build_data["tag"] = self._infer_tag()
 
     def _sys_tag_platform(self) -> str:
@@ -162,7 +173,6 @@ class PactCliBuildHook(BuildHookInterface[BuilderConfig]):
         self._extract(artefact)
         return {
             str(PKG_DIR / "bin"): "pact_cli/bin",
-            # TODO(epoch-transition): Remove lib/ when standalone dropped  # noqa: TD003
             str(PKG_DIR / "lib"): "pact_cli/lib",
         }
 
@@ -187,6 +197,9 @@ class PactCliBuildHook(BuildHookInterface[BuilderConfig]):
             os_name = "linux"
             ext = "tar.gz"
         elif platform.startswith("win"):
+            if platform.endswith(("arm64", "aarch64")):
+                # The Ruby standalone has no Windows ARM release.
+                raise UnsupportedPlatformError(platform)
             os_name = "windows"
             ext = "zip"
         else:
@@ -255,7 +268,7 @@ class PactCliBuildHook(BuildHookInterface[BuilderConfig]):
             ext=ext,
         )
 
-    def _install_rust_cli(self) -> None:
+    def _install_rust_cli(self) -> Mapping[str, str]:
         """
         Install the Rust pact binary from pact-cli.
 
@@ -274,6 +287,8 @@ class PactCliBuildHook(BuildHookInterface[BuilderConfig]):
         shutil.copy2(artefact, dest)
         if sys.platform != "win32":
             dest.chmod(0o755)
+
+        return {str(PKG_DIR / "bin"): "pact_cli/bin"}
 
     def _extract(self, artefact: Path) -> None:
         """


### PR DESCRIPTION
## :memo: Summary

Silently ignore errors from missing Ruby CLIs, in which case the wheel will only have the Rust CLI.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

To ensure consistency before, if the Ruby CLI was not available, we simply did not produce the wheel. Given we have deprecated and soon will remove the Ruby CLI, it is now fine to have some platforms (in this case, Windows ARM) to be bundled with _only_ the Rust CLI and no Ruby CLIs.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
