### PR TITLE
fix: avoid rare port clash

### DIFF
--- a/src/pact/pact.py
+++ b/src/pact/pact.py
@@ -76,7 +76,6 @@ from typing import (
 from yarl import URL
 
 import pact_ffi
-from pact._util import find_free_port
 from pact.error import (
     InteractionVerificationError,
     Mismatch,
@@ -667,7 +666,7 @@ class PactServer:
                 independently of `raises`.
         """
         self._host = host
-        self._port = port or find_free_port()
+        self._port = port or 0
         self._transport = transport
         self._transport_config = transport_config
         self._pact_handle = pact_handle


### PR DESCRIPTION
## :memo: Summary

Fix a rare port clash due to the port being released temporary between the Python-to-FFI handover.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

The FFI has built-in support for finding a free port, and it is exposed in Python through the `PactServer.port` method.

This should avoid the rare race condition whereby the same port might be used by two concurrent tests. This was likely caused by the brief time window between Python releasing the port (used to find the free port), and the FFI binding to said port.

## :hammer: Test Plan

All tests are running fine.

## :link: Related issues/PRs

Fixes: #1541