### PR TITLE
fix: report message handler failures instead of transport errors

### DIFF
--- a/src/pact/_server.py
+++ b/src/pact/_server.py
@@ -282,9 +282,21 @@ class MessageProducerHandler(SimpleHTTPRequestHandler, Generic[_CM]):
             self.send_error(400, "Bad Request")
             return
 
-        self.send_response(200, "OK")
+        # The handler must be called before the response line is sent. Any
+        # exception it raises has to be reported as a 500, and not leave the
+        # client with a truncated 200 response.
+        try:
+            message = self.server.handler(description, data)
+        except Exception as e:
+            logger.exception("Message handler for %s raised an exception.", description)
+            self.send_error(
+                500,
+                "Message handler failed",
+                f"{type(e).__name__}: {e}",
+            )
+            return
 
-        message = self.server.handler(description, data)
+        self.send_response(200, "OK")
 
         metadata = message.get("metadata") or {}
         if content_type := message.get("content_type"):
@@ -491,7 +503,17 @@ class StateCallbackHandler(SimpleHTTPRequestHandler, Generic[_CN]):
             self.send_error(400, "Bad Request")
             return
 
-        self.server.handler(state, action, params)
+        try:
+            self.server.handler(state, action, params)
+        except Exception as e:
+            logger.exception("State handler for %s raised an exception.", state)
+            self.send_error(
+                500,
+                "State handler failed",
+                f"{type(e).__name__}: {e}",
+            )
+            return
+
         self.send_response(200, "OK")
         self.end_headers()
 

--- a/src/pact/_server.py
+++ b/src/pact/_server.py
@@ -296,21 +296,44 @@ class MessageProducerHandler(SimpleHTTPRequestHandler, Generic[_CM]):
             )
             return
 
-        self.send_response(200, "OK")
+        # The response is serialised in full before the response line is sent,
+        # for the same reason: a malformed message must be reported as a 500,
+        # and not leave the client with a truncated 200 response.
+        try:
+            contents = message.get("contents") or b""
+            if not isinstance(contents, (bytes, bytearray)):
+                msg = (
+                    f"Message handler for {description!r} returned contents of "
+                    f"type {type(contents).__name__}, expected bytes."
+                )
+                raise TypeError(msg)  # noqa: TRY301
 
-        metadata = message.get("metadata") or {}
-        if content_type := message.get("content_type"):
-            self.send_header("Content-Type", content_type)
-            if "contentType" not in metadata:
+            metadata = message.get("metadata") or {}
+            content_type = message.get("content_type")
+            if content_type and "contentType" not in metadata:
                 metadata["contentType"] = content_type
