### PR TITLE
chore(ci): use GitHub App token

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -82,13 +82,27 @@ jobs:
     environment:
       name: release-pr
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.PACT_FOUNDATION_BOT_APP_ID }}
+          private-key: ${{ secrets.PACT_FOUNDATION_BOT_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Need full history for git-cliff to determine the next version and
           # generate the changelog
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq '.id')+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Install git-cliff and typos
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9  # v2.82.2
@@ -105,7 +119,9 @@ jobs:
       - name: Update release PR
         run: uv run python scripts/release.py prepare cli
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Use the GitHub App token instead of GITHUB_TOKEN so that the PR can
+          # itself trigger workflows
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   tag:
     name: Create CLI release tag
@@ -116,11 +132,25 @@ jobs:
     environment:
       name: release-pr
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.PACT_FOUNDATION_BOT_APP_ID }}
+          private-key: ${{ secrets.PACT_FOUNDATION_BOT_PRIVATE_KEY }}
+
       - name: Checkout main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq '.id')+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -132,9 +162,9 @@ jobs:
       - name: Create and push release tag
         run: uv run python scripts/release.py tag cli
         env:
-          # Require GH_TOKEN (PAT) instead of GITHUB_TOKEN so that the PR can
+          # Use the GitHub App token instead of GITHUB_TOKEN so that the tag can
           # itself trigger workflows
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build-sdist:
     name: Build CLI source distribution

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -78,13 +78,27 @@ jobs:
     environment:
       name: release-pr
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.PACT_FOUNDATION_BOT_APP_ID }}
+          private-key: ${{ secrets.PACT_FOUNDATION_BOT_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Need full history for git-cliff to determine the next version and
           # generate the changelog
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq '.id')+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Install git-cliff and typos
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9  # v2.82.2
@@ -100,9 +114,9 @@ jobs:
       - name: Update release PR
         run: uv run python scripts/release.py prepare core
         env:
-          # Require GH_TOKEN (PAT) instead of GITHUB_TOKEN so that the PR can
+          # Use the GitHub App token instead of GITHUB_TOKEN so that the PR can
           # itself trigger workflows
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   tag:
     name: Create release tag
@@ -113,11 +127,25 @@ jobs:
     environment:
       name: release-pr
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.PACT_FOUNDATION_BOT_APP_ID }}
+          private-key: ${{ secrets.PACT_FOUNDATION_BOT_PRIVATE_KEY }}
+
       - name: Checkout main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq '.id')+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -128,9 +156,9 @@ jobs:
       - name: Create and push release tag
         run: uv run python scripts/release.py tag core
         env:
-          # Require GH_TOKEN (PAT) instead of GITHUB_TOKEN so that the PR can
+          # Use the GitHub App token instead of GITHUB_TOKEN so that the tag can
           # itself trigger workflows
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build:
     name: Build source distribution

--- a/.github/workflows/release-ffi.yml
+++ b/.github/workflows/release-ffi.yml
@@ -83,13 +83,27 @@ jobs:
     environment:
       name: release-pr
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.PACT_FOUNDATION_BOT_APP_ID }}
+          private-key: ${{ secrets.PACT_FOUNDATION_BOT_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Need full history for git-cliff to determine the next version and
           # generate the changelog
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq '.id')+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Install git-cliff and typos
         uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9  # v2.82.2
@@ -106,7 +120,9 @@ jobs:
       - name: Update release PR
         run: uv run python scripts/release.py prepare ffi
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # Use the GitHub App token instead of GITHUB_TOKEN so that the PR can
+          # itself trigger workflows
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   tag:
     name: Create FFI release tag
@@ -117,11 +133,25 @@ jobs:
     environment:
       name: release-pr
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ vars.PACT_FOUNDATION_BOT_APP_ID }}
+          private-key: ${{ secrets.PACT_FOUNDATION_BOT_PRIVATE_KEY }}
+
       - name: Checkout main
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq '.id')+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -133,9 +163,9 @@ jobs:
       - name: Create and push release tag
         run: uv run python scripts/release.py tag ffi
         env:
-          # Require GH_TOKEN (PAT) instead of GITHUB_TOKEN so that the PR can
+          # Use the GitHub App token instead of GITHUB_TOKEN so that the tag can
           # itself trigger workflows
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build-sdist:
     name: Build FFI source distribution

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -302,48 +302,6 @@ class Package:
             cwd=self.directory,
         )
 
-    def _configure_git_for_ci(self) -> None:
-        """Configure git identity and authenticate the remote for CI operations.
-
-        Sets `user.name` and `user.email` only when they are not already
-        configured (preserving a developer's local git config when running
-        outside CI).  If `GH_TOKEN` is set, embeds the token in the HTTPS
-        remote URL so that `git push` and `gh` operations authenticate without
-        a separate credential helper.
-        """
-        logger.debug("Configuring git identity for CI")
-        if not subprocess.run(
-            ["git", "config", "--get", "user.name"],
-            text=True,
-            check=False,
-            capture_output=True,
-            cwd=ROOT,
-        ).stdout.strip():
-            logger.debug("Setting git user.name to github-actions[bot]")
-            subprocess.check_call(
-                ["git", "config", "user.name", "github-actions[bot]"],
-                text=True,
-                cwd=ROOT,
-            )
-        if not subprocess.run(
-            ["git", "config", "--get", "user.email"],
-            text=True,
-            check=False,
-            capture_output=True,
-            cwd=ROOT,
-        ).stdout.strip():
-            logger.debug("Setting git user.email to github-actions[bot]@...")
-            subprocess.check_call(
-                [
-                    "git",
-                    "config",
-                    "user.email",
-                    "github-actions[bot]@users.noreply.github.com",
-                ],
-                text=True,
-                cwd=ROOT,
-            )
-
     def _push_release_branch(
         self,
         pr_title: str,
@@ -489,7 +447,6 @@ class Package:
             return
 
         try:
-            self._configure_git_for_ci()
             self._push_release_branch(pr_title, changelog, existing_pr)
         finally:
             # Return to main so the local repo is left in a clean state, even on failure


### PR DESCRIPTION
## :memo: Summary

With an org-specific GitHub App created, use its credentials instead of a user-linked PAT.
