### PR TITLE
chore(ci): avoid most of CI on draft PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 env:
   STABLE_PYTHON_VERSION: '3.10'
@@ -17,7 +22,7 @@ env:
 jobs:
   build:
     name: Build docs
-
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
@@ -51,7 +56,6 @@ jobs:
 
   publish:
     name: Publish docs
-
     if: github.ref == 'refs/heads/main'
 
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -45,13 +50,13 @@ jobs:
         if: |
           contains(needs.*.result, 'failure')
           || contains(needs.*.result, 'cancelled')
-          || contains(needs.*.result, 'skipped')
 
   test:
     name: >-
       Test Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os,
       'windows-') && 'Windows' || 'Linux' }}
 
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -125,6 +130,7 @@ jobs:
       Test Python Example ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS'
       || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
 
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -180,7 +186,7 @@ jobs:
 
   format:
     name: Format
-
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
@@ -212,7 +218,7 @@ jobs:
         run: hatch run format --check --output-format github
   lint:
     name: Lint
-
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
@@ -245,7 +251,7 @@ jobs:
 
   typecheck:
     name: Typecheck
-
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
@@ -274,7 +280,7 @@ jobs:
 
   prek:
     name: Prek (pre-commit)
-
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## :memo: Summary

Avoid running most CI on draft PRs

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

CI usage has significantly increased recently due to three release PRs being constantly kept up to date. As these PRs are kept as draft, CI doesn't need to run.


## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
