### PR TITLE
chore: set user agent

### DIFF
--- a/src/pact/_util.py
+++ b/src/pact/_util.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 import inspect
 import logging
 import socket
+import sys
 import warnings
 from functools import partial
+from importlib.metadata import PackageNotFoundError, version
 from inspect import Parameter, _ParameterKind
 from typing import TYPE_CHECKING, TypeVar
 
@@ -21,6 +23,31 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
 logger = logging.getLogger(__name__)
+
+
+def user_agent() -> str:
+    """
+    Build the `User-Agent` header value for outbound HTTP requests.
+
+    Returns a string of the form
+    `pact-python/{version} requests/{requests_version} python/{py_version}`.
+
+    Returns:
+        The formatted `User-Agent` string.
+    """
+    try:
+        pact_ver = version("pact-python")
+    except PackageNotFoundError:
+        pact_ver = "unknown"
+
+    try:
+        requests_ver = version("requests")
+    except PackageNotFoundError:
+        requests_ver = "unknown"
+
+    py_ver = "{}.{}.{}".format(*sys.version_info[:3])
+    return f"pact-python/{pact_ver} requests/{requests_ver} python/{py_ver}"
+
 
 _PYTHON_FORMAT_TO_JAVA_DATETIME = {
     "a": "EEE",

--- a/src/pact/v2/message_provider.py
+++ b/src/pact/v2/message_provider.py
@@ -6,6 +6,9 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3 import Retry
 from multiprocessing import Process
+
+from pact._util import user_agent
+
 from .verifier import Verifier
 from .http_proxy import run_proxy
 
@@ -26,6 +29,8 @@ class MessageProvider(object):
         version='3.0.0'
     )
     """
+
+    HEADERS = {'User-Agent': user_agent()}
 
     def __init__(
         self,
@@ -59,6 +64,7 @@ class MessageProvider(object):
             message_handlers[f'{key}'] = handler()
 
         resp = requests.post(f'{self._proxy_url()}/setup',
+                             headers=self.HEADERS,
                              verify=False,
                              json={"messageHandlers": message_handlers})
         assert resp.status_code == 201, resp.text
@@ -75,7 +81,7 @@ class MessageProvider(object):
         retries = Retry(total=9, backoff_factor=0.5)
         http_mount = 'http://'
         s.mount(http_mount, HTTPAdapter(max_retries=retries))
-        resp = s.get(f'{self._proxy_url()}/ping', verify=False)
+        resp = s.get(f'{self._proxy_url()}/ping', headers=self.HEADERS, verify=False)
         if resp.status_code != 200:
             self._stop_proxy()
             raise RuntimeError(

--- a/src/pact/v2/pact.py
+++ b/src/pact/v2/pact.py
@@ -12,6 +12,8 @@ from requests.packages.urllib3 import Retry
 
 from pact_cli import _telemetry_env
 
+from pact._util import user_agent
+
 from .broker import Broker
 from .constants import MOCK_SERVICE_PATH
 from .matchers import from_term
@@ -40,7 +42,7 @@ class Pact(Broker):
     does match the defined interaction, it will respond with the text `Hello!`.
     """
 
-    HEADERS = {'X-Pact-Mock-Service': 'true'}
+    HEADERS = {'X-Pact-Mock-Service': 'true', 'User-Agent': user_agent()}
 
     MANDATORY_FIELDS = {'response', 'description', 'request'}
 

--- a/tests/v2/test_message_provider.py
+++ b/tests/v2/test_message_provider.py
@@ -2,6 +2,7 @@ import os
 # import pytest
 from mock import patch, Mock
 from unittest import TestCase
+from unittest.mock import ANY
 
 from pact.v2.message_provider import MessageProvider
 from pact.v2 import message_provider as message_provider
@@ -123,7 +124,7 @@ class SetupStateTestCase(MessageProviderTestCase):
             }
         }
 
-        mock_requests.assert_called_once_with(f'{self.provider._proxy_url()}/setup', verify=False, json=expected_payload)
+        mock_requests.assert_called_once_with(f'{self.provider._proxy_url()}/setup', headers={'User-Agent': ANY}, verify=False, json=expected_payload)
 
 
 class WaitForServerStartTestCase(MessageProviderTestCase):
