### PR TITLE
feat: Add DSL method to capture an external reference agaist a V4 Pact interaction

### DIFF
--- a/src/pact/interaction/_base.py
+++ b/src/pact/interaction/_base.py
@@ -480,6 +480,55 @@ class Interaction(abc.ABC):
         pact_ffi.add_text_comment(self._handle, comment)
         return self
 
+    def add_external_reference(
+        self,
+        group: str,
+        name: str,
+        value: str,
+    ) -> Self:
+        """
+        Add an external reference to the interaction.
+
+        This is used by V4 interactions to record references to external
+        resources, such as tickets or pull requests, against the interaction.
+        References are stored under `comments.references[group][name]` in the
+        generated Pact file.
+
+        This method may be called multiple times to add references to multiple
+        external systems. Calling it with the same `group` and `name` will
+        overwrite the previous value.
+
+        Args:
+            group:
+                Group or system the reference belongs to (e.g. `"Jira"`,
+                `"OpenAPI"`, `"GitHub"`).
+
+            name:
+                Name or identifier of the reference (e.g. `"TICKET"`,
+                `"OperationID"`, `"PullRequest"`).
+
+            value:
+                Value of the reference, typically an ID (e.g., `"TICKET-123"`,
+                `"getUserById"`, `"#123"`).
+
+        Example:
+            ```python
+            (
+                pact
+                .upon_receiving("a request")
+                .add_external_reference(
+                    "Jira",
+                    "TICKET-123",
+                    "https://jira.example.com/browse/TICKET-123",
+                )
+                .with_request("GET", "/users/123")
+                .will_respond_with(200)
+            )
+            ```
+        """
+        pact_ffi.add_interaction_reference(self._handle, group, name, value)
+        return self
+
     def test_name(
         self,
         name: str,

--- a/tests/interaction/test_async_message_interaction.py
+++ b/tests/interaction/test_async_message_interaction.py
@@ -4,11 +4,16 @@ Pact Async Message Interaction unit tests.
 
 from __future__ import annotations
 
+import json
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
 from pact import Pact
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -33,3 +38,20 @@ def test_repr(pact: Pact) -> None:
         )
         is not None
     )
+
+
+def test_add_external_reference(pact: Pact, tmp_path: Path) -> None:
+    (
+        pact
+        .upon_receiving("an async message with an external reference", "Async")
+        .add_external_reference(
+            "GitHub",
+            "PR-456",
+            "https://github.com/org/repo/pull/456",
+        )
+        .with_body({"event": "user.created"})
+    )
+    pact.write_file(tmp_path)
+    data = json.load((tmp_path / "consumer-provider.json").open())
+    references = data["interactions"][0]["comments"]["references"]
+    assert references["GitHub"]["PR-456"] == "https://github.com/org/repo/pull/456"

--- a/tests/interaction/test_http_interaction.py
+++ b/tests/interaction/test_http_interaction.py
@@ -589,6 +589,46 @@ async def test_name(pact: Pact) -> None:
                 assert await resp.read() == b""
 
 
