### PR TITLE
chore(ci): handle version degeneracy nicely

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -162,7 +162,8 @@ class Package:
         """Return the next semver via git cliff, or None.
 
         Returns `None` when there are no unreleased commits that would produce a
-        version bump (git cliff exits non-zero or returns empty output).
+        version bump (git cliff exits non-zero, returns empty output, or returns
+        the version that is already in `pyproject.toml`).
 
         Returns:
             The next version string (e.g. `"3.2.2"`), or `None` if no bump is
@@ -182,6 +183,15 @@ class Package:
         raw = result.stdout.strip()
         # git cliff outputs the full tag name (e.g. "pact-python/3.2.2"); strip prefix
         version = strip_tag_prefix(raw, self.tag_prefix)
+        # When all commits since the last tag are excluded from version bumping
+        # (e.g. chore(deps) commits), git cliff returns the already-released
+        # version rather than exiting non-zero.  Treat this as "nothing to do".
+        current = self.read_version()
+        if version == current:
+            logger.debug(
+                "git cliff returned current version %s — no bump needed", version
+            )
+            return None
         logger.debug("git cliff bumped version: %s", version)
         return version
 


### PR DESCRIPTION
## :memo: Summary

If there are no substantive commits, git cliff doesn't bump the version, but the script worked on the assumption there is always a change.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

To avoid having red builds (despite not being of any relevance to the package).

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