-
-        if metadata:
-            self.send_header(
-                "Pact-Message-Metadata",
-                base64.b64encode(json.dumps(metadata).encode()).decode(),
+            encoded_metadata = (
+                base64.b64encode(json.dumps(metadata).encode()).decode()
+                if metadata
+                else None
             )
+        except Exception as e:
+            logger.exception(
+                "Message from handler for %s could not be serialised.",
+                description,
+            )
+            self.send_error(
+                500,
+                "Message handler failed",
+                f"{type(e).__name__}: {e}",
+            )
+            return
 
-        contents = message.get("contents", b"")
+        self.send_response(200, "OK")
+        if content_type:
+            self.send_header("Content-Type", content_type)
+        if encoded_metadata:
+            self.send_header("Pact-Message-Metadata", encoded_metadata)
         self.send_header("Content-Length", str(len(contents)))
         self.end_headers()
         self.wfile.write(contents)

--- a/src/pact/verifier.py
+++ b/src/pact/verifier.py
@@ -111,6 +111,65 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _missing_contents_msg(name: str) -> str:
+    """
+    Error message for a message handler dictionary without a `contents` key.
+
+    Args:
+        name:
+            The name of the message whose handler is invalid.
+    """
+    return (
+        f"Message handler for {name!r} is missing the 'contents' key. Dictionary "
+        "values must be Message envelopes, such as {'contents': b'...', "
+        "'content_type': 'application/json'}, and not the raw payload."
+    )
+
+
+def _invalid_value_msg(name: str, value: object) -> str:
+    """
+    Error message for a message handler value of an unsupported type.
+
+    Args:
+        name:
+            The name of the message whose handler is invalid.
+
+        value:
+            The offending value.
+    """
+    return (
+        f"Invalid message handler value for {name!r}: expected a callable, bytes, "
+        f"or a Message dictionary, got {type(value).__name__}."
+    )
+
+
+def _validate_message_handlers(
+    handler: dict[str, Callable[..., Message] | Message | bytes],
+) -> None:
+    """
+    Check that every value of a message handler dictionary is usable.
+
+    The handler is only called during verification, at which point a failure is
+    reported by the underlying FFI as a failed interaction and its cause is
+    easily missed.
+
+    Args:
+        handler:
+            The dictionary mapping message names to handler values.
+
+    Raises:
+        TypeError:
+            If any value is neither a callable, bytes, nor a Message dictionary.
+    """
+    for name, value in handler.items():
+        if callable(value) or isinstance(value, bytes):
+            continue
+        if not isinstance(value, dict):
+            raise TypeError(_invalid_value_msg(name, value))
+        if "contents" not in value:
+            raise TypeError(_missing_contents_msg(name))
+
+
 class _ProviderTransport(TypedDict):
     """
     Provider transport information.
@@ -385,6 +444,12 @@ class Verifier:
         Raises:
             TypeError:
                 If the handler or its values are invalid.
+
+            KeyError:
+                If a message is requested which is not present in the
+                dictionary. As the handler is called during verification, this
+                is raised within the message relay server and surfaces as a
+                failed interaction.
         """
         logger.debug(
             "Setting message handler for verifier",
@@ -414,12 +479,19 @@ class Verifier:
             return self
 
         if isinstance(handler, dict):
+            _validate_message_handlers(handler)
 
             def _handler(
                 name: str,
                 metadata: dict[str, Any] | None,
             ) -> Message:
                 logger.info("Internal message produced called.")
+                if name not in handler:
+                    msg = (
+                        f"No message handler for {name!r}. "
+                        f"Known messages: {', '.join(sorted(handler))}"
+                    )
+                    raise KeyError(msg)
                 val = handler[name]
 
                 if callable(val):
@@ -430,14 +502,15 @@ class Verifier:
                 if isinstance(val, bytes):
                     return Message(contents=val, metadata=None, content_type=None)
                 if isinstance(val, dict):
+                    if "contents" not in val:
+                        raise TypeError(_missing_contents_msg(name))
                     return Message(
                         contents=val["contents"],
                         metadata=val.get("metadata"),
                         content_type=val.get("content_type"),
                     )
 
-                msg = "Invalid message handler value"
-                raise TypeError(msg)
+                raise TypeError(_invalid_value_msg(name, val))
 
             self._message_producer = MessageProducer(_handler)
             self.add_transport(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -73,6 +73,30 @@ async def test_message_post_http() -> None:
     assert handler.call_args.args == ("A simple message", {})
 
 
+@pytest.mark.asyncio
+async def test_message_post_handler_raises() -> None:
+    """
+    A failing handler must produce a 500, not a truncated 200.
+
+    The response line used to be sent before the handler was called, so any
+    exception left the client with a half-written response and the Pact core
+    reported it as `error sending request for url`. See #1665.
+    """
+    handler = MagicMock(side_effect=RuntimeError("handler is broken"))
+    server = MessageProducer(handler)
+
+    with server:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                server.url,
+                data=json.dumps({"description": "A simple message"}),
+            ) as response:
+                assert response.status == 500
+                assert "handler is broken" in await response.text()
+
+    handler.assert_called_once()
+
+
 def test_callback_default_init() -> None:
     handler = MagicMock()
     server = StateCallback(handler)
@@ -132,3 +156,21 @@ async def test_callback_post() -> None:
         "setup",
         {"id": 123},
     )
+
+
+@pytest.mark.asyncio
+async def test_callback_post_handler_raises() -> None:
+    """A failing state handler must produce a 500."""
+    handler = MagicMock(side_effect=RuntimeError("state setup is broken"))
+    server = StateCallback(handler)
+
+    with server:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                server.url,
+                json={"state": "user exists", "action": "setup", "params": {}},
+            ) as response:
+                assert response.status == 500
+                assert "state setup is broken" in await response.text()
+
+    handler.assert_called_once()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ Tests for `pact._server` module.
 from __future__ import annotations
 
 import json
+from typing import Any
 from unittest.mock import MagicMock
 
 import aiohttp
