### PR TITLE
chore(ci): skip generic linux_ tags

### DIFF
--- a/pact-python-cli/hatch_build.py
+++ b/pact-python-cli/hatch_build.py
@@ -149,8 +149,22 @@ class PactCliBuildHook(BuildHookInterface[BuilderConfig]):
         Get the platform tag from the current system tags.
 
         This is used to determine the target platform for the Pact binaries.
+
+        On Linux, the generic `linux_{arch}` tag conveys no information about
+        the platform's C library, so the more specific `manylinux`/`musllinux`
+        tag is preferred when one is available.
+
+        Returns:
+            The most specific platform tag supported by the current system.
         """
-        return next(t.platform for t in sys_tags())
+        platforms = (t.platform for t in sys_tags())
+        preferred = next(platforms)
+        if preferred.startswith("linux_"):
+            return next(
+                (p for p in platforms if not p.startswith("linux_")),
+                preferred,
+            )
+        return preferred
 
     def _install_ruby_cli(self, version: str) -> Mapping[str, str]:
         """

--- a/pact-python-ffi/hatch_build.py
+++ b/pact-python-ffi/hatch_build.py
@@ -135,8 +135,22 @@ class PactBuildHook(BuildHookInterface[Any]):
         Get the platform tag from the current system tags.
 
         This is used to determine the target platform for the Pact library.
+
+        On Linux, the generic `linux_{arch}` tag conveys no information about
+        the platform's C library, so the more specific `manylinux`/`musllinux`
+        tag is preferred when one is available.
+
+        Returns:
+            The most specific platform tag supported by the current system.
         """
-        return next(t.platform for t in sys_tags())
+        platforms = (t.platform for t in sys_tags())
+        preferred = next(platforms)
+        if preferred.startswith("linux_"):
+            return next(
+                (p for p in platforms if not p.startswith("linux_")),
+                preferred,
+            )
+        return preferred
 
     def _install(self, version: str) -> Mapping[str, str]:
         """


### PR DESCRIPTION
## :memo: Summary

Python has introduced generic `linux_` tags which are independent of the libc implementation. We need to know whether we are building against glibc or musl, so we have to skip these `linux_` tags.