+def test_add_external_reference(pact: Pact, tmp_path: Path) -> None:
+    (
+        pact
+        .upon_receiving("a request with an external reference")
+        .add_external_reference(
+            "Jira",
+            "TICKET-123",
+            "https://jira.example.com/browse/TICKET-123",
+        )
+        .with_request("GET", "/")
+        .will_respond_with(200)
+    )
+    pact.write_file(tmp_path)
+    data = json.load((tmp_path / "consumer-provider.json").open())
+    references = data["interactions"][0]["comments"]["references"]
+    assert (
+        references["Jira"]["TICKET-123"] == "https://jira.example.com/browse/TICKET-123"
+    )
+
+
+def test_add_external_reference_multiple(pact: Pact, tmp_path: Path) -> None:
+    (
+        pact
+        .upon_receiving("a request with multiple external references")
+        .add_external_reference(
+            "Jira", "TICKET-123", "https://jira.example.com/TICKET-123"
+        )
+        .add_external_reference(
+            "GitHub", "PR-456", "https://github.com/org/repo/pull/456"
+        )
+        .with_request("GET", "/")
+        .will_respond_with(200)
+    )
+    pact.write_file(tmp_path)
+    data = json.load((tmp_path / "consumer-provider.json").open())
+    references = data["interactions"][0]["comments"]["references"]
+    assert references["Jira"]["TICKET-123"] == "https://jira.example.com/TICKET-123"
+    assert references["GitHub"]["PR-456"] == "https://github.com/org/repo/pull/456"
+
+
 @pytest.mark.asyncio
 async def test_with_plugin(pact: Pact) -> None:
     (

--- a/tests/interaction/test_sync_message_interaction.py
+++ b/tests/interaction/test_sync_message_interaction.py
@@ -4,12 +4,17 @@ Pact Sync Message Interaction unit tests.
 
 from __future__ import annotations
 
+import json
 import re
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 
 from pact import Pact
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -106,3 +111,24 @@ def test_with_metadata_with_part(pact: Pact) -> None:
     assert handler.call_args[0][1]["foo"] == {"bar": 1.23}
     assert "metadata" in handler.call_args[0][1]
     assert handler.call_args[0][1]["metadata"] == 123
+
+
+def test_add_external_reference(pact: Pact, tmp_path: Path) -> None:
+    (
+        pact
+        .upon_receiving("a sync message with an external reference", "Sync")
+        .add_external_reference(
+            "Jira",
+            "TICKET-789",
+            "https://jira.example.com/browse/TICKET-789",
+        )
+        .with_body("request", content_type="text/plain")
+        .will_respond_with()
+        .with_body("response", content_type="text/plain")
+    )
+    pact.write_file(tmp_path)
+    data = json.load((tmp_path / "consumer-provider.json").open())
+    references = data["interactions"][0]["comments"]["references"]
+    assert (
+        references["Jira"]["TICKET-789"] == "https://jira.example.com/browse/TICKET-789"
+    )


### PR DESCRIPTION
This PR adds `add_external_reference` — a new V4 DSL method that records references to external resources (tickets, pull requests, etc.) against a Pact interaction. It is the Python equivalent of the `reference()` method added to pact-js.                                               
                                                                                                                                                                 
### What it does                                                                                                                                                   
                                                         
Calling `add_external_reference(group, name, value)` on any interaction stores the reference under `comments.references[group][name]` in the generated Pact file:  

```python
  (                                                                                                                                                              
      pact                                               
      .upon_receiving("get user")    
      .add_external_reference(                                                                                                                                   
          "Jira",
          "TICKET-123",                                                                                                                                          
          "https://jira.example.com/browse/TICKET-123",  
      )                                                                                                                                                          
      .with_request("GET", "/users/123")
      .will_respond_with(200)                                                                                                                                    
  )                                                      
```                     

Multiple references can be chained:

```python
  interaction
      .add_external_reference("Jira", "TICKET-123", "https://jira.example.com/TICKET-123")                                                                       
      .add_external_reference("GitHub", "PR-456", "https://github.com/org/repo/pull/456")
```

### Changes                                                
                                                                                                                                                                 
- `pact-python-ffi` — bumped from 0.5.3.0 to 0.5.4.0 to pull in the Rust FFI binary that introduced pactffi_add_interaction_reference                            
- `pact_ffi/__init__.py` — added add_interaction_reference(interaction, group, name, value) Python wrapper around the new FFI function
- `pact/interaction/_base.py` — added add_external_reference(group, name, value) to the Interaction base class, making it available on HTTP, async-message, and sync-message interactions; returns self for method chaining                                                     
- Tests — added tests across all three interaction types (`test_http_interaction.py`, `test_async_message_interaction.py`, `test_sync_message_interaction.py`) that write the Pact file and assert the reference appears at the correct path in the JSON                                              