@@ -93,6 +94,47 @@ async def test_message_post_handler_raises() -> None:
             ) as response:
                 assert response.status == 500
                 assert "handler is broken" in await response.text()
+
+    handler.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("message", "match"),
+    [
+        pytest.param(
+            {"contents": "not bytes", "metadata": None, "content_type": None},
+            "expected bytes",
+            id="str_contents",
+        ),
+        pytest.param(
+            {"contents": b"", "metadata": {"key": object()}, "content_type": None},
+            "TypeError",
+            id="unserialisable_metadata",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_message_post_unserialisable_message(
+    message: dict[str, Any],
+    match: str,
+) -> None:
+    """
+    A message which cannot be serialised must produce a 500.
+
+    The handler itself succeeds here; it is the response which cannot be built,
+    and that must not leave the client with a truncated 200 either.
+    """
+    handler = MagicMock(return_value=message)
+    server = MessageProducer(handler)
+
+    with server:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                server.url,
+                data=json.dumps({"description": "A simple message"}),
+            ) as response:
+                assert response.status == 500
+                assert match in await response.text()
 
     handler.assert_called_once()
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -238,6 +238,45 @@ def test_verify_message_only(verifier: Verifier) -> None:
     mock_add_transport.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("handler", "match"),
+    [
+        pytest.param(
+            {"a-message": {"field": "value"}},
+            r"missing the 'contents' key",
+            id="dict_without_contents",
+        ),
+        pytest.param(
+            {"a-message": 42},
+            r"expected a callable, bytes, or a Message dictionary, got int",
+            id="unsupported_value_type",
+        ),
+    ],
+)
+def test_message_handler_invalid_dict_value(
+    verifier: Verifier,
+    handler: dict[str, Any],
+    match: str,
+) -> None:
+    """
+    Invalid handler values must be rejected when the handler is set.
+
+    Deferring the error to verification time hides the cause behind a failed
+    interaction. See #1665.
+    """
+    with pytest.raises(TypeError, match=match):
+        verifier.message_handler(handler)
+
+
+def test_message_handler_unknown_message(verifier: Verifier) -> None:
+    """A message with no handler must name the messages which do have one."""
+    verifier.message_handler({"a-message": b"", "b-message": b""})
+    handler = verifier._message_producer._handler  # noqa: SLF001
+
+    with pytest.raises(KeyError, match=r"Known messages: a-message, b-message"):
+        handler("c-message", None)
+
+
 def test_logs(verifier: Verifier) -> None:
     logs = verifier.logs
     assert logs == ""

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -271,7 +272,9 @@ def test_message_handler_invalid_dict_value(
 def test_message_handler_unknown_message(verifier: Verifier) -> None:
     """A message with no handler must name the messages which do have one."""
     verifier.message_handler({"a-message": b"", "b-message": b""})
-    handler = verifier._message_producer._handler  # noqa: SLF001
+    producer = verifier._message_producer  # noqa: SLF001
+    assert not isinstance(producer, nullcontext)
+    handler = producer._handler  # noqa: SLF001
 
     with pytest.raises(KeyError, match=r"Known messages: a-message, b-message"):
         handler("c-message", None)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to Pact-python here: https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md

Happy contributing!
-->

## :airplane: Pre-flight checklist

-   [x] I have read the [Contributing Guidelines on pull requests](https://github.com/pact-foundation/pact-python/blob/main/CONTRIBUTING.md#pull-requests).
-   [x] **If this is a code change**: I have written unit tests and/or added dogfooding pages to fully verify the new behavior.
-   [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #1665) and the maintainers have approved on my working plan.
    <!-- Not a new API. This is a bugfix for #1665; I have not had a working plan
    approved, so please do say if you would prefer a narrower change — see the
    note on the eager validation in point 3 below. -->



## :memo: Summary

<!-- Help us understand the PR at a high level. What changes is it proposing? -->
`MessageProducerHandler.do_POST` sent the `200 OK` response line *before* calling
the handler:

```python
self.send_response(200, "OK")

message = self.server.handler(description, data)
```

Any exception raised by the handler therefore left the client with a
half-written response. `http.server` printed a traceback to stderr and dropped
the connection, and the Pact core reported the disconnect as
`Request Failed - error sending request for url (http://localhost:<port>/_pact/message)`.

Three unrelated failures collapsed into that one misleading message:

| Cause | Real exception | Reported as |
| --- | --- | --- |
| Handler dict value missing `contents` | `KeyError: 'contents'` | `error sending request for url` |
| Message description with no handler | `KeyError: '<description>'` | `error sending request for url` |
| Any exception in a user-provided handler | e.g. `RuntimeError` | `error sending request for url` |

This PR makes three changes:

1.  **`MessageProducerHandler.do_POST` calls the handler before responding**, and
    reports any exception as a `500` whose body carries the exception type and
    message. This also makes it consistent with `StateCallbackHandler.do_POST`,
    which already called its handler first.

2.  **`StateCallbackHandler.do_POST` catches handler exceptions** the same way.
    Its ordering was already correct, but an exception still dropped the
    connection rather than producing a `500`.

3.  **`Verifier.message_handler` validates dictionary values eagerly.** The case
    in #1665 is a configuration error that is fully knowable when the handler is
    set, so it is now raised as a `TypeError` on the `message_handler(...)` line
    in the user's own test, rather than surfacing much later as a failed
    interaction. The error names the offending message and shows the expected
    envelope shape:

    ```
    TypeError: Message handler for 'some-message' is missing the 'contents' key.
    Dictionary values must be Message envelopes, such as {'contents': b'...',
    'content_type': 'application/json'}, and not the raw payload.
    ```

    A request for a message with no handler now also lists the messages which
    do have one.

## :rotating_light: Breaking Changes

<!-- Does this PR include any breaking changes? If not, feel free to delete this section. If so, please detail:

-  What is the breaking change?
-  Why is the breaking change necessary?
-  What steps should a user take in order to migrate from the old behavior to the new one?
-->
`Verifier.message_handler` now raises `TypeError` for a dictionary value that is
neither a callable, `bytes`, nor a `Message` dictionary. Previously such a value
was accepted and only failed during verification.

This only rejects handlers which could never have worked, and `TypeError` was
already the documented behaviour for invalid handler values. Anyone affected was
already getting a failed verification; they now get a clear error earlier

## :fire: Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
Closes #1665.

The error the user sees points squarely at the network layer, so the natural
first steps are to check IPv4/IPv6 resolution, port binding, and the ordering of
`add_transport` — none of which are involved. The reporter of #1665 spent
roughly six hours on it, including two false-lead fixes, before spotting the
stderr traceback beneath the FFI error.

## :hammer: Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
Added to `tests/test_server.py`:

-   `test_message_post_handler_raises` — a handler raising `RuntimeError`
    produces a `500` whose body contains the exception message, and the handler
    is called exactly once.
-   `test_callback_post_handler_raises` — the same for the state callback server.

Added to `tests/test_verifier.py`:

-   `test_message_handler_invalid_dict_value` — a dict without `contents` and a
    value of an unsupported type both raise `TypeError` at `message_handler`
    time.
-   `test_message_handler_unknown_message` — the `KeyError` for an unknown
    message names the messages which do have a handler.

Verified locally on Python 3.14 / Linux:

-   `pytest tests/ --ignore=tests/compatibility_suite --ignore=tests/v2` —
    354 passed, 2 skipped.
-   `pytest tests/compatibility_suite` — 167 passed, 12 skipped, including
    `test_v3_message_producer` and `test_v4_message_provider`, which exercise
    the real FFI message-producer path.
-   `ruff check`, `ruff format --check` and `mypy` clean.

I also reproduced the original report end-to-end against a V3 message pact. The
misleading transport error is gone; the verifier now fails the interaction on a
content-type mismatch against the `500` body, and the cause is visible in the
log:

```
Message handler for some-message raised an exception.
...
TypeError: Message handler for 'some-message' is missing the 'contents' key. ...
127.0.0.1 - - [...] code 500, message Message handler failed
```

## :link: Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
Closes #1665.

### Known limitation

The Pact core still matches the `500` response body against the expected
message body, so the verifier output reports a content-type mismatch
(`expected a body of 'application/json' but the actual content type was 'text/html;charset=utf-8'`) rather than the producer error itself. Surfacing the error explanation in the verifier output would require a change in `pact-reference`, so it is out of scope here. Happy to raise that separately if you think it is worth doing — the eager validation in point 3 above means the most common case in #1665 never reaches the FFI at all.
