### PR TITLE
chore(release): pact-python v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file.
 <!-- markdownlint-disable emph-style -->
 <!-- markdownlint-disable strong-style -->
 
+## [pact-python/3.4.0] _2026-05-04_
+
+### 🚀 Features
+
+-   Add external reference dsl
+
+### Contributors
+
+-   @rholshausen
+-   @JP-Ellis
+
 ## [pact-python/3.3.1] _2026-04-22_
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pact-python"
-version = "3.3.1"
+version = "3.4.0"
 description = "Tool for creating and verifying consumer-driven contracts using the Pact framework."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## [pact-python/3.4.0] _2026-05-04_

### 🚀 Features

-   Add external reference dsl

### Contributors

-   @JP-Ellis

<!-- generated by git-cliff on 2026-05-04-->
