### PR TITLE
chore: simplify find_free_port

### DIFF
--- a/src/pact/_util.py
+++ b/src/pact/_util.py
@@ -13,7 +13,6 @@ import inspect
 import logging
 import socket
 import warnings
-from contextlib import closing
 from functools import partial
 from inspect import Parameter, _ParameterKind
 from typing import TYPE_CHECKING, TypeVar
@@ -173,9 +172,8 @@ def find_free_port() -> int:
     Returns:
         The port number.
     """
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
 
 


### PR DESCRIPTION
## :memo: Summary

Minor refactor of the internal `find_free_port` function.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

Since Python 3.2, the socket object implements the context protocol, making the use of `contextlib.closing` redundant.

Additionally, `setsockopt` should be called _before_ the port is bound, and therefore its invocation was likely a no-op (if my understanding is correct).

## :hammer: Test Plan

All tests run fine.

## :link: Related issues/PRs

N/A