@@ -141,7 +142,7 @@ class WaitForServerStartTestCase(MessageProviderTestCase):
         session = mock_Session.return_value
         session.mount.assert_called_once_with(
             'http://', mock_HTTPAdapter.return_value)
-        session.get.assert_called_once_with(f'{self.provider._proxy_url()}/ping', verify=False)
+        session.get.assert_called_once_with(f'{self.provider._proxy_url()}/ping', headers={'User-Agent': ANY}, verify=False)
         mock_HTTPAdapter.assert_called_once_with(
             max_retries=mock_Retry.return_value)
         mock_Retry.assert_called_once_with(total=9, backoff_factor=0.5)
@@ -160,7 +161,7 @@ class WaitForServerStartTestCase(MessageProviderTestCase):
         session = mock_Session.return_value
         session.mount.assert_called_once_with(
             'http://', mock_HTTPAdapter.return_value)
-        session.get.assert_called_once_with(f'{self.provider._proxy_url()}/ping', verify=False)
+        session.get.assert_called_once_with(f'{self.provider._proxy_url()}/ping', headers={'User-Agent': ANY}, verify=False)
         mock_HTTPAdapter.assert_called_once_with(
             max_retries=mock_Retry.return_value)
         mock_Retry.assert_called_once_with(total=9, backoff_factor=0.5)

--- a/tests/v2/test_pact.py
+++ b/tests/v2/test_pact.py
@@ -235,13 +235,13 @@ class PactSetupTestCase(PactTestCase):
          .will_respond_with(200, body='success'))
 
         self.delete_call = call('delete', 'http://localhost:1234/interactions',
-                                headers={'X-Pact-Mock-Service': 'true'},
+                                headers={'X-Pact-Mock-Service': 'true', 'User-Agent': ANY},
                                 verify=False)
 
         self.put_interactions_call = call(
             'put', 'http://localhost:1234/interactions',
             data=None,
-            headers={'X-Pact-Mock-Service': 'true'},
+            headers={'X-Pact-Mock-Service': 'true', 'User-Agent': ANY},
             verify=False,
             json={'interactions': [{
                 'response': {'status': 200, 'body': 'success'},
@@ -449,7 +449,7 @@ class PactWaitForServerStartTestCase(TestCase):
             'http://', self.mock_HTTPAdapter.return_value)
         session.get.assert_called_once_with(
             'http://localhost:1234',
-            headers={'X-Pact-Mock-Service': 'true'},
+            headers={'X-Pact-Mock-Service': 'true', 'User-Agent': ANY},
             verify=False)
         self.mock_HTTPAdapter.assert_called_once_with(
             max_retries=self.mock_Retry.return_value)
@@ -469,7 +469,7 @@ class PactWaitForServerStartTestCase(TestCase):
             'http://', self.mock_HTTPAdapter.return_value)
         session.get.assert_called_once_with(
             'http://localhost:1234',
-            headers={'X-Pact-Mock-Service': 'true'},
+            headers={'X-Pact-Mock-Service': 'true', 'User-Agent': ANY},
             verify=False)
         self.mock_HTTPAdapter.assert_called_once_with(
             max_retries=self.mock_Retry.return_value)
@@ -491,14 +491,14 @@ class PactVerifyTestCase(PactTestCase):
          .will_respond_with(200, body='success'))
         self.get_verification_call = call(
             'get', 'http://localhost:1234/interactions/verification',
-            headers={'X-Pact-Mock-Service': 'true'},
+            headers={'X-Pact-Mock-Service': 'true', 'User-Agent': ANY},
             verify=False,
             params=None)
 
         self.post_publish_pacts_call = call(
             'post', 'http://localhost:1234/pact',
             data=None,
-            headers={'X-Pact-Mock-Service': 'true'},
+            headers={'X-Pact-Mock-Service': 'true', 'User-Agent': ANY},
             verify=False,
             json=None)
 


### PR DESCRIPTION
## :memo: Summary

Set a `pact-python/*` user agent for requests made by Pact Python.

## ~:rotating_light: Breaking Changes~

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->

## :fire: Motivation

This is to help identify traffic from Pact Python.