### PR TITLE
chore: replace deprecated codecov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,9 +121,11 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: tests
+          report_type: test_results
 
   example:
     name: >-
@@ -180,9 +182,11 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: examples
+          report_type: test_results
 
   format:
     name: Format


### PR DESCRIPTION
## :memo: Summary

Repalce `codecov/test-results-action` with `codecov/codecov-action`.

## :fire: Motivation

Codecov's test results action is deprecated, and has been folded into their main action.