### PR TITLE
chore(release): pact-python-cli v2.6.0.1

### DIFF
--- a/pact-python-cli/CHANGELOG.md
+++ b/pact-python-cli/CHANGELOG.md
@@ -8,6 +8,11 @@ Note that this _only_ includes changes to the Python re-packaging of the Pact CL
 <!-- markdownlint-disable emph-style -->
 <!-- markdownlint-disable strong-style -->
 
+## [pact-python-cli/2.6.0.1] _2026-04-17_
+
+### Contributors
+
+
 ## [pact-python-cli/2.6.0.0] _2026-04-16_
 
 ### 🐛 Bug Fixes

--- a/pact-python-cli/CHANGELOG.md
+++ b/pact-python-cli/CHANGELOG.md
@@ -8,6 +8,16 @@ Note that this _only_ includes changes to the Python re-packaging of the Pact CL
 <!-- markdownlint-disable emph-style -->
 <!-- markdownlint-disable strong-style -->
 
+## [pact-python-cli/2.6.0.1] _2026-06-02_
+
+### 🚀 Features
+
+-   Bump Rust CLI to 0.10.2. See [Pact CLI releases](https://github.com/pact-foundation/pact-cli/releases) for details.
+
+### Contributors
+
+-   @JP-Ellis
+
 ## [pact-python-cli/2.6.0.0] _2026-04-16_
 
 ### 🐛 Bug Fixes

--- a/pact-python-cli/hatch_build.py
+++ b/pact-python-cli/hatch_build.py
@@ -30,7 +30,7 @@ PACT_CLI_URL = "https://github.com/pact-foundation/pact-standalone/releases/down
 
 # Remove fixed version and infer from package metadata when pact-cli versioning
 # is adopted.
-PACT_RUST_CLI_VERSION = "0.9.5"
+PACT_RUST_CLI_VERSION = "0.10.2"
 PACT_RUST_CLI_URL = "https://github.com/pact-foundation/pact-cli/releases/download/v{version}/pact-{arch}-{os}{ext}"
 
 

--- a/pact-python-cli/pyproject.toml
+++ b/pact-python-cli/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pact-python-cli"
-version = "2.6.0.0"
+version = "2.6.0.1"
 description = "Pact CLI bundle for Python"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## [pact-python-cli/2.6.0.1] _2026-06-02_

### Contributors


<!-- generated by git-cliff on 2026-06-02-->
